### PR TITLE
tpm2: Only write STATE_RESET and STATE_CLEAR blobs when needed

### DIFF
--- a/src/tpm2/Global.h
+++ b/src/tpm2/Global.h
@@ -533,6 +533,7 @@ extern  BOOL            g_StartupLocality3;
    locality 3. These flags are only relevant if after a TPM2_Shutdown(STATE). */
 #define PRE_STARTUP_FLAG	 0x8000
 #define STARTUP_LOCALITY_3   0x4000
+#define TPM_SU_STATE_MASK ~(PRE_STARTUP_FLAG | STARTUP_LOCALITY_3) // libtpms added
 #ifdef USE_DA_USED
 /*     5.10.10.15 g_daUsed */
 /* This location indicates if a DA-protected value is accessed during a boot cycle. If none has,


### PR DESCRIPTION
STATE_RESET_DATA and STATE_CLEAR_DATA need to only be written if the
orderlyState has TPM_SU_STATE (after masking out some other bits) set.

We bump up the version of the PERSISTENT_STATE to 3 and since previous
versions cannot deal with the missing STATE_{RESET,CLEAR}_DATA we require
that the minimum supported version understood by the implementation is
also '3'. This prevents downgrading of libtpms to a version prior to this
(patch).

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>