### PR TITLE
Fix some issues related to TPM 2 failure mode and running the fuzzer

### DIFF
--- a/README
+++ b/README
@@ -88,7 +88,7 @@ Fuzz testing is known to work with Fedora 28 or later. It requires that the
 Ex:
 $ ./configure --with-openssl --with-tpm2 --enable-sanitizers --enable-fuzzer CC=clang
 $ make && make -C tests fuzz
-$ tests/fuzz tests/corpus-execute-command
+$ tests/run-fuzzer.sh
 
 Maintainers
 -----------

--- a/src/tpm_library.c
+++ b/src/tpm_library.c
@@ -546,6 +546,33 @@ void TPMLIB_LogPrintfA(unsigned int indent, const char *format, ...)
     va_end(args);
 }
 
+/*
+ * TPMLIB_LogArray: Display an array of data
+ *
+ * @indent: how many spaces to indent; indent of ~0 forces logging
+ *          with indent 0 even if not debug_level is set
+ * @data: the data to print
+ * @datalen: length of the data
+ */
+void TPMLIB_LogArray(unsigned int indent, const unsigned char *data,
+                     size_t datalen)
+{
+    char line[80];
+    size_t i, o = 0;
+
+    for (i = 0; i < datalen; i++) {
+        snprintf(&line[o], sizeof(line) - o, "%02x ", data[i]);
+        o += 3;
+        if (o >= 16 * 3) {
+            TPMLIB_LogPrintfA(indent, "%s\n", line);
+            o = 0;
+        }
+    }
+    if (o > 0) {
+        TPMLIB_LogPrintfA(indent, "%s\n", line);
+    }
+}
+
 void ClearCachedState(enum TPMLIB_StateType st)
 {
     free(cached_blobs[st].buffer);

--- a/src/tpm_library_intern.h
+++ b/src/tpm_library_intern.h
@@ -103,7 +103,8 @@ TPM_RESULT TPM12_IO_TpmEstablished_Reset(void);
 int TPMLIB_LogPrintf(const char *format, ...);
 void TPMLIB_LogPrintfA(unsigned int indent, const char *format, ...) \
      ATTRIBUTE_FORMAT(2, 3);
-
+void TPMLIB_LogArray(unsigned int indent, const unsigned char *data,
+                     size_t datalen);
 
 #define TPMLIB_LogError(format, ...) \
      TPMLIB_LogPrintfA(~0, "libtpms: "format, __VA_ARGS__)

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -191,6 +191,13 @@ TPM_RESULT TPM2_Process(unsigned char **respbuffer, uint32_t *resp_size,
 
     _rpc__Send_Command(locality, req, &resp);
 
+    /* it may come back with a different buffer, especially in failure mode */
+    if (resp.Buffer != *respbuffer) {
+        if (resp.BufferSize > *respbufsize)
+            resp.BufferSize = *respbufsize;
+        memcpy(*respbuffer, resp.Buffer, resp.BufferSize);
+    }
+
     *resp_size = resp.BufferSize;
 
     return TPM_SUCCESS;

--- a/tests/run-fuzzer.sh
+++ b/tests/run-fuzzer.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+DIR=${PWD}/$(dirname "$0")
+ROOT=${DIR}/..
+WORKDIR=$(mktemp -d)
+export LD_LIBRARY_PATH=${ROOT}/src/.libs
+
+if ! [ -d ${LD_LIBRARY_PATH} ]; then
+	echo "Wrong path to libtpms library: ${LD_LIBRARY_PATH}"
+	exit 1
+fi
+
+if ! [ -f "$(readlink -f ${LD_LIBRARY_PATH}/libtpms.so)" ]; then
+	echo "Cannot find libtpms at ${LD_LIBRARY_PATH}/libtpms.so"
+	exit 1
+fi
+
+function cleanup()
+{
+	rm -rf ${WORKDIR}
+}
+
+trap "cleanup" QUIT EXIT
+
+pushd $WORKDIR
+
+${DIR}/fuzz $@ ${DIR}/corpus-execute-command
+rc=$?
+
+popd
+
+exit $rc


### PR DESCRIPTION
Log the TPM 2 command that put it into failure mode.
When entering failure mode _rpc__Send_Command() returns a different buffer with the response message than the buffer that was passed into it. So we need to check for this and copy from the returned buffer into the expected one.

Wrap the running of the fuzzer into a script so we can run each instance of the fuzzer in a temporary directory where it creates its own private NvChip file.