### PR TITLE
Add support for code coverage and a travis build that checks libtpms using swtpm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,27 @@ script:
 matrix:
   include:
     - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2" "TARGET=distcheck"
+    - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2 --enable-test-coverage"
+           TARGET="install"
+      dist: xenial
+      before_script:
+      - sudo pip install cpp-coveralls
+      script:
+        ./autogen.sh ${CONFIG} &&
+        sudo make -j$(nproc) ${TARGET} &&
+        sudo make -j$(nproc) check &&
+        git clone https://github.com/stefanberger/swtpm.git &&
+        pushd swtpm &&
+         sudo apt -y install devscripts equivs python-twisted libfuse-dev
+           libglib2.0-dev libgmp-dev expect libtasn1-dev socat findutils
+           tpm-tools gnutls-dev gnutls-bin &&
+         ./autogen.sh --with-gnutls --prefix=/usr &&
+         export SWTPM_TEST_EXPENSIVE=1 &&
+         sudo make -j$(nproc) check &&
+        popd
+      after_success:
+        # coveralls creates some odd paths
+        sudo cpp-coveralls --gcov-options '\-lp'
+          -e src/tpm12/tpm12
+          -e src/tpm2/tpm2
+          -e src/tpm2/crypto/openssl/tpm2/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: c
 dist: trusty
-before_install:
-- sudo apt-get install automake autoconf libtool libssl-dev sed make gawk sed bash
-  dh-exec
 script: "./bootstrap.sh && ./configure --with-openssl --prefix=/usr --with-tpm2 &&
   make -j4 check"
 env:
   global:
     secure: THraWTkpyL+b3lcnLenhXR6sxphcJS23MoUP36PT9VYhgZRI2YjO1w2h4V0uwzovbGJDU4Tc88Yxn8kL4RSgwy9cIcJcTOAorbePVRd+UFVU0nUjhwYLCKYBTLVLo7lYc0FHTgsdsba65X6keuSlAdegzCRbTvcwNqX9nanSRGI1CvYcwx22Iu5eOdJvMjwIuFOuECs7hVFrGS2rvGoyzqGNMT4A8shXOBZM/pwklRFS1oS/L1g45y3OP27yqINjtfC7wXRGsR8ItH7LAaQ+yCzNg3QzSd/3H3niEC5grcEMS23YugFUkGpqSca8SGJmkK2LFaBctpZS1P75lA/47Bxbh/byu85TUE6wZ+VPm520NkiYtBB+oxIbq1mYv+hhKuxPf5OqzdwLXVO7EAfzO57VkUqQfumWIZqV0WqCU3SdpRk+CUCCURR4P0ww+w6hQx6PzK21+d9tLtqMqdRwuricdyeLvxboWQXXl36fPf4ifmi0AZ6ILaV/LUQu24Di56RG4hO+/Pv/Qqxa8rJLpqJa0PtsYIiBNeVYLH/ZYIlS8saBedMIJ9dqh1dvBw/Jql8EZCOWif6UjYzQFgZAOZQqH9VAp1WVwQxQRo+Sq7dy+MtRKT2GEcNrdfYcL6qucBAQY00vQQBfl+FOnEzIAUImt4tbitnYTxmNx8N+QZU=
 addons:
+  apt:
+    packages:
+      - automake
+      - autoconf
+      - libtool
+      - libssl-dev
+      - sed
+      - make
+      - gawk
+      - sed
+      - bash
+      - dh-exec
   coverity_scan:
     project:
       name: libtpms

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,13 @@ addons:
     branch_pattern: coverity_scan
 script:
   - ./autogen.sh ${CONFIG}
-  - make -j$(nproc) ${TARGET}
+  - make -j$(${NPROC}) ${TARGET}
 matrix:
   include:
     - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2" "TARGET=distcheck"
+           NPROC="nproc"
     - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2 --enable-test-coverage"
-           TARGET="install"
+           TARGET="install" NPROC="nproc"
       dist: xenial
       before_script:
       - sudo pip install cpp-coveralls
@@ -54,3 +55,9 @@ matrix:
           -e src/tpm12/tpm12
           -e src/tpm2/tpm2
           -e src/tpm2/crypto/openssl/tpm2/
+    - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2" "TARGET=check"
+           NPROC="sysctl -n hw.ncpu" CFLAGS="-I/usr/local/opt/openssl/include"
+           LDFLAGS="-L/usr/local/opt/openssl/lib"
+           # 'distcheck' results in duplicate symbol errors
+      os: osx
+      compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: c
 dist: trusty
-script: "./bootstrap.sh && ./configure --with-openssl --prefix=/usr --with-tpm2 &&
-  make -j4 check"
 env:
   global:
     secure: THraWTkpyL+b3lcnLenhXR6sxphcJS23MoUP36PT9VYhgZRI2YjO1w2h4V0uwzovbGJDU4Tc88Yxn8kL4RSgwy9cIcJcTOAorbePVRd+UFVU0nUjhwYLCKYBTLVLo7lYc0FHTgsdsba65X6keuSlAdegzCRbTvcwNqX9nanSRGI1CvYcwx22Iu5eOdJvMjwIuFOuECs7hVFrGS2rvGoyzqGNMT4A8shXOBZM/pwklRFS1oS/L1g45y3OP27yqINjtfC7wXRGsR8ItH7LAaQ+yCzNg3QzSd/3H3niEC5grcEMS23YugFUkGpqSca8SGJmkK2LFaBctpZS1P75lA/47Bxbh/byu85TUE6wZ+VPm520NkiYtBB+oxIbq1mYv+hhKuxPf5OqzdwLXVO7EAfzO57VkUqQfumWIZqV0WqCU3SdpRk+CUCCURR4P0ww+w6hQx6PzK21+d9tLtqMqdRwuricdyeLvxboWQXXl36fPf4ifmi0AZ6ILaV/LUQu24Di56RG4hO+/Pv/Qqxa8rJLpqJa0PtsYIiBNeVYLH/ZYIlS8saBedMIJ9dqh1dvBw/Jql8EZCOWif6UjYzQFgZAOZQqH9VAp1WVwQxQRo+Sq7dy+MtRKT2GEcNrdfYcL6qucBAQY00vQQBfl+FOnEzIAUImt4tbitnYTxmNx8N+QZU=
@@ -23,7 +21,12 @@ addons:
       name: libtpms
       description: Build submitted via Travis CI
     notification_email: stefanb@linux.vnet.ibm.com
-    build_command_prepend: "./bootstrap.sh; ./configure --with-openssl --with-tpm2; make clean"
-    build_command: make -j4
+    build_command_prepend: "./autogen.sh --with-openssl --with-tpm2; make clean"
+    build_command: make -j$(nproc)
     branch_pattern: coverity_scan
-script: ./bootstrap.sh && ./configure --with-openssl --prefix=/usr --with-tpm2 && make -j4 distcheck
+script:
+  - ./autogen.sh ${CONFIG}
+  - make -j$(nproc) ${TARGET}
+matrix:
+  include:
+    - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2" "TARGET=distcheck"

--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,10 @@ AC_ARG_ENABLE([fuzzer], AS_HELP_STRING([--enable-fuzzer], [Enable fuzzer]),
 AC_SUBST([SANITIZERS])
 AC_SUBST([FUZZER])
 
+AC_ARG_ENABLE([test-coverage],
+  AS_HELP_STRING([--enable-test-coverage], [Enable test coverage flags]),
+  [COVERAGE_CFLAGS="-fprofile-arcs -ftest-coverage" COVERAGE_LDFLAGS="-fprofile-arcs"])
+
 LT_INIT
 AC_PROG_CC
 AC_PROG_INSTALL
@@ -209,7 +213,8 @@ if test "x$enable_hardening" != "xno"; then
 fi
 
 if test "$test_CFLAGS" != set; then
-  CFLAGS="$CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign"
+  CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign"
+  LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
 fi
 
 AC_CONFIG_FILES(Makefile                   \

--- a/configure.ac
+++ b/configure.ac
@@ -38,15 +38,7 @@ AC_ARG_ENABLE(debug, AC_HELP_STRING([--enable-debug], [create a debug build]),
   [DEBUG="no",
    AC_MSG_RESULT([no])])
 
-# If the user has not set CFLAGS, do something appropriate
-test_CFLAGS=${CFLAGS+set}
-if test "$test_CFLAGS" != set; then
-	if test "$DEBUG" = "yes"; then
-		CFLAGS="-O0 -g -DDEBUG"
-	else
-		CFLAGS="-g -O2"
-	fi
-elif test "$DEBUG" = "yes"; then
+if test "$DEBUG" = "yes"; then
 	CFLAGS="$CFLAGS -O0 -g -DDEBUG"
 fi
 
@@ -212,10 +204,8 @@ if test "x$enable_hardening" != "xno"; then
 	AC_SUBST([HARDENING_LDFLAGS])
 fi
 
-if test "$test_CFLAGS" != set; then
-  CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign"
-  LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
-fi
+CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign"
+LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
 
 AC_CONFIG_FILES(Makefile                   \
 		dist/libtpms.spec          \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -598,4 +598,17 @@ EXTRA_DIST = \
 	libtpms.syms \
 	test.syms
 
-CLEANFILES = a.out
+CLEANFILES = \
+	a.out \
+	*.gcov \
+	*.gcda \
+	*.gcno \
+	tpm12/*.gcov \
+	tpm12/*.gcda \
+	tpm12/*.gcno \
+	tpm2/*.gcov \
+	tpm2/*.gcda \
+	tpm2/*.gcno \
+	tpm2/crypto/openssl/*.gcov \
+	tpm2/crypto/openssl/*.gcda \
+	tpm2/crypto/openssl/*.gcno

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -56,3 +56,8 @@ EXTRA_DIST = \
 	common \
 	tpm2_pcr_read.c \
 	tpm2_pcr_read.sh
+
+CLEANFILES = \
+	*.gcov \
+	*.gcda \
+	*.gcno


### PR DESCRIPTION
Add coverage support to the build system and fix the CFLAGS passing from the command line.
Add a Travis build that gets swtpm from the git repo and builds it and runs the test suite with code coverage enabled for libtpms.

Unfortunately cpp-coveralls cannot properly process all the input file due to malforming the path of the source files, so the results are currently not good unless I can figure out how to invoke cpp-coveralls or cpp-coveralls gets fixed.
