### PR TITLE
build-sys: add oss-fuzz support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,7 @@ lib_LTLIBRARIES=libtpms.la
 
 common_CFLAGS = -include tpm_library_conf.h \
                 -I$(top_srcdir)/include/libtpms \
+		-I$(top_builddir)/include/libtpms \
                 $(HARDENING_CFLAGS) \
                $(SANITIZERS) \
                $(FUZZER)

--- a/tests/oss-fuzz.sh
+++ b/tests/oss-fuzz.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ex
+
+export CC=${CC:-clang}
+export CXX=${CXX:-clang++}
+export WORK=${WORK:-$(pwd)}
+export OUT=${OUT:-$(pwd)/out}
+
+mkdir -p $OUT
+
+build=$WORK/build
+rm -rf $build
+mkdir -p $build
+
+export LIBTPMS=$(pwd)
+autoreconf -vfi
+
+cd $build
+$LIBTPMS/configure --disable-shared --enable-static --with-openssl --with-tpm2 --enable-fuzzer
+make -j$(nproc) && make -C tests fuzz
+
+zip -jqr $OUT/fuzz_seed_corpus.zip "$LIBTPMS/tests/corpus-execute-command"
+
+find $build -type f -executable -name "fuzz*" -exec mv {} $OUT \;
+find $build -type f -name "*.options" -exec mv {} $OUT \;


### PR DESCRIPTION
This script will permit integration with Google OSS-FUZZ
https://github.com/google/oss-fuzz

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>