### PR TITLE
travis: Use cpp-coveralls with the -b option for proper path creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,7 @@ matrix:
          sudo make -j$(nproc) check &&
         popd
       after_success:
-        # coveralls creates some odd paths
-        sudo cpp-coveralls --gcov-options '\-lp'
-          -e src/tpm12/tpm12
-          -e src/tpm2/tpm2
-          -e src/tpm2/crypto/openssl/tpm2/
+        sudo cpp-coveralls -b src -e tests -e swtpm --gcov-options '\-lp'
     - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2" "TARGET=check"
            NPROC="sysctl -n hw.ncpu" CFLAGS="-I/usr/local/opt/openssl/include"
            LDFLAGS="-L/usr/local/opt/openssl/lib"


### PR DESCRIPTION
Add the option -b ./src for proper path creation. Exclude the test
dir to avoid malformed path creation. Also exclude the swtpm dir
since nothing interesting is to be found there.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>