### PR TITLE
tpm12: Deactivate unused code and maintenance commands

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,8 @@ libtpms_tpm12_la_CFLAGS += -DTPM_LIBTPMS_CALLBACKS
 libtpms_tpm12_la_CFLAGS += -DTPM_NV_DISK
 # build a POSIX type of TPM
 libtpms_tpm12_la_CFLAGS += -DTPM_POSIX
+# build without maintenance commands
+libtpms_tpm12_la_CFLAGS += -DTPM_NOMAINTENANCE_COMMANDS
 
 libtpms_tpm12_la_CFLAGS += @DEBUG_DEFINES@
 

--- a/src/tpm12/tpm_auth.c
+++ b/src/tpm12/tpm_auth.c
@@ -82,6 +82,7 @@
        authFailCount = 0
 */
 
+#if 0
 /* TPM_Authdata_Init() zeros the tpm_authdata
 
 */
@@ -92,6 +93,7 @@ void TPM_Authdata_Init(TPM_AUTHDATA tpm_authdata)
     memset(tpm_authdata, 0, TPM_AUTHDATA_SIZE);
     return;
 }
+#endif
 
 /* TPM_Authdata_Load()
 
@@ -509,6 +511,7 @@ TPM_RESULT TPM_ChangeauthValidate_Load(TPM_CHANGEAUTH_VALIDATE *tpm_changeauth_v
     return rc;
 }
 
+#if 0
 /* TPM_ChangeauthValidate_Store()
    
    serialize the structure to a stream contained in 'sbuffer'
@@ -531,6 +534,7 @@ TPM_RESULT TPM_ChangeauthValidate_Store(TPM_STORE_BUFFER *sbuffer,
     }
     return rc;
 }
+#endif
 
 /* TPM_ChangeauthValidate_Delete()
 

--- a/src/tpm12/tpm_auth.h
+++ b/src/tpm12/tpm_auth.h
@@ -50,7 +50,9 @@
   TPM_AUTHDATA
 */
 
+#if 0
 void       TPM_Authdata_Init(TPM_AUTHDATA tpm_authdata);
+#endif
 TPM_RESULT TPM_Authdata_Load(TPM_AUTHDATA tpm_authdata,
                              unsigned char **stream,
                              uint32_t *stream_size);
@@ -112,8 +114,10 @@ void       TPM_ChangeauthValidate_Init(TPM_CHANGEAUTH_VALIDATE *tpm_changeauth_v
 TPM_RESULT TPM_ChangeauthValidate_Load(TPM_CHANGEAUTH_VALIDATE *tpm_changeauth_validate,
                                        unsigned char **stream,
                                        uint32_t *stream_size);
+#if 0
 TPM_RESULT TPM_ChangeauthValidate_Store(TPM_STORE_BUFFER *sbuffer,
                                         const TPM_CHANGEAUTH_VALIDATE *tpm_changeauth_validate);
+#endif
 void       TPM_ChangeauthValidate_Delete(TPM_CHANGEAUTH_VALIDATE *tpm_changeauth_validate);
 
 /*

--- a/src/tpm12/tpm_crypto.c
+++ b/src/tpm12/tpm_crypto.c
@@ -752,6 +752,7 @@ TPM_RESULT TPM_RSAPublicEncrypt(unsigned char* encrypt_data,    /* encrypted dat
     return rc;
 }
 
+#if 0
 /* TPM_RSAPublicEncryptRaw() does a raw public key operation without any padding.
 
 */
@@ -821,6 +822,7 @@ TPM_RESULT TPM_RSAPublicEncryptRaw(unsigned char *encrypt_data,	/* output */
     }
     return rc;
 }
+#endif
 
 /* TPM_RSASign() signs 'message' of size 'message_size' using the private key n,e,d and the
    signature scheme 'sigScheme' as specified in PKCS #1 v2.0.

--- a/src/tpm12/tpm_crypto.h
+++ b/src/tpm12/tpm_crypto.h
@@ -129,6 +129,7 @@ TPM_RESULT TPM_RSAPublicEncrypt(unsigned char* encrypt_data,
                                 uint32_t nbytes,
                                 unsigned char *earr,
                                 uint32_t ebytes);
+#if 0
 TPM_RESULT TPM_RSAPublicEncryptRaw(unsigned char *encrypt_data,
 				   uint32_t encrypt_data_size,
 				   unsigned char *decrypt_data,
@@ -137,6 +138,7 @@ TPM_RESULT TPM_RSAPublicEncryptRaw(unsigned char *encrypt_data,
 				   uint32_t nbytes,
 				   unsigned char *earr,
 				   uint32_t ebytes);
+#endif
     
 TPM_RESULT TPM_RSAGetPrivateKey(uint32_t *qbytes, unsigned char **qarr,
                                 uint32_t *dbytes, unsigned char **darr,

--- a/src/tpm12/tpm_cryptoh.c
+++ b/src/tpm12/tpm_cryptoh.c
@@ -176,6 +176,7 @@ void TPM_CertifyInfo_Init(TPM_CERTIFY_INFO *tpm_certify_info)
     return;
 }
 
+#if 0
 /* TPM_CertifyInfo_Load()
 
    deserialize the structure from a 'stream'
@@ -242,6 +243,7 @@ TPM_RESULT TPM_CertifyInfo_Load(TPM_CERTIFY_INFO *tpm_certify_info,
     }
     return rc;
 }
+#endif
 
 /* TPM_CertifyInfo_Store()
    
@@ -382,6 +384,7 @@ void TPM_CertifyInfo2_Init(TPM_CERTIFY_INFO2 *tpm_certify_info2)
     return;
 }
 
+#if 0
 /* TPM_CertifyInfo2_Load()
 
    deserialize the structure from a 'stream'
@@ -471,6 +474,7 @@ TPM_RESULT TPM_CertifyInfo2_Load(TPM_CERTIFY_INFO2 *tpm_certify_info2,
     }
     return rc;
 }
+#endif
 
 /* TPM_CertifyInfo2_Store()
    

--- a/src/tpm12/tpm_cryptoh.h
+++ b/src/tpm12/tpm_cryptoh.h
@@ -59,9 +59,11 @@ void       TPM_SignInfo_Delete(TPM_SIGN_INFO *tpm_sign_info);
 */
 
 void       TPM_CertifyInfo_Init(TPM_CERTIFY_INFO *tpm_certify_info);
+#if 0
 TPM_RESULT TPM_CertifyInfo_Load(TPM_CERTIFY_INFO *tpm_certify_info,
                                 unsigned char **stream,
                                 uint32_t *stream_size);
+#endif
 TPM_RESULT TPM_CertifyInfo_Store(TPM_STORE_BUFFER *sbuffer,
                                  TPM_CERTIFY_INFO *tpm_certify_info);
 void       TPM_CertifyInfo_Delete(TPM_CERTIFY_INFO *tpm_certify_info);
@@ -74,9 +76,11 @@ TPM_RESULT TPM_CertifyInfo_Set(TPM_CERTIFY_INFO *tpm_certify_info,
 */
 
 void       TPM_CertifyInfo2_Init(TPM_CERTIFY_INFO2 *tpm_certify_info2);
+#if 0
 TPM_RESULT TPM_CertifyInfo2_Load(TPM_CERTIFY_INFO2 *tpm_certify_info2,
                                  unsigned char **stream,
                                  uint32_t *stream_size);
+#endif
 TPM_RESULT TPM_CertifyInfo2_Store(TPM_STORE_BUFFER *sbuffer,
                                   TPM_CERTIFY_INFO2 *tpm_certify_info2);
 void       TPM_CertifyInfo2_Delete(TPM_CERTIFY_INFO2 *tpm_certify_info2);

--- a/src/tpm12/tpm_digest.c
+++ b/src/tpm12/tpm_digest.c
@@ -146,6 +146,7 @@ void TPM_Digest_IsZero(TPM_BOOL *isZero, TPM_DIGEST tpm_digest)
     return;
 }
 
+#if 0
 void TPM_Digest_IsMinusOne(TPM_BOOL *isMinusOne, TPM_DIGEST tpm_digest)
 {
     size_t i;
@@ -158,4 +159,4 @@ void TPM_Digest_IsMinusOne(TPM_BOOL *isMinusOne, TPM_DIGEST tpm_digest)
     }
     return;
 }
-
+#endif

--- a/src/tpm12/tpm_digest.h
+++ b/src/tpm12/tpm_digest.h
@@ -57,6 +57,8 @@ void       TPM_Digest_XOR(TPM_DIGEST out,
                           const TPM_DIGEST in2);
 TPM_RESULT TPM_Digest_Compare(const TPM_DIGEST expect, const TPM_DIGEST actual);
 void       TPM_Digest_IsZero(TPM_BOOL *isZero, TPM_DIGEST tpm_digest);
+#if 0
 void 	   TPM_Digest_IsMinusOne(TPM_BOOL *isMinusOne, TPM_DIGEST tpm_digest);
+#endif
 
 #endif

--- a/src/tpm12/tpm_global.c
+++ b/src/tpm12/tpm_global.c
@@ -126,6 +126,7 @@ TPM_RESULT TPM_Global_Init(tpm_state_t *tpm_state)
     return rc;
 }
 
+#if 0
 /* TPM_Global_Load() loads the tpm_state_t global structures for the TPM instance from NVRAM.
 
    tpm_state->tpm_number must be set by the caller.
@@ -169,6 +170,7 @@ TPM_RESULT TPM_Global_Store(tpm_state_t *tpm_state)
     }
     return rc;
 }
+#endif
 
 /* TPM_Global_Delete()
 

--- a/src/tpm12/tpm_global.h
+++ b/src/tpm12/tpm_global.h
@@ -90,8 +90,10 @@ extern tpm_state_t *tpm_instances[];
 */
 
 TPM_RESULT TPM_Global_Init(tpm_state_t *tpm_state);
+#if 0
 TPM_RESULT TPM_Global_Load(tpm_state_t *tpm_state);
 TPM_RESULT TPM_Global_Store(tpm_state_t *tpm_state);
+#endif
 void       TPM_Global_Delete(tpm_state_t *tpm_state);
 
 

--- a/src/tpm12/tpm_identity.c
+++ b/src/tpm12/tpm_identity.c
@@ -107,6 +107,7 @@ TPM_RESULT TPM_EKBlob_Load(TPM_EK_BLOB *tpm_ek_blob,
     return rc;
 }
 
+#if 0
 /* TPM_EKBlob_Store()
    
    serialize the structure to a stream contained in 'sbuffer'
@@ -130,6 +131,7 @@ TPM_RESULT TPM_EKBlob_Store(TPM_STORE_BUFFER *sbuffer,
     }
     return rc;
 }
+#endif
 
 /* TPM_EKBlob_Delete()
 
@@ -206,6 +208,7 @@ TPM_RESULT TPM_EKBlobActivate_Load(TPM_EK_BLOB_ACTIVATE *tpm_ek_blob_activate,
     return rc;
 }
 
+#if 0
 /* TPM_EKBlobActivate_Store()
    
    serialize the structure to a stream contained in 'sbuffer'
@@ -236,6 +239,7 @@ TPM_RESULT TPM_EKBlobActivate_Store(TPM_STORE_BUFFER *sbuffer,
     }
     return rc;
 }
+#endif
 
 /* TPM_EKBlobActivate_Delete()
 
@@ -261,6 +265,7 @@ void TPM_EKBlobActivate_Delete(TPM_EK_BLOB_ACTIVATE *tpm_ek_blob_activate)
   TPM_EK_BLOB_AUTH
 */
 
+#if 0
 /* TPM_EKBlobAuth_Init()
 
    sets members to default values
@@ -341,6 +346,7 @@ void TPM_EKBlobAuth_Delete(TPM_EK_BLOB_AUTH *tpm_ek_blob_auth)
     }
     return;
 }
+#endif
 
 /*
   TPM_IDENTITY_CONTENTS
@@ -500,6 +506,7 @@ TPM_RESULT TPM_AsymCaContents_Load(TPM_ASYM_CA_CONTENTS *tpm_asym_ca_contents,
     return rc;
 }
 
+#if 0
 /* TPM_AsymCaContents_Store()
    
    serialize the structure to a stream contained in 'sbuffer'
@@ -520,6 +527,7 @@ TPM_RESULT TPM_AsymCaContents_Store(TPM_STORE_BUFFER *sbuffer,
     }
     return rc;
 }
+#endif
 
 /* TPM_AsymCaContents_Delete()
 

--- a/src/tpm12/tpm_identity.h
+++ b/src/tpm12/tpm_identity.h
@@ -50,8 +50,10 @@ void       TPM_EKBlob_Init(TPM_EK_BLOB *tpm_ek_blob);
 TPM_RESULT TPM_EKBlob_Load(TPM_EK_BLOB *tpm_ek_blob,
                            unsigned char **stream,
                            uint32_t *stream_size);
+#if 0
 TPM_RESULT TPM_EKBlob_Store(TPM_STORE_BUFFER *sbuffer,
                             const TPM_EK_BLOB *tpm_ek_blob);
+#endif
 void       TPM_EKBlob_Delete(TPM_EK_BLOB *tpm_ek_blob);
 
 /*
@@ -62,14 +64,17 @@ void       TPM_EKBlobActivate_Init(TPM_EK_BLOB_ACTIVATE *tpm_ek_blob_activate);
 TPM_RESULT TPM_EKBlobActivate_Load(TPM_EK_BLOB_ACTIVATE *tpm_ek_blob_activate,
                                    unsigned char **stream,
                                    uint32_t *stream_size);
+#if 0
 TPM_RESULT TPM_EKBlobActivate_Store(TPM_STORE_BUFFER *sbuffer,
                                     const TPM_EK_BLOB_ACTIVATE *tpm_ek_blob_activate);
+#endif
 void       TPM_EKBlobActivate_Delete(TPM_EK_BLOB_ACTIVATE *tpm_ek_blob_activate);
 
 /*
   TPM_EK_BLOB_AUTH
 */
 
+#if 0
 void       TPM_EKBlobAuth_Init(TPM_EK_BLOB_AUTH *tpm_ek_blob_auth);
 TPM_RESULT TPM_EKBlobAuth_Load(TPM_EK_BLOB_AUTH *tpm_ek_blob_auth,
                                unsigned char **stream,
@@ -77,7 +82,7 @@ TPM_RESULT TPM_EKBlobAuth_Load(TPM_EK_BLOB_AUTH *tpm_ek_blob_auth,
 TPM_RESULT TPM_EKBlobAuth_Store(TPM_STORE_BUFFER *sbuffer,
                                 const TPM_EK_BLOB_AUTH *tpm_ek_blob_auth);
 void       TPM_EKBlobAuth_Delete(TPM_EK_BLOB_AUTH *tpm_ek_blob_auth);
-
+#endif
 
 
 /*
@@ -85,9 +90,11 @@ void       TPM_EKBlobAuth_Delete(TPM_EK_BLOB_AUTH *tpm_ek_blob_auth);
 */
 
 void       TPM_IdentityContents_Init(TPM_IDENTITY_CONTENTS *tpm_identity_contents);
+#if 0
 TPM_RESULT TPM_IdentityContents_Load(TPM_IDENTITY_CONTENTS *tpm_identity_contents,
                                      unsigned char **stream,
                                      uint32_t *stream_size);
+#endif
 TPM_RESULT TPM_IdentityContents_Store(TPM_STORE_BUFFER *sbuffer,
                                       TPM_IDENTITY_CONTENTS *tpm_identity_contents);
 void       TPM_IdentityContents_Delete(TPM_IDENTITY_CONTENTS *tpm_identity_contents);
@@ -100,8 +107,10 @@ void       TPM_AsymCaContents_Init(TPM_ASYM_CA_CONTENTS *tpm_asym_ca_contents);
 TPM_RESULT TPM_AsymCaContents_Load(TPM_ASYM_CA_CONTENTS *tpm_asym_ca_contents,
                                    unsigned char **stream,
                                    uint32_t *stream_size);
+#if 0
 TPM_RESULT TPM_AsymCaContents_Store(TPM_STORE_BUFFER *sbuffer,
                                     const TPM_ASYM_CA_CONTENTS *tpm_asym_ca_contents);
+#endif
 void       TPM_AsymCaContents_Delete(TPM_ASYM_CA_CONTENTS *tpm_asym_ca_contents);
 
 

--- a/src/tpm12/tpm_key.c
+++ b/src/tpm12/tpm_key.c
@@ -1465,6 +1465,7 @@ void TPM_KeyParms_Init(TPM_KEY_PARMS *tpm_key_parms)
     return;
 }
 
+#if 0
 /* TPM_KeyParms_SetRSA() is a 'Set' version specific to RSA keys */
 
 TPM_RESULT TPM_KeyParms_SetRSA(TPM_KEY_PARMS *tpm_key_parms,
@@ -1499,6 +1500,7 @@ TPM_RESULT TPM_KeyParms_SetRSA(TPM_KEY_PARMS *tpm_key_parms,
     }
     return rc;
 }
+#endif
 
 
 /* TPM_KeyParms_Copy() copies the source to the destination.

--- a/src/tpm12/tpm_key.h
+++ b/src/tpm12/tpm_key.h
@@ -178,12 +178,14 @@ TPM_RESULT TPM_KeyParms_Set(TPM_KEY_PARMS *tpm_key_parms,
                             TPM_SIG_SCHEME sigScheme,
                             uint32_t parmSize,
                             BYTE* parms);
+#if 0
 TPM_RESULT TPM_KeyParms_SetRSA(TPM_KEY_PARMS *tpm_key_parms,
                                TPM_ALGORITHM_ID algorithmID,
                                TPM_ENC_SCHEME encScheme,
                                TPM_SIG_SCHEME sigScheme,
                                uint32_t keyLength,
                                TPM_SIZED_BUFFER *exponent);
+#endif
 TPM_RESULT TPM_KeyParms_Copy(TPM_KEY_PARMS *tpm_key_parms_dest,
                              TPM_KEY_PARMS *tpm_key_parms_src);
 TPM_RESULT TPM_KeyParms_Load(TPM_KEY_PARMS *tpm_key_parms,

--- a/src/tpm12/tpm_load.c
+++ b/src/tpm12/tpm_load.c
@@ -254,6 +254,7 @@ TPM_RESULT TPM_LoadLong(unsigned long *result,
     return rc;
 }
 
+#if 0
 /* TPM_LoadString() returns a pointer to a C string.  It does not copy the string.
 
  */
@@ -280,6 +281,7 @@ TPM_RESULT TPM_LoadString(const char **name,
     }
     return rc;
 }
+#endif
 
 /* TPM_CheckTag() loads a TPM_STRUCTURE_TAG from 'stream'.  It check that the value is 'expectedTag'
    and returns TPM_INVALID_STRUCTURE on error.

--- a/src/tpm12/tpm_load.h
+++ b/src/tpm12/tpm_load.h
@@ -62,9 +62,11 @@ TPM_RESULT TPM_LoadBool(TPM_BOOL *tpm_bool,
 TPM_RESULT TPM_LoadLong(unsigned long *result,
                         const unsigned char *stream,
                         uint32_t stream_size);
+#if 0
 TPM_RESULT TPM_LoadString(const char **name,
                           unsigned char **stream,
                           uint32_t *stream_size);
+#endif
 TPM_RESULT TPM_CheckTag(TPM_STRUCTURE_TAG expectedTag,
 			unsigned char **stream,
                         uint32_t *stream_size);

--- a/src/tpm12/tpm_maint.c
+++ b/src/tpm12/tpm_maint.c
@@ -37,7 +37,7 @@
 /* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.		*/
 /********************************************************************************/
 
-#ifndef TPM_NOMAINTENANCE
+#if !defined(TPM_NOMAINTENANCE) && !defined(TPM_NOMAINTENANCE_COMMANDS)
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/tpm12/tpm_owner.c
+++ b/src/tpm12/tpm_owner.c
@@ -1035,7 +1035,7 @@ TPM_RESULT TPM_OwnerClearCommon(tpm_state_t *tpm_state,
 	tpm_state->tpm_permanent_flags.disableFullDALogicInfo = FALSE;
 #endif
 	/* f. allowMaintenance */
-#ifdef TPM_NOMAINTENANCE
+#if defined(TPM_NOMAINTENANCE) || defined(TPM_NOMAINTENANCE_COMMANDS)
 	tpm_state->tpm_permanent_flags.allowMaintenance = FALSE;
 #else
 	tpm_state->tpm_permanent_flags.allowMaintenance = TRUE;

--- a/src/tpm12/tpm_pcr.c
+++ b/src/tpm12/tpm_pcr.c
@@ -2281,6 +2281,7 @@ void TPM_PCRSelection_Compare(TPM_BOOL *match,
     return;
 }
 
+#if 0
 /* TPM_PCRSelection_LessThan() compares the new selection to the old selection.	 It returns lessThan
    TRUE is the new selection does not select a PCR that was selected by the old selection.
 */
@@ -2303,6 +2304,7 @@ void TPM_PCRSelection_LessThan(TPM_BOOL *lessThan,
     }	
     return;
 }
+#endif
 
 
 /*
@@ -2326,6 +2328,7 @@ void TPM_QuoteInfo_Init(TPM_QUOTE_INFO *tpm_quote_info)
     return;
 }
 
+#if 0
 /* TPM_QuoteInfo_Load()
 
    deserialize the structure from a 'stream'
@@ -2367,6 +2370,7 @@ TPM_RESULT TPM_QuoteInfo_Load(TPM_QUOTE_INFO *tpm_quote_info,
     }
     return rc;
 }
+#endif
 
 /* TPM_QuoteInfo_Store()
    
@@ -2437,6 +2441,7 @@ void TPM_QuoteInfo2_Init(TPM_QUOTE_INFO2 *tpm_quote_info2)
     return;
 }
 
+#if 0
 /* TPM_QuoteInfo2_Load()
 
    deserialize the structure from a 'stream'
@@ -2472,6 +2477,7 @@ TPM_RESULT TPM_QuoteInfo2_Load(TPM_QUOTE_INFO2 *tpm_quote_info2,
     }
     return rc;
 }
+#endif
 
 /* TPM_QuoteInfo2_Store()
    

--- a/src/tpm12/tpm_pcr.h
+++ b/src/tpm12/tpm_pcr.h
@@ -119,9 +119,11 @@ TPM_RESULT TPM_PCRSelection_CheckRange(const TPM_PCR_SELECTION *tpm_pcr_selectio
 void       TPM_PCRSelection_Compare(TPM_BOOL *match,
                                     TPM_PCR_SELECTION *tpm_pcr_selection1,
                                     TPM_PCR_SELECTION *tpm_pcr_selection2);
+#if 0
 void TPM_PCRSelection_LessThan(TPM_BOOL *lessThan,
                                TPM_PCR_SELECTION *tpm_pcr_selection_new,
                                TPM_PCR_SELECTION *tpm_pcr_selection_old);
+#endif
 
 /* TPM_PCR_ATTRIBUTES */
 
@@ -288,9 +290,11 @@ TPM_RESULT TPM_PCRComposite_Set(TPM_PCR_COMPOSITE *tpm_pcr_composite,
 */
 
 void       TPM_QuoteInfo_Init(TPM_QUOTE_INFO *tpm_quote_info);
+#if 0
 TPM_RESULT TPM_QuoteInfo_Load(TPM_QUOTE_INFO *tpm_quote_info,
                               unsigned char **stream,
                               uint32_t *stream_size);
+#endif
 TPM_RESULT TPM_QuoteInfo_Store(TPM_STORE_BUFFER *sbuffer,
                                const TPM_QUOTE_INFO *tpm_quote_info);
 void       TPM_QuoteInfo_Delete(TPM_QUOTE_INFO *tpm_quote_info);
@@ -300,9 +304,11 @@ void       TPM_QuoteInfo_Delete(TPM_QUOTE_INFO *tpm_quote_info);
 */
 
 void       TPM_QuoteInfo2_Init(TPM_QUOTE_INFO2 *tpm_quote_info2);
+#if 0
 TPM_RESULT TPM_QuoteInfo2_Load(TPM_QUOTE_INFO2 *tpm_quote_info2,
                                unsigned char **stream,
                                uint32_t *stream_size);
+#endif
 TPM_RESULT TPM_QuoteInfo2_Store(TPM_STORE_BUFFER *sbuffer,
                                 const TPM_QUOTE_INFO2 *tpm_quote_info2);
 void       TPM_QuoteInfo2_Delete(TPM_QUOTE_INFO2 *tpm_quote_info2);

--- a/src/tpm12/tpm_process.c
+++ b/src/tpm12/tpm_process.c
@@ -633,7 +633,7 @@ static TPM_ORDINAL_TABLE tpm_ordinal_table[] =
      FALSE},
     
     {TPM_ORD_CreateMaintenanceArchive,
-#ifdef TPM_NOMAINTENANCE
+#if defined(TPM_NOMAINTENANCE) || defined(TPM_NOMAINTENANCE_COMMANDS)
      TPM_Process_Unused, TPM_Process_Unused,
      FALSE,
      FALSE,
@@ -1172,7 +1172,7 @@ static TPM_ORDINAL_TABLE tpm_ordinal_table[] =
      FALSE},
     
     {TPM_ORD_KillMaintenanceFeature,
-#ifdef TPM_NOMAINTENANCE
+#if defined(TPM_NOMAINTENANCE) || defined(TPM_NOMAINTENANCE_COMMANDS)
      TPM_Process_Unused, TPM_Process_Unused,
      FALSE,
      FALSE,
@@ -1256,7 +1256,7 @@ static TPM_ORDINAL_TABLE tpm_ordinal_table[] =
      FALSE},
     
     {TPM_ORD_LoadMaintenanceArchive,
-#ifdef TPM_NOMAINTENANCE
+#if defined(TPM_NOMAINTENANCE) || defined(TPM_NOMAINTENANCE_COMMANDS)
      TPM_Process_Unused, TPM_Process_Unused,
      FALSE,
      FALSE,
@@ -1275,7 +1275,7 @@ static TPM_ORDINAL_TABLE tpm_ordinal_table[] =
      FALSE},
     
     {TPM_ORD_LoadManuMaintPub,
-#ifdef TPM_NOMAINTENANCE
+#if defined(TPM_NOMAINTENANCE) || defined(TPM_NOMAINTENANCE_COMMANDS)
      TPM_Process_Unused, TPM_Process_Unused,
      FALSE,
      FALSE,
@@ -1567,7 +1567,7 @@ static TPM_ORDINAL_TABLE tpm_ordinal_table[] =
      FALSE},
     
     {TPM_ORD_ReadManuMaintPub,
-#ifdef TPM_NOMAINTENANCE
+#if defined(TPM_NOMAINTENANCE) || defined(TPM_NOMAINTENANCE_COMMANDS)
      TPM_Process_Unused, TPM_Process_Unused,
      FALSE,
      FALSE,

--- a/src/tpm12/tpm_startup.c
+++ b/src/tpm12/tpm_startup.c
@@ -1258,6 +1258,7 @@ TPM_RESULT TPM_Startup_Deactivated(tpm_state_t *tpm_state)
     return returnCode;
 }
 
+#if 0
 /* TPM_Startup_Any() rev 96
 
    Handles Actions common to all TPM_Startup options.
@@ -1277,6 +1278,7 @@ TPM_RESULT TPM_Startup_Any(tpm_state_t *tpm_state)
     tpm_state->tpm_stany_flags.postInitialise = FALSE;
     return returnCode;
 }
+#endif
 
 /* 3.3 TPM_SaveState rev 111
 

--- a/src/tpm12/tpm_startup.h
+++ b/src/tpm12/tpm_startup.h
@@ -51,7 +51,9 @@
 TPM_RESULT TPM_Startup_Clear(tpm_state_t *tpm_state);
 TPM_RESULT TPM_Startup_State(tpm_state_t *tpm_state);
 TPM_RESULT TPM_Startup_Deactivated(tpm_state_t *tpm_state);
+#if 0
 TPM_RESULT TPM_Startup_Any(tpm_state_t *tpm_state);
+#endif
 
 /*
   Save State

--- a/src/tpm12/tpm_storage.c
+++ b/src/tpm12/tpm_storage.c
@@ -144,6 +144,7 @@ TPM_RESULT TPM_BoundData_Load(TPM_BOUND_DATA *tpm_bound_data,
     return rc;
 }
 
+#if 0
 /* TPM_BoundData_Store()
    
    serialize the structure to a stream contained in 'sbuffer'
@@ -171,6 +172,7 @@ TPM_RESULT TPM_BoundData_Store(TPM_STORE_BUFFER *sbuffer,
     }
     return rc;
 }
+#endif
 
 /* TPM_BoundData_Delete()
 

--- a/src/tpm12/tpm_storage.h
+++ b/src/tpm12/tpm_storage.h
@@ -52,8 +52,10 @@ void       TPM_BoundData_Init(TPM_BOUND_DATA *tpm_bound_data);
 TPM_RESULT TPM_BoundData_Load(TPM_BOUND_DATA *tpm_bound_data,
                               unsigned char **stream,
                               uint32_t *stream_size);
+#if 0
 TPM_RESULT TPM_BoundData_Store(TPM_STORE_BUFFER *sbuffer,
                                const TPM_BOUND_DATA *tpm_bound_data);
+#endif
 void       TPM_BoundData_Delete(TPM_BOUND_DATA *tpm_bound_data);
 
 /*

--- a/src/tpm12/tpm_store.c
+++ b/src/tpm12/tpm_store.c
@@ -485,6 +485,7 @@ static TPM_RESULT TPM_Sbuffer_AdjustReturnCode(TPM_STORE_BUFFER *sbuffer, TPM_RE
     return rc;
 }
 
+#if 0
 /* Test appending to the TPM_STORE_BUFFER up to the limit */
 
 TPM_RESULT TPM_Sbuffer_Test(void)
@@ -518,6 +519,7 @@ TPM_RESULT TPM_Sbuffer_Test(void)
     TPM_Sbuffer_Delete(&sbuffer);
     return rc;
 }
+#endif
 
 /* type to byte stream */
 void STORE32(unsigned char *buffer, unsigned int offset, uint32_t value)

--- a/src/tpm12/tpm_store.h
+++ b/src/tpm12/tpm_store.h
@@ -84,7 +84,9 @@ TPM_RESULT TPM_Sbuffer_StoreFinalResponse(TPM_STORE_BUFFER *sbuffer,
                                           TPM_RESULT returnCode,
                                           tpm_state_t *tpm_state);
 
+#if 0
 TPM_RESULT TPM_Sbuffer_Test(void);
+#endif
 
 /* type to byte stream */
 

--- a/src/tpm12/tpm_ver.c
+++ b/src/tpm12/tpm_ver.c
@@ -204,6 +204,7 @@ void TPM_Version_Set(TPM_VERSION *tpm_version,
     return;
 }
 
+#if 0
 /* TPM_Version_Load()
 
    deserialize the structure from a 'stream'
@@ -238,6 +239,7 @@ TPM_RESULT TPM_Version_Load(TPM_VERSION *tpm_version,
     }
     return rc;
 }
+#endif
 /* TPM_Version_Store()
    
    serialize the structure to a stream contained in 'sbuffer'

--- a/src/tpm12/tpm_ver.h
+++ b/src/tpm12/tpm_ver.h
@@ -61,9 +61,11 @@ TPM_RESULT TPM_StructVer_CheckVer(TPM_STRUCT_VER *tpm_struct_ver);
 void       TPM_Version_Init(TPM_VERSION *tpm_version);
 void       TPM_Version_Set(TPM_VERSION *tpm_version,
                            TPM_PERMANENT_DATA *tpm_permanent_data);
+#if 0
 TPM_RESULT TPM_Version_Load(TPM_VERSION *tpm_version,
                             unsigned char **stream,
                             uint32_t *stream_size);
+#endif
 TPM_RESULT TPM_Version_Store(TPM_STORE_BUFFER *sbuffer,
                              const TPM_VERSION *tpm_version);
 void       TPM_Version_Delete(TPM_VERSION *tpm_version);


### PR DESCRIPTION
There are quite a few unused functions in the TPM 1.2 code and this patch comments them out.
Also the TPM 1.2 maintenance commands are not useful. Deactivate them as well, which also increases code coverage using swtpm's TPM 1.2 test suite.