### PR TITLE
tpm2: TPMT_PUBLIC_PARMS_Marshal is unused

### DIFF
--- a/src/tpm2/Marshal_fp.h
+++ b/src/tpm2/Marshal_fp.h
@@ -352,12 +352,12 @@ extern "C" {
     TPMS_RSA_PARMS_Marshal(TPMS_RSA_PARMS *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMS_ECC_PARMS_Marshal(TPMS_ECC_PARMS *source, BYTE **buffer, INT32 *size);
-#if 0 /* libtpms added */
     UINT16
     TPMU_PUBLIC_PARMS_Marshal(TPMU_PUBLIC_PARMS *source, BYTE **buffer, INT32 *size, UINT32 selector) ;
-#endif /* libtpms added */
+#if 0 /* libtpms added */
     UINT16
     TPMT_PUBLIC_PARMS_Marshal(TPMT_PUBLIC_PARMS *source, BYTE **buffer, INT32 *size);
+#endif /* libtpms added */
     UINT16
     TPMT_PUBLIC_Marshal(TPMT_PUBLIC *source, BYTE **buffer, INT32 *size);
     UINT16


### PR DESCRIPTION
... and TPMU_PUBLIC_PARMS_Marshal is used, so leave its prototype active.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>