### PR TITLE
Add missing #define TPM_HAVE_TPM2_DECLARATIONS in tpm2 code (RHEL 6)

### DIFF
--- a/src/tpm2/Manufacture.c
+++ b/src/tpm2/Manufacture.c
@@ -68,6 +68,7 @@
 #define MANUFACTURE_C
 #include "Tpm.h"
 #include "TpmSizeChecks_fp.h"
+#define TPM_HAVE_TPM2_DECLARATIONS
 #include "tpm_library_intern.h"  // libtpms added
 /* 9.9.3 Functions */
 /* 9.9.3.1 TPM_Manufacture() */

--- a/src/tpm2/NVMem.c
+++ b/src/tpm2/NVMem.c
@@ -74,6 +74,7 @@
 #include "NVMarshal.h"
 #include "LibtpmsCallbacks.h"
 #include <errno.h>
+#define TPM_HAVE_TPM2_DECLARATIONS
 #include "tpm_library_intern.h"
 /* libtpms added end */
 


### PR DESCRIPTION
Add some missing #define TPM_HAVE_TPM2_DECLARATIONS before the include
of "tpm_library_intern.h" in TPM 2 code so we don't run into compile
errors on RHEL 6 when data types are redefined in TPM 1.2 code.

Previous patch 73cad883bac seems to have missed those.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>