### PR TITLE
build-sys: don't tweak LD_LIBRARY_PATH

### DIFF
--- a/tests/run-fuzzer.sh
+++ b/tests/run-fuzzer.sh
@@ -5,17 +5,6 @@
 DIR=${PWD}/$(dirname "$0")
 ROOT=${DIR}/..
 WORKDIR=$(mktemp -d)
-export LD_LIBRARY_PATH=${ROOT}/src/.libs
-
-if ! [ -d ${LD_LIBRARY_PATH} ]; then
-	echo "Wrong path to libtpms library: ${LD_LIBRARY_PATH}"
-	exit 1
-fi
-
-if ! [ -f "$(readlink -f ${LD_LIBRARY_PATH}/libtpms.so)" ]; then
-	echo "Cannot find libtpms at ${LD_LIBRARY_PATH}/libtpms.so"
-	exit 1
-fi
 
 function cleanup()
 {

--- a/tests/tpm2_createprimary.sh
+++ b/tests/tpm2_createprimary.sh
@@ -7,25 +7,8 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 DIR=${PWD}
 
 WORKDIR=$(mktemp -d)
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-${ROOT}/src/.libs}
 
 . ${TESTDIR}/common
-
-case "$(uname -s)" in
-Linux)
-	if ! [ -d ${LD_LIBRARY_PATH} ]; then
-		echo "Wrong path to libtpms library: ${LD_LIBRARY_PATH}"
-		exit 1
-	fi
-
-	if ! [ -f "$(readlink -f ${LD_LIBRARY_PATH}/libtpms.so)" ]; then
-		echo "Cannot find libtpms at ${LD_LIBRARY_PATH}/libtpms.so"
-		exit 1
-	fi
-	;;
-*)
-	;;
-esac
 
 function cleanup()
 {

--- a/tests/tpm2_pcr_read.sh
+++ b/tests/tpm2_pcr_read.sh
@@ -7,25 +7,8 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 DIR=${PWD}
 
 WORKDIR=$(mktemp -d)
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-${ROOT}/src/.libs}
 
 . ${TESTDIR}/common
-
-case "$(uname -s)" in
-Linux)
-	if ! [ -d ${LD_LIBRARY_PATH} ]; then
-		echo "Wrong path to libtpms library: ${LD_LIBRARY_PATH}"
-		exit 1
-	fi
-
-	if ! [ -f "$(readlink -f ${LD_LIBRARY_PATH}/libtpms.so)" ]; then
-		echo "Cannot find libtpms at ${LD_LIBRARY_PATH}/libtpms.so"
-		exit 1
-	fi
-	;;
-*)
-	;;
-esac
 
 function cleanup()
 {


### PR DESCRIPTION
libtool already provides helper scripts around executables.

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>