### PR TITLE
tpm2: Rename NV_ROUNDUP to TPM2_ROUNDUP and move to new Utils.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -486,6 +486,7 @@ noinst_HEADERS += \
 	tpm2/LibtpmsCallbacks.h \
 	tpm2/NVMarshal.h \
 	tpm2/StateMarshal.h \
+	tpm2/Utils.h \
 	tpm2/Volatile.h
 
 if LIBTPMS_USE_OPENSSL

--- a/src/tpm2/Global.h
+++ b/src/tpm2/Global.h
@@ -89,6 +89,7 @@ _NORMAL_WARNING_LEVEL_
 #include "CryptTest.h"
 #include "TpmError.h"
 #include "NV.h"
+#include "Utils.h"
 //** Defines and Types
 //*** Crypto Self-Test Values
 extern ALGORITHM_VECTOR     g_implementedAlgorithms;
@@ -886,15 +887,12 @@ extern STATE_RESET_DATA gr;
 /* libtpms added: to put certain data structure at fixed offsets
  *                to give the ones below some room to expand
  */
-#define NV_ROUNDUP(VAL, SIZE) \
-  ( ( (VAL) + (SIZE) - 1 ) / (SIZE) ) * (SIZE)
-
 #define NV_PERSISTENT_DATA  (0)
 #define NV_STATE_RESET_DATA (NV_PERSISTENT_DATA + sizeof(PERSISTENT_DATA))
 #define NV_STATE_CLEAR_DATA (NV_STATE_RESET_DATA + sizeof(STATE_RESET_DATA))
 #define NV_ORDERLY_DATA     (NV_STATE_CLEAR_DATA + sizeof(STATE_CLEAR_DATA))
-#define NV_INDEX_RAM_DATA   NV_ROUNDUP(NV_ORDERLY_DATA + sizeof(ORDERLY_DATA),\
-                                       1024) /* libtpms added */
+#define NV_INDEX_RAM_DATA   TPM2_ROUNDUP(NV_ORDERLY_DATA + sizeof(ORDERLY_DATA),\
+                                         1024) /* libtpms added */
 #define NV_USER_DYNAMIC     (NV_INDEX_RAM_DATA + sizeof(s_indexOrderlyRam))
 #define NV_USER_DYNAMIC_END     NV_MEMORY_SIZE
 /* 5.10.13 Global Macro Definitions */

--- a/src/tpm2/Utils.h
+++ b/src/tpm2/Utils.h
@@ -1,0 +1,45 @@
+/********************************************************************************/
+/*										*/
+/*			        Utility functions				*/
+/*			     Written by Stefan Berger				*/
+/*		       IBM Thomas J. Watson Research Center			*/
+/*										*/
+/* (c) Copyright IBM Corporation 2017,2018.					*/
+/*										*/
+/* All rights reserved.								*/
+/* 										*/
+/* Redistribution and use in source and binary forms, with or without		*/
+/* modification, are permitted provided that the following conditions are	*/
+/* met:										*/
+/* 										*/
+/* Redistributions of source code must retain the above copyright notice,	*/
+/* this list of conditions and the following disclaimer.			*/
+/* 										*/
+/* Redistributions in binary form must reproduce the above copyright		*/
+/* notice, this list of conditions and the following disclaimer in the		*/
+/* documentation and/or other materials provided with the distribution.		*/
+/* 										*/
+/* Neither the names of the IBM Corporation nor the names of its		*/
+/* contributors may be used to endorse or promote products derived from		*/
+/* this software without specific prior written permission.			*/
+/* 										*/
+/* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS		*/
+/* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT		*/
+/* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR	*/
+/* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT		*/
+/* HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,	*/
+/* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT		*/
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,	*/
+/* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY	*/
+/* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT		*/
+/* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE	*/
+/* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.		*/
+/********************************************************************************/
+
+#ifndef UTILS_H
+#define UTILS_H
+
+#define TPM2_ROUNDUP(VAL, SIZE) \
+  ( ( (VAL) + (SIZE) - 1) / (SIZE) ) * (SIZE)
+
+#endif /* UTILS_H */


### PR DESCRIPTION
Move NV_ROUNDUP to Utils.h and call it TPM2_ROUNDUP for reuse by
other functions.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>