### PR TITLE
Have the TPM 2 code use OpenSSL's symmetric cipher functions for AES and TDES.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,24 @@ matrix:
         uidgid="$(id -nu):$(id -ng)" &&
         sudo chown -R ${uidgid} ./ &&
         cpp-coveralls -b src -e tests -e swtpm --gcov-options '\-lp'
+    - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2 --enable-test-coverage"
+           TARGET="install" NPROC="nproc"
+      dist: xenial
+      script:
+        sed -i 's/.* USE_OPENSSL_FUNCTIONS .*/#define USE_OPENSSL_FUNCTIONS NO/'
+            src/tpm2/Implementation.h &&
+        ./autogen.sh ${CONFIG} &&
+        sudo make -j$(nproc) ${TARGET} &&
+        sudo make -j$(nproc) check &&
+        git clone https://github.com/stefanberger/swtpm.git &&
+        pushd swtpm &&
+         sudo apt -y install devscripts equivs python-twisted libfuse-dev
+           libglib2.0-dev libgmp-dev expect libtasn1-dev socat findutils
+           tpm-tools gnutls-dev gnutls-bin &&
+         ./autogen.sh --with-gnutls --prefix=/usr &&
+         export SWTPM_TEST_EXPENSIVE=1 &&
+         sudo make -j$(nproc) check &&
+        popd
     - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2" "TARGET=check"
            NPROC="sysctl -n hw.ncpu" CFLAGS="-I/usr/local/opt/openssl/include"
            LDFLAGS="-L/usr/local/opt/openssl/lib"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -505,6 +505,7 @@ libtpms_tpm2_la_SOURCES += \
 	tpm2/crypto/openssl/CryptRsa.c \
 	tpm2/crypto/openssl/CryptSmac.c \
 	tpm2/crypto/openssl/CryptSym.c \
+	tpm2/crypto/openssl/Helpers.c \
 	tpm2/crypto/openssl/TpmToOsslDesSupport.c \
 	tpm2/crypto/openssl/TpmToOsslMath.c \
 	tpm2/crypto/openssl/TpmToOsslSupport.c
@@ -514,6 +515,7 @@ noinst_HEADERS += \
 	tpm2/crypto/openssl/BnMath_fp.h \
 	tpm2/crypto/openssl/BnMemory_fp.h \
 	tpm2/crypto/openssl/BnValues.h \
+	tpm2/crypto/openssl/Helpers_fp.h \
 	tpm2/crypto/openssl/LibSupport.h \
 	tpm2/crypto/openssl/TpmToOsslDesSupport_fp.h \
 	tpm2/crypto/openssl/TpmToOsslHash.h \

--- a/src/tpm2/Implementation.h
+++ b/src/tpm2/Implementation.h
@@ -1218,4 +1218,8 @@ typedef TPM2B_MAX_HASH_BLOCK    TPM2B_HASH_BLOCK;
 #if MAX_SYM_KEY_BITS == 0 || MAX_SYM_BLOCK_SIZE == 0
 #   error Bad size for MAX_SYM_KEY_BITS or MAX_SYM_BLOCK_SIZE
 #endif
+
+/* libtpms: Use OpenSSL's crypto functions where possible */
+#define USE_OPENSSL_FUNCTIONS   YES
+
 #endif  // _IMPLEMENTATION_H_

--- a/src/tpm2/Utils.h
+++ b/src/tpm2/Utils.h
@@ -39,7 +39,16 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include "Memory_fp.h"
+
 #define TPM2_ROUNDUP(VAL, SIZE) \
   ( ( (VAL) + (SIZE) - 1) / (SIZE) ) * (SIZE)
+
+static inline void clear_and_free(void *ptr, size_t size) {
+    if (ptr) {
+        MemorySet(ptr, 0, size);
+        free(ptr);
+    }
+}
 
 #endif /* UTILS_H */

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -1,0 +1,181 @@
+/********************************************************************************/
+/*										*/
+/*			       OpenSSL helper functions				*/
+/*			     Written by Stefan Berger				*/
+/*		       IBM Thomas J. Watson Research Center			*/
+/*										*/
+/*  Licenses and Notices							*/
+/*										*/
+/*  1. Copyright Licenses:							*/
+/*										*/
+/*  - Trusted Computing Group (TCG) grants to the user of the source code in	*/
+/*    this specification (the "Source Code") a worldwide, irrevocable, 		*/
+/*    nonexclusive, royalty free, copyright license to reproduce, create 	*/
+/*    derivative works, distribute, display and perform the Source Code and	*/
+/*    derivative works thereof, and to grant others the rights granted herein.	*/
+/*										*/
+/*  - The TCG grants to the user of the other parts of the specification 	*/
+/*    (other than the Source Code) the rights to reproduce, distribute, 	*/
+/*    display, and perform the specification solely for the purpose of 		*/
+/*    developing products based on such documents.				*/
+/*										*/
+/*  2. Source Code Distribution Conditions:					*/
+/*										*/
+/*  - Redistributions of Source Code must retain the above copyright licenses, 	*/
+/*    this list of conditions and the following disclaimers.			*/
+/*										*/
+/*  - Redistributions in binary form must reproduce the above copyright 	*/
+/*    licenses, this list of conditions	and the following disclaimers in the 	*/
+/*    documentation and/or other materials provided with the distribution.	*/
+/*										*/
+/*  3. Disclaimers:								*/
+/*										*/
+/*  - THE COPYRIGHT LICENSES SET FORTH ABOVE DO NOT REPRESENT ANY FORM OF	*/
+/*  LICENSE OR WAIVER, EXPRESS OR IMPLIED, BY ESTOPPEL OR OTHERWISE, WITH	*/
+/*  RESPECT TO PATENT RIGHTS HELD BY TCG MEMBERS (OR OTHER THIRD PARTIES)	*/
+/*  THAT MAY BE NECESSARY TO IMPLEMENT THIS SPECIFICATION OR OTHERWISE.		*/
+/*  Contact TCG Administration (admin@trustedcomputinggroup.org) for 		*/
+/*  information on specification licensing rights available through TCG 	*/
+/*  membership agreements.							*/
+/*										*/
+/*  - THIS SPECIFICATION IS PROVIDED "AS IS" WITH NO EXPRESS OR IMPLIED 	*/
+/*    WARRANTIES WHATSOEVER, INCLUDING ANY WARRANTY OF MERCHANTABILITY OR 	*/
+/*    FITNESS FOR A PARTICULAR PURPOSE, ACCURACY, COMPLETENESS, OR 		*/
+/*    NONINFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS, OR ANY WARRANTY 		*/
+/*    OTHERWISE ARISING OUT OF ANY PROPOSAL, SPECIFICATION OR SAMPLE.		*/
+/*										*/
+/*  - Without limitation, TCG and its members and licensors disclaim all 	*/
+/*    liability, including liability for infringement of any proprietary 	*/
+/*    rights, relating to use of information in this specification and to the	*/
+/*    implementation of this specification, and TCG disclaims all liability for	*/
+/*    cost of procurement of substitute goods or services, lost profits, loss 	*/
+/*    of use, loss of data or any incidental, consequential, direct, indirect, 	*/
+/*    or special damages, whether under contract, tort, warranty or otherwise, 	*/
+/*    arising in any way out of use or reliance upon this specification or any 	*/
+/*    information herein.							*/
+/*										*/
+/*  (c) Copyright IBM Corp. and others, 2019					*/
+/*										*/
+/********************************************************************************/
+
+#include "Tpm.h"
+#include "Helpers_fp.h"
+
+#include <openssl/evp.h>
+
+#if USE_OPENSSL_FUNCTIONS
+
+evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
+                     UINT16        keySizeInBits,   // IN
+                     TPM_ALG_ID    mode,            // IN
+                     const BYTE   *key,             // IN
+                     BYTE         *keyToUse,        // OUT same as key or stretched key
+                     UINT16       *keyToUseLen      // IN/OUT
+                    )
+{
+    int i;
+    UINT16 keySizeInBytes = keySizeInBits / 8;
+    evpfunc evpfn = NULL;
+
+    // key size to array index: 128 -> 0, 192 -> 1, 256 -> 2
+    i = (keySizeInBits >> 6) - 2;
+    if (i < 0 || i > 2)
+        return NULL;
+
+    pAssert(*keyToUseLen >= keySizeInBytes)
+    memcpy(keyToUse, key, keySizeInBytes);
+
+    switch (algorithm) {
+#if ALG_AES
+    case TPM_ALG_AES:
+        *keyToUseLen = keySizeInBytes;
+        switch (mode) {
+#if ALG_CTR
+        case ALG_CTR_VALUE:
+            evpfn = (evpfunc []){EVP_aes_128_ctr, EVP_aes_192_ctr,
+                                 EVP_aes_256_ctr}[i];
+            break;
+#endif
+#if ALG_OFB
+        case ALG_OFB_VALUE:
+            evpfn = (evpfunc[]){EVP_aes_128_ofb, EVP_aes_192_ofb,
+                                EVP_aes_256_ofb}[i];
+            break;
+#endif
+#if ALG_CBC
+        case ALG_CBC_VALUE:
+            evpfn = (evpfunc[]){EVP_aes_128_cbc, EVP_aes_192_cbc,
+                                EVP_aes_256_cbc}[i];
+            break;
+#endif
+#if ALG_CFB
+        case ALG_CFB_VALUE:
+            evpfn = (evpfunc[]){EVP_aes_128_cfb, EVP_aes_192_cfb,
+                                EVP_aes_256_cfb}[i];
+            break;
+#endif
+#if ALG_ECB
+        case ALG_ECB_VALUE:
+            evpfn = (evpfunc[]){EVP_aes_128_ecb, EVP_aes_192_ecb,
+                                EVP_aes_256_ecb}[i];
+            break;
+#endif
+        }
+        break;
+#endif
+#if ALG_TDES
+    case TPM_ALG_TDES:
+        if (keySizeInBits == 128) {
+            pAssert(*keyToUseLen >= BITS_TO_BYTES(192))
+            // stretch the key
+            memcpy(&keyToUse[16], &keyToUse[0], 8);
+            *keyToUseLen = BITS_TO_BYTES(192);
+        }
+
+        switch (mode) {
+#if ALG_CTR
+        case ALG_CTR_VALUE:
+            evpfn = (evpfunc[]){EVP_des_ede3, EVP_des_ede3, NULL}[i];
+            break;
+#endif
+#if ALG_OFB
+        case ALG_OFB_VALUE:
+            evpfn = (evpfunc[]){EVP_des_ede3_ofb, EVP_des_ede3_ofb, NULL}[i];
+            break;
+#endif
+#if ALG_CBC
+        case ALG_CBC_VALUE:
+            evpfn = (evpfunc[]){EVP_des_ede3_cbc, EVP_des_ede3_cbc, NULL}[i];
+            break;
+#endif
+#if ALG_CFB
+        case ALG_CFB_VALUE:
+            evpfn = (evpfunc[]){EVP_des_ede3_cfb64, EVP_des_ede3_cfb64, NULL}[i];
+            break;
+#endif
+#if ALG_ECB
+        case ALG_ECB_VALUE:
+            evpfn = (evpfunc[]){EVP_des_ede3_ecb, EVP_des_ede3_ecb, NULL}[i];
+            break;
+#endif
+	}
+#endif
+#if ALG_SM4
+#error Missing implementation of EVP for SM4
+    case TPM_ALG_SM4:
+        break;
+#endif
+#if ALG_CAMELLIA
+#error Missing implementation of EVP for Camellia
+    case TPM_ALG_CAMELLIA:
+        break;
+#endif
+    }
+
+    if (evpfn == NULL)
+        MemorySet(keyToUse, 0, *keyToUseLen);
+
+    return evpfn;
+}
+
+#endif // USE_OPENSSL_FUNCTIONS

--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -1,0 +1,74 @@
+/********************************************************************************/
+/*										*/
+/*			       OpenSSL helper functions				*/
+/*			     Written by Stefan Berger				*/
+/*		       IBM Thomas J. Watson Research Center			*/
+/*										*/
+/*  Licenses and Notices							*/
+/*										*/
+/*  1. Copyright Licenses:							*/
+/*										*/
+/*  - Trusted Computing Group (TCG) grants to the user of the source code in	*/
+/*    this specification (the "Source Code") a worldwide, irrevocable, 		*/
+/*    nonexclusive, royalty free, copyright license to reproduce, create 	*/
+/*    derivative works, distribute, display and perform the Source Code and	*/
+/*    derivative works thereof, and to grant others the rights granted herein.	*/
+/*										*/
+/*  - The TCG grants to the user of the other parts of the specification 	*/
+/*    (other than the Source Code) the rights to reproduce, distribute, 	*/
+/*    display, and perform the specification solely for the purpose of 		*/
+/*    developing products based on such documents.				*/
+/*										*/
+/*  2. Source Code Distribution Conditions:					*/
+/*										*/
+/*  - Redistributions of Source Code must retain the above copyright licenses, 	*/
+/*    this list of conditions and the following disclaimers.			*/
+/*										*/
+/*  - Redistributions in binary form must reproduce the above copyright 	*/
+/*    licenses, this list of conditions	and the following disclaimers in the 	*/
+/*    documentation and/or other materials provided with the distribution.	*/
+/*										*/
+/*  3. Disclaimers:								*/
+/*										*/
+/*  - THE COPYRIGHT LICENSES SET FORTH ABOVE DO NOT REPRESENT ANY FORM OF	*/
+/*  LICENSE OR WAIVER, EXPRESS OR IMPLIED, BY ESTOPPEL OR OTHERWISE, WITH	*/
+/*  RESPECT TO PATENT RIGHTS HELD BY TCG MEMBERS (OR OTHER THIRD PARTIES)	*/
+/*  THAT MAY BE NECESSARY TO IMPLEMENT THIS SPECIFICATION OR OTHERWISE.		*/
+/*  Contact TCG Administration (admin@trustedcomputinggroup.org) for 		*/
+/*  information on specification licensing rights available through TCG 	*/
+/*  membership agreements.							*/
+/*										*/
+/*  - THIS SPECIFICATION IS PROVIDED "AS IS" WITH NO EXPRESS OR IMPLIED 	*/
+/*    WARRANTIES WHATSOEVER, INCLUDING ANY WARRANTY OF MERCHANTABILITY OR 	*/
+/*    FITNESS FOR A PARTICULAR PURPOSE, ACCURACY, COMPLETENESS, OR 		*/
+/*    NONINFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS, OR ANY WARRANTY 		*/
+/*    OTHERWISE ARISING OUT OF ANY PROPOSAL, SPECIFICATION OR SAMPLE.		*/
+/*										*/
+/*  - Without limitation, TCG and its members and licensors disclaim all 	*/
+/*    liability, including liability for infringement of any proprietary 	*/
+/*    rights, relating to use of information in this specification and to the	*/
+/*    implementation of this specification, and TCG disclaims all liability for	*/
+/*    cost of procurement of substitute goods or services, lost profits, loss 	*/
+/*    of use, loss of data or any incidental, consequential, direct, indirect, 	*/
+/*    or special damages, whether under contract, tort, warranty or otherwise, 	*/
+/*    arising in any way out of use or reliance upon this specification or any 	*/
+/*    information herein.							*/
+/*										*/
+/*  (c) Copyright IBM Corp. and others, 2019					*/
+/*										*/
+/********************************************************************************/
+
+#ifndef HELPERS_H
+#define HELPERS_H
+
+typedef const EVP_CIPHER *(*evpfunc)(void);
+
+evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
+                     UINT16        keySizeInBits,   // IN
+                     TPM_ALG_ID    mode,            // IN
+                     const BYTE   *key,             // IN
+                     BYTE         *keyToUse,        // OUT same as key or stretched key
+                     UINT16       *keyToUseLen      // IN/OUT
+                     );
+
+#endif  /* HELPERS_H */

--- a/src/tpm2/crypto/openssl/TpmToOsslDesSupport.c
+++ b/src/tpm2/crypto/openssl/TpmToOsslDesSupport.c
@@ -101,6 +101,7 @@ void TDES_encrypt(
 		     &ks[0], &ks[1], &ks[2],
 		     DES_ENCRYPT);
 }
+#if !USE_OPENSSL_FUNCTIONS
 /* B.2.3.1.3.3. TDES_decrypt() */
 /* As with TDES_encypt() this function bridges between the TPM single schedule model and the
    OpenSSL() three schedule model. */
@@ -114,4 +115,5 @@ void TDES_decrypt(
 		     &ks[0], &ks[1], &ks[2],
 		     DES_DECRYPT);
 }
+#endif
 #endif // SYM_LIB == OSSL


### PR DESCRIPTION
This set of patches adds an implementation for using OpenSSL's symmetric cipher functions (EVP) for AES and TDES. We leave the original code around, which again can be activate by setting USE_OPENSSL_FUNCTIONS to 'NO'.