### PR TITLE
Switch ECDSA signature verification to OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,6 +147,7 @@ AC_ARG_WITH([tpm2],
 
 use_openssl_functions_for=""
 use_openssl_functions_symmetric=0
+use_openssl_functions_ecdsa=0
 AC_ARG_ENABLE(use-openssl-functions,
 	AS_HELP_STRING([--disable-use-openssl-functions],
 		       [Use TPM 2 crypot code rather than OpenSSL crypto functions]),
@@ -165,8 +166,19 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 		use_openssl_functions_symmetric=1
 		use_openssl_functions_for="symmetric (AES, TDES) "
 	fi
+	# Check for ECDSA crypto support
+	not_found=0
+	AC_CHECK_LIB([crypto], [ECDSA_SIG_new],, not_found=1)
+	AC_CHECK_LIB([crypto], [ECDSA_SIG_set0],, not_found=1)
+	AC_CHECK_LIB([crypto], [ECDSA_do_verify],, not_found=1)
+	AC_CHECK_LIB([crypto], [EC_KEY_set_group],, not_found=1)
+	if test "x$not_found" = "x0"; then
+		use_openssl_functions_ecdsa=1
+		use_openssl_functions_for="${use_openssl_functions_for}elliptic curve (ECDSA)"
+	fi
 ])
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=$use_openssl_functions_symmetric"
+CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_ECDSA=$use_openssl_functions_ecdsa"
 
 AC_ARG_ENABLE([sanitizers], AS_HELP_STRING([--enable-sanitizers], [Enable address sanitizing]),
     [SANITIZERS="-fsanitize=address,undefined"], [])

--- a/src/tpm2/crypto/openssl/TpmToOsslMath.c
+++ b/src/tpm2/crypto/openssl/TpmToOsslMath.c
@@ -446,7 +446,7 @@ PointFromOssl(
 }
 /* B.2.3.2.3.10. EcPointInitialized() */
 /* Allocate and initialize a point. */
-static EC_POINT *
+LIB_EXPORT EC_POINT *   // libtpms: exported function
 EcPointInitialized(
 		   pointConst          initializer,
 		   bigCurve            E

--- a/src/tpm2/crypto/openssl/TpmToOsslMath_fp.h
+++ b/src/tpm2/crypto/openssl/TpmToOsslMath_fp.h
@@ -71,6 +71,13 @@ BIGNUM *
 BigInitialized(
 	       bigConst            initializer
 	       );
+// libtpms added begin
+EC_POINT *
+EcPointInitialized(
+		   pointConst          initializer,
+		   bigCurve            E
+		   );
+// libtpms added end
 void
 MathLibraryCompatibilityCheck(
 			      void


### PR DESCRIPTION
Switch the ECDSA signature verification to OpenSSL. Do the signature
creation in the next step so we can verify the creation / verification
against the original TPM 2 code.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>