### PR TITLE
build-sys: Add support for --enable-use-openssl-functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,10 @@ matrix:
         uidgid="$(id -nu):$(id -ng)" &&
         sudo chown -R ${uidgid} ./ &&
         cpp-coveralls -b src -e tests -e swtpm --gcov-options '\-lp'
-    - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2 --enable-test-coverage"
+    - env: CONFIG="--with-openssl --prefix=/usr --with-tpm2 --enable-test-coverage --disable-use-openssl-functions"
            TARGET="install" NPROC="nproc"
       dist: xenial
       script:
-        sed -i 's/.* USE_OPENSSL_FUNCTIONS .*/#define USE_OPENSSL_FUNCTIONS NO/'
-            src/tpm2/Implementation.h &&
         ./autogen.sh ${CONFIG} &&
         sudo make -j$(nproc) ${TARGET} &&
         sudo make -j$(nproc) check &&

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,29 @@ AC_ARG_WITH([tpm2],
 	AM_CONDITIONAL(WITH_TPM2, false)
 )
 
+use_openssl_functions_for=""
+use_openssl_functions_symmetric=0
+AC_ARG_ENABLE(use-openssl-functions,
+	AS_HELP_STRING([--disable-use-openssl-functions],
+		       [Use TPM 2 crypot code rather than OpenSSL crypto functions]),
+)
+AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
+	if test "x$cryptolib" != "xopenssl"; then
+		AC_MSG_ERROR([OpenSSL crypto function usage requires openssl as crypto library])
+	fi
+	# Check for symmetric key crypto functions
+	not_found=0
+	AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_new],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_EncryptInit_ex],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_aes_128_cbc],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_des_ede3_cbc],, not_found=1)
+	if test "x$not_found" = "x0"; then
+		use_openssl_functions_symmetric=1
+		use_openssl_functions_for="symmetric (AES, TDES) "
+	fi
+])
+CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=$use_openssl_functions_symmetric"
+
 AC_ARG_ENABLE([sanitizers], AS_HELP_STRING([--enable-sanitizers], [Enable address sanitizing]),
     [SANITIZERS="-fsanitize=address,undefined"], [])
 AC_ARG_ENABLE([fuzzer], AS_HELP_STRING([--enable-fuzzer], [Enable fuzzer]),
@@ -236,10 +259,11 @@ echo "HARDENING_CFLAGS=$HARDENING_CFLAGS"
 echo "HARDENING_LDFLAGS=$HARDENING_LDFLAGS"
 echo "LDFLAGS=$LDFLAGS"
 echo
-echo "Version to build    : $PACKAGE_VERSION"
-echo "Crypto library      : $cryptolib"
-echo "Debug build         : $enable_debug"
-echo "With TPM2 support   : $with_tpm2"
-echo "HAVE_VERSION_SCRIPT : $have_version_script"
+echo "Version to build        : $PACKAGE_VERSION"
+echo "Crypto library          : $cryptolib"
+echo "Debug build             : $enable_debug"
+echo "With TPM2 support       : $with_tpm2"
+echo "HAVE_VERSION_SCRIPT     : $have_version_script"
+echo "Use openssl crypto for  : $use_openssl_functions_for"
 echo
 echo

--- a/src/tpm2/Implementation.h
+++ b/src/tpm2/Implementation.h
@@ -1219,7 +1219,4 @@ typedef TPM2B_MAX_HASH_BLOCK    TPM2B_HASH_BLOCK;
 #   error Bad size for MAX_SYM_KEY_BITS or MAX_SYM_BLOCK_SIZE
 #endif
 
-/* libtpms: Use OpenSSL's crypto functions where possible */
-#define USE_OPENSSL_FUNCTIONS   YES
-
 #endif  // _IMPLEMENTATION_H_

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -157,7 +157,7 @@ CryptGetSymmetricBlockSize(
     return 0;
 }
 
-#if !USE_OPENSSL_FUNCTIONS // libtpms added
+#if !USE_OPENSSL_FUNCTIONS_SYMMETRIC // libtpms added
 /* 10.2.20.5 Symmetric Encryption */
 /* This function performs symmetric encryption based on the mode. */
 /* Error Returns Meaning */

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -63,7 +63,7 @@
 
 #include <openssl/evp.h>
 
-#if USE_OPENSSL_FUNCTIONS
+#if USE_OPENSSL_FUNCTIONS_SYMMETRIC
 
 evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
                      UINT16        keySizeInBits,   // IN
@@ -178,4 +178,4 @@ evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
     return evpfn;
 }
 
-#endif // USE_OPENSSL_FUNCTIONS
+#endif // USE_OPENSSL_FUNCTIONS_SYMMETRIC

--- a/src/tpm2/crypto/openssl/TpmToOsslDesSupport.c
+++ b/src/tpm2/crypto/openssl/TpmToOsslDesSupport.c
@@ -101,7 +101,7 @@ void TDES_encrypt(
 		     &ks[0], &ks[1], &ks[2],
 		     DES_ENCRYPT);
 }
-#if !USE_OPENSSL_FUNCTIONS
+#if !USE_OPENSSL_FUNCTIONS_SYMMETRIC
 /* B.2.3.1.3.3. TDES_decrypt() */
 /* As with TDES_encypt() this function bridges between the TPM single schedule model and the
    OpenSSL() three schedule model. */


### PR DESCRIPTION
OpenSSL's crypto library does not support all crypto functionality
we need in all versions. Elliptic curve support via EVP seems to
have been added much later than for example symmetric crypot support.
So, we move the USE_OPENSSL_FUNCTIONS out of Implementation.h
into configure.ac and let the build system detect what functionality
is available in the crypto library. In this patch we now rename
USE_OPENSSL_FUNCTIONS to USE_OPENSSL_FUNCTIONS_SYMMETRIC to indicate
that we can use the symmetric crypto functions of the crypto lib.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>