### PR TITLE
Convert to OpenSSL RSA functions for encrypting and signing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 	AC_CHECK_LIB([crypto], [EC_KEY_set_group],, not_found=1)
 	if test "x$not_found" = "x0"; then
 		use_openssl_functions_ecdsa=1
-		use_openssl_functions_for="${use_openssl_functions_for}elliptic curve (ECDSA)"
+		use_openssl_functions_for="${use_openssl_functions_for}elliptic curve (ECDSA) "
 	fi
 ])
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=$use_openssl_functions_symmetric"

--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,7 @@ use_openssl_functions_for=""
 use_openssl_functions_symmetric=0
 use_openssl_functions_ec=0
 use_openssl_functions_ecdsa=0
+use_openssl_functions_rsa=0
 AC_ARG_ENABLE(use-openssl-functions,
 	AS_HELP_STRING([--disable-use-openssl-functions],
 		       [Use TPM 2 crypot code rather than OpenSSL crypto functions]),
@@ -188,10 +189,31 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 		use_openssl_functions_ecdsa=1
 		use_openssl_functions_for="${use_openssl_functions_for}elliptic curve (ECDSA) "
 	fi
+	# Check for RSA crypto functions
+	not_found=0
+	AC_CHECK_LIB([crypto], [RSA_set0_key],, not_found=1)
+	AC_CHECK_LIB([crypto], [RSA_set0_factors],, not_found=1)
+	AC_CHECK_LIB([crypto], [RSA_set0_crt_params],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_CTX_new],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_assign],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_encrypt_init],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_encrypt],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_decrypt_init],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_decrypt],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_sign_init],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_sign],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_verify_init],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_PKEY_verify],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_get_digestbyname],, not_found=1)
+	if test "x$not_found" = "x0"; then
+		use_openssl_functions_rsa=1
+		use_openssl_functions_for="${use_openssl_functions_for}RSA "
+	fi
 ])
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=$use_openssl_functions_symmetric"
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_EC=$use_openssl_functions_ec"
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_ECDSA=$use_openssl_functions_ecdsa"
+CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_RSA=$use_openssl_functions_rsa"
 
 AC_ARG_ENABLE([sanitizers], AS_HELP_STRING([--enable-sanitizers], [Enable address sanitizing]),
     [SANITIZERS="-fsanitize=address,undefined"], [])

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -62,6 +62,8 @@
 #include "Helpers_fp.h"
 #include "TpmToOsslMath_fp.h"
 
+#include "config.h"
+
 #include <openssl/evp.h>
 
 #if USE_OPENSSL_FUNCTIONS_SYMMETRIC
@@ -234,3 +236,51 @@ OpenSSLEccGetPrivate(
     return OK;
 }
 #endif // USE_OPENSSL_FUNCTIONS_EC
+
+#if USE_OPENSSL_FUNCTIONS_RSA
+
+static const struct hnames {
+    const char *name;
+    TPM_ALG_ID hashAlg;
+} hnames[HASH_COUNT + 1] = {
+    {
+#if ALG_SHA1
+        .name     = "sha1",
+        .hashAlg  = ALG_SHA1_VALUE,
+    }, {
+#endif
+#if ALG_SHA256
+        .name     = "sha256",
+        .hashAlg  = ALG_SHA256_VALUE,
+    }, {
+#endif
+#if ALG_SHA384
+        .name     = "sha384",
+        .hashAlg  = ALG_SHA384_VALUE,
+    }, {
+#endif
+#if ALG_SHA512
+        .name     = "sha512",
+        .hashAlg  = ALG_SHA512_VALUE,
+    }, {
+#endif
+        .name     = NULL,
+    }
+};
+#if HASH_COUNT != ALG_SHA1 + ALG_SHA256 + ALG_SHA384 + ALG_SHA512
+# error Missing entry in hnames array!
+#endif
+
+LIB_EXPORT const char *
+GetDigestNameByHashAlg(const TPM_ALG_ID hashAlg)
+{
+    unsigned i;
+
+    for (i = 0; i < HASH_COUNT; i++) {
+        if (hashAlg == hnames[i].hashAlg)
+            return hnames[i].name;
+    }
+    return NULL;
+}
+
+#endif // USE_OPENSSL_FUNCTIONS_RSA

--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -61,6 +61,8 @@
 #ifndef HELPERS_H
 #define HELPERS_H
 
+#include "TpmTypes.h"
+
 #if USE_OPENSSL_FUNCTIONS_SYMMETRIC
 TPM_RC
 OpenSSLCryptGenerateKeyDes(
@@ -84,5 +86,11 @@ BOOL OpenSSLEccGetPrivate(
                           const EC_GROUP    *G       // IN:  the EC_GROUP to use
                          );
 #endif
+
+#if USE_OPENSSL_FUNCTIONS_RSA
+
+const char *GetDigestNameByHashAlg(const TPM_ALG_ID hashAlg);
+
+#endif // USE_OPENSSL_FUNCTIONS_RSA
 
 #endif  /* HELPERS_H */

--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -63,6 +63,8 @@
 
 #include "TpmTypes.h"
 
+#include <openssl/evp.h>
+
 #if USE_OPENSSL_FUNCTIONS_SYMMETRIC
 TPM_RC
 OpenSSLCryptGenerateKeyDes(
@@ -90,6 +92,16 @@ BOOL OpenSSLEccGetPrivate(
 #if USE_OPENSSL_FUNCTIONS_RSA
 
 const char *GetDigestNameByHashAlg(const TPM_ALG_ID hashAlg);
+
+LIB_EXPORT TPM_RC
+InitOpenSSLRSAPublicKey(OBJECT    *key,   // IN
+                        EVP_PKEY **pkey   //OUT
+                       );
+
+LIB_EXPORT TPM_RC
+InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
+                         EVP_PKEY  **pkey      // OUT
+                        );
 
 #endif // USE_OPENSSL_FUNCTIONS_RSA
 


### PR DESCRIPTION
This series of patches converts existing RSA code for encryption and signing to use OpenSSL code for doing these operations.