### PR TITLE
Use OpenSSL function for ECDSA signature creation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,7 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 	AC_CHECK_LIB([crypto], [ECDSA_SIG_new],, not_found=1)
 	AC_CHECK_LIB([crypto], [ECDSA_SIG_set0],, not_found=1)
 	AC_CHECK_LIB([crypto], [ECDSA_do_verify],, not_found=1)
+	AC_CHECK_LIB([crypto], [ECDSA_do_sign],, not_found=1)
 	AC_CHECK_LIB([crypto], [EC_KEY_set_group],, not_found=1)
 	if test "x$not_found" = "x0"; then
 		use_openssl_functions_ecdsa=1

--- a/src/tpm2/crypto/openssl/TpmToOsslMath.c
+++ b/src/tpm2/crypto/openssl/TpmToOsslMath.c
@@ -81,7 +81,7 @@
 void
 OsslToTpmBn(
 	    bigNum          bn,
-	    BIGNUM          *osslBn
+	    const BIGNUM   *osslBn   // libtpms: added 'const'
 	    )
 {
     unsigned char buffer[LARGEST_NUMBER + 1];

--- a/src/tpm2/crypto/openssl/TpmToOsslMath.h
+++ b/src/tpm2/crypto/openssl/TpmToOsslMath.h
@@ -71,6 +71,9 @@
 #include <openssl/evp.h>
 #include <openssl/ec.h>
 #include <openssl/bn.h>
+#if USE_OPENSSL_FUNCTIONS_ECDSA        // libtpms added begin
+#include <openssl/ecdsa.h>
+#endif                                 // libtpms added end
 /* B.2.2.2.2. Macros and Defines */
 /* Make sure that the library is using the correct size for a crypt word */
 #if !(defined THIRTY_TWO_BIT || defined SIXTY_FOUR_BIT || defined SIXTY_FOUR_BIT_LONG)

--- a/src/tpm2/crypto/openssl/TpmToOsslMath_fp.h
+++ b/src/tpm2/crypto/openssl/TpmToOsslMath_fp.h
@@ -65,7 +65,7 @@
 void
 OsslToTpmBn(
 	    bigNum          bn,
-	    BIGNUM          *osslBn
+	    const BIGNUM   *osslBn   // libtpms added 'const'
 	    );
 BIGNUM *
 BigInitialized(


### PR DESCRIPTION
This series of patches converts the ECDSA signing code to use OpenSSL crypto library functions.