### PR TITLE
tpm2: Use OpenSSL to create TDES keys if rand == NULL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,7 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 	AC_CHECK_LIB([crypto], [EVP_EncryptInit_ex],, not_found=1)
 	AC_CHECK_LIB([crypto], [EVP_aes_128_cbc],, not_found=1)
 	AC_CHECK_LIB([crypto], [EVP_des_ede3_cbc],, not_found=1)
+	AC_CHECK_LIB([crypto], [DES_random_key],, not_found=1)
 	if test "x$not_found" = "x0"; then
 		use_openssl_functions_symmetric=1
 		use_openssl_functions_for="symmetric (AES, TDES) "

--- a/src/tpm2/crypto/openssl/CryptDes.c
+++ b/src/tpm2/crypto/openssl/CryptDes.c
@@ -64,6 +64,7 @@
 /* This file contains the extra functions required for TDES. */
 /* 10.2.9.2 Includes, Defines, and Typedefs */
 #include "Tpm.h"
+#include "Helpers_fp.h"                // libtpms added
 #if ALG_TDES
 #define DES_NUM_WEAK 64
 const UINT64 DesWeakKeys[DES_NUM_WEAK] = {
@@ -165,6 +166,10 @@ CryptGenerateKeyDes(
     // number of bits.
     sensitive->sensitive.sym.t.size =
 	BITS_TO_BYTES(publicArea->parameters.symDetail.sym.keyBits.sym);
+#if USE_OPENSSL_FUNCTIONS_SYMMETRIC    // libtpms added begin
+    if (rand == NULL)
+        return OpenSSLCryptGenerateKeyDes(sensitive);
+#endif                                 // libtpms added end
     do
 	{
 	    BYTE                    *pK = sensitive->sensitive.sym.t.buffer;

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -66,6 +66,28 @@
 
 #if USE_OPENSSL_FUNCTIONS_SYMMETRIC
 
+TPM_RC
+OpenSSLCryptGenerateKeyDes(
+                           TPMT_SENSITIVE *sensitive    // OUT: sensitive area
+                          )
+{
+    DES_cblock *key;
+    size_t      offset;
+    size_t      limit;
+
+    limit = MIN(sizeof(sensitive->sensitive.sym.t.buffer),
+                sensitive->sensitive.sym.t.size);
+    limit = TPM2_ROUNDUP(limit, sizeof(*key));
+    pAssert(limit < sizeof(sensitive->sensitive.sym.t.buffer));
+
+    for (offset = 0; offset < limit; offset += sizeof(*key)) {
+        key = (DES_cblock *)&sensitive->sensitive.sym.t.buffer[offset];
+        if (DES_random_key(key) != 1)
+            return TPM_RC_NO_RESULT;
+    }
+    return TPM_RC_SUCCESS;
+}
+
 evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
                      UINT16        keySizeInBits,   // IN
                      TPM_ALG_ID    mode,            // IN

--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -61,6 +61,12 @@
 #ifndef HELPERS_H
 #define HELPERS_H
 
+#if USE_OPENSSL_FUNCTIONS_SYMMETRIC
+TPM_RC
+OpenSSLCryptGenerateKeyDes(
+                           TPMT_SENSITIVE *sensitive    // OUT: sensitive area
+                          );
+
 typedef const EVP_CIPHER *(*evpfunc)(void);
 
 evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
@@ -70,6 +76,7 @@ evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
                      BYTE         *keyToUse,        // OUT same as key or stretched key
                      UINT16       *keyToUseLen      // IN/OUT
                      );
+#endif
 
 #if USE_OPENSSL_FUNCTIONS_EC
 BOOL OpenSSLEccGetPrivate(


### PR DESCRIPTION
Use OpenSSL function to create TDES keys if rand == NULL,
which indicates that a truely random key needs to be generated
rather than one derived from a KDF.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>