### PR TITLE
build-sys: Require only autoconf 2.63 for older systems

### DIFF
--- a/m4/ax_check_define.m4
+++ b/m4/ax_check_define.m4
@@ -11,7 +11,7 @@
 #    See the root directory of the libtpms project for the LICENSE
 #
 AC_DEFUN([AX_CHECK_DEFINE],
- [AC_PREREQ(2.64)
+ [AC_PREREQ(2.63)
   AC_MSG_CHECKING(whether $2 is defined in $1)
   AC_COMPILE_IFELSE(
    [AC_LANG_PROGRAM([[#include $1]],


### PR DESCRIPTION
autoconf 2.63 is sufficient as a dependency for AX_CHECK_DEFINE

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>