### PR TITLE
tpm2: Fix Coverity complaint by using iv.t.buffer

### DIFF
--- a/src/tpm2/CryptUtil.c
+++ b/src/tpm2/CryptUtil.c
@@ -724,7 +724,7 @@ CryptSecretDecrypt(
 			      {
 				  if(nonceCaller->t.size > sizeof(iv.t.buffer))
 				      return TPM_RC_FAILURE;
-				  MemoryCopy(iv.b.buffer, nonceCaller->t.buffer,
+				  MemoryCopy(iv.t.buffer, nonceCaller->t.buffer,  // libtpms changed: use iv.t.buffer
 					     nonceCaller->t.size);
 			      }
 			  // make sure secret will fit


### PR DESCRIPTION
Fix a Coverity complaint by using iv.t.buffer rather than the
1-byte synonym (due to union) iv.b.buffer.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>