### PR TITLE
Add missing packages to spec files for RPM and Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Section: libs
 Priority: optional
 Build-Depends: automake, autoconf, libtool, libssl-dev,
- gawk, dh-exec, debhelper
+ gawk, dh-exec, debhelper, g++
 
 Package: libtpms0
 Architecture: any

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -33,7 +33,7 @@ BuildRequires:  nss-softokn-freebl-static >= 3.12.9-2
 BuildRequires:  nss-softokn-devel >= 3.12.9-2, gmp-devel
 %endif
 BuildRequires:  pkgconfig gawk sed
-BuildRequires:  automake autoconf libtool bash coreutils
+BuildRequires:  automake autoconf libtool bash coreutils gcc-c++
 
 %if "%{crypto_subsystem}" == "openssl"
 Requires:       openssl

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -33,7 +33,7 @@ BuildRequires:  nss-softokn-freebl-static >= 3.12.9-2
 BuildRequires:  nss-softokn-devel >= 3.12.9-2, gmp-devel
 %endif
 BuildRequires:  pkgconfig gawk sed
-BuildRequires:  automake autoconf libtool bash coreutils
+BuildRequires:  automake autoconf libtool bash coreutils gcc-c++
 
 %if "%{crypto_subsystem}" == "openssl"
 Requires:       openssl


### PR DESCRIPTION
Build now requires g++ compiler for fuzz tests. Add it to the build dependencies.