### PR TITLE
tpm2: Check data size to be at least size of hash

### DIFF
--- a/src/tpm2/Volatile.c
+++ b/src/tpm2/Volatile.c
@@ -62,6 +62,9 @@ VolatileState_Load(BYTE **buffer, INT32 *size)
     UINT16 hashAlg = TPM_ALG_SHA1;
 
     if (rc == TPM_RC_SUCCESS) {
+        if ((UINT32)*size < sizeof(hash))
+            return TPM_RC_INSUFFICIENT;
+
         CryptHashBlock(hashAlg, *size - sizeof(hash), *buffer,
                        sizeof(acthash), acthash);
         rc = VolatileState_Unmarshal(buffer, size);


### PR DESCRIPTION
Check the size of the available data before hashing them. A minimum
of 20 bytes needs to be passed into the function so that we can hash
the data 'before' it.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
Reported-by: Yi Ren <yunye.ry@alibaba-inc.com>