### PR TITLE
docs: Update READLE to include CXX=clang++ for fuzzer build

### DIFF
--- a/README
+++ b/README
@@ -86,7 +86,8 @@ Fuzz testing is known to work with Fedora 28 or later. It requires that the
 'clang' package is installed.
 
 Ex:
-$ ./configure --with-openssl --with-tpm2 --enable-sanitizers --enable-fuzzer CC=clang
+$ ./configure --with-openssl --with-tpm2 --enable-sanitizers --enable-fuzzer \
+    CC=clang CXX=clang++
 $ make && make -C tests fuzz
 $ tests/run-fuzzer.sh
 


### PR DESCRIPTION
We were missing CXX=clang++ in the docs for the fuzzer build. Add it.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>