### PR TITLE
tpm12: Fix some possible out of bounds data accesses when printing

### DIFF
--- a/src/tpm12/tpm_crypto.c
+++ b/src/tpm12/tpm_crypto.c
@@ -649,7 +649,7 @@ TPM_RESULT TPM_RSAPrivateDecrypt(unsigned char *decrypt_data,   /* decrypted dat
     if (rc == 0) {
         *decrypt_data_length = irc;
         printf("  TPM_RSAPrivateDecrypt: RSA_padding_check_PKCS1_OAEP() recovered %d bytes\n", irc);
-        TPM_PrintFour("  TPM_RSAPrivateDecrypt: Decrypt data", decrypt_data);
+        TPM_PrintFourLimit("  TPM_RSAPrivateDecrypt: Decrypt data", decrypt_data, *decrypt_data_length);
     }
     if (rsa_pri_key != NULL) {
         RSA_free(rsa_pri_key);          /* @1 */
@@ -798,7 +798,7 @@ TPM_RESULT TPM_RSAPublicEncryptRaw(unsigned char *encrypt_data,	/* output */
     if (rc == 0) {
         TPM_PrintFour("  TPM_RSAPublicEncryptRaw: Public modulus", narr);
         TPM_PrintAll("  TPM_RSAPublicEncryptRaw: Public exponent", earr, ebytes);
-        TPM_PrintFour("  TPM_RSAPublicEncryptRaw: Decrypt data", decrypt_data);
+        TPM_PrintFourLimit("  TPM_RSAPublicEncryptRaw: Decrypt data", decrypt_data, decrypt_data_size);
         /* encrypt the decrypt_data */
         irc = RSA_public_encrypt(decrypt_data_size,      	/* from length */
                                  decrypt_data,     	/* from - the clear text data */
@@ -981,7 +981,7 @@ static TPM_RESULT TPM_RSASignDER(unsigned char *signature,              /* outpu
     if (rc == 0) {
         printf("  TPM_RSASignDER: Applying PKCS1 type 1 padding, size from %lu to %u\n",
                (unsigned long)message_size, key_size);
-        TPM_PrintFour("  TPM_RSASignDER: Input message", message);
+        TPM_PrintFourLimit("  TPM_RSASignDER: Input message", message, message_size);
         /* This call checks that the message will fit with the padding */
         irc = RSA_padding_add_PKCS1_type_1(message_pad,         /* to */
                                            key_size,
@@ -2319,7 +2319,7 @@ static TPM_RESULT TPM_SymmetricKeyData_Crypt(unsigned char *data_out,           
     }
     /* initialize initial chaining vector */
     if (rc == 0) {
-        TPM_PrintFour("  TPM_SymmetricKeyData_Crypt: Input", data_in);
+        TPM_PrintFourLimit("  TPM_SymmetricKeyData_Crypt: Input", data_in, length);
         /* encrypt operation */
         memset(&ivec, 0, sizeof(DES_cblock));
         DES_ede3_cbc_encrypt(data_in,

--- a/src/tpm12/tpm_crypto_freebl.c
+++ b/src/tpm12/tpm_crypto_freebl.c
@@ -654,7 +654,7 @@ TPM_RESULT TPM_RSAPrivateDecrypt(unsigned char *decrypt_data,   /* decrypted dat
     if (rc == 0) {
         printf("  TPM_RSAPrivateDecrypt: RSA_padding_check_PKCS1 recovered %d bytes\n",
 	       *decrypt_data_length);
-        TPM_PrintFour("  TPM_RSAPrivateDecrypt: Decrypt data", decrypt_data);
+        TPM_PrintFourLimit("  TPM_RSAPrivateDecrypt: Decrypt data", decrypt_data, decrypt_data_size);
     }
     PORT_FreeArena(rsa_pri_key.arena, PR_TRUE);	/* @1 */
     free(padded_data);                  	/* @2 */
@@ -772,7 +772,7 @@ TPM_RESULT TPM_RSAPublicEncryptRaw(unsigned char *encrypt_data,	/* output */
     if (rc == 0) {
         TPM_PrintFour("  TPM_RSAPublicEncryptRaw: Public modulus", narr);
         TPM_PrintAll("  TPM_RSAPublicEncryptRaw: Public exponent", earr, ebytes);
-        TPM_PrintFour("  TPM_RSAPublicEncryptRaw: Decrypt data", decrypt_data);
+        TPM_PrintFourLimit("  TPM_RSAPublicEncryptRaw: Decrypt data", decrypt_data, decrypt_data_size);
         /* raw public key operation, encrypt the decrypt_data */
 	rv = RSA_PublicKeyOp(&rsa_pub_key,	/* freebl public key token */
 			     encrypt_data,      /* output - the encrypted data */
@@ -941,7 +941,7 @@ static TPM_RESULT TPM_RSASignDER(unsigned char *signature,              /* outpu
     if (rc == 0) {
         printf("  TPM_RSASignDER: Applying PKCS1 type 1 padding, size from %lu to %u\n",
                (unsigned long)message_size, rsa_pri_key->modulus.len);
-        TPM_PrintFour("  TPM_RSASignDER: Input message", message);
+        TPM_PrintFourLimit("  TPM_RSASignDER: Input message", message, message_size);
         /* This call checks that the message will fit with the padding */
 	rc = TPM_PKCS1_PaddingType1Add(message_pad,         		/* to */
 				       rsa_pri_key->modulus.len,	/* to length */
@@ -1028,8 +1028,8 @@ TPM_RESULT TPM_RSAVerifySHA1(unsigned char *signature,          /* input */
 	irc = memcmp(message, padded_data + padLength, message_size);
 	if (irc != 0) {
 	    printf("TPM_RSAVerifySHA1: Error, message mismatch\n");
-	    TPM_PrintFour(" TPM_RSAVerifySHA1: message", message);
-	    TPM_PrintFour(" TPM_RSAVerifySHA1: message from signature", padded_data + padLength);
+	    TPM_PrintFourLimit(" TPM_RSAVerifySHA1: message", message, message_size);
+	    TPM_PrintFourLimit(" TPM_RSAVerifySHA1: message from signature", padded_data + padLength, message_size);
 	    rc = TPM_BAD_SIGNATURE;
 	}
     }

--- a/src/tpm12/tpm_cryptoh.c
+++ b/src/tpm12/tpm_cryptoh.c
@@ -1597,7 +1597,7 @@ TPM_RESULT TPM_RSAPrivateDecryptH(unsigned char *decrypt_data,	/* decrypted data
     uint32_t		dbytes;
 
     printf(" TPM_RSAPrivateDecryptH: Data size %u bytes\n", encrypt_data_size);
-    TPM_PrintFour("  TPM_RSAPrivateDecryptH: Encrypt data", encrypt_data);
+    TPM_PrintFourLimit("  TPM_RSAPrivateDecryptH: Encrypt data", encrypt_data, encrypt_data_size);
     if (rc == 0) {
 	if (tpm_key == NULL) {
 	    printf("TPM_RSAPrivateDecryptH: Error, NULL key\n");
@@ -1646,7 +1646,7 @@ TPM_RESULT TPM_RSAPrivateDecryptH(unsigned char *decrypt_data,	/* decrypted data
 				   dbytes);
     }
     if (rc == 0) {
-	TPM_PrintFour(" TPM_RSAPrivateDecryptH: Decrypt data", decrypt_data);
+	TPM_PrintFourLimit(" TPM_RSAPrivateDecryptH: Decrypt data", decrypt_data, *decrypt_data_length);
     }
     return rc;
 }
@@ -1779,7 +1779,7 @@ TPM_RESULT TPM_RSAPublicEncrypt_Common(TPM_SIZED_BUFFER *enc_data,
     unsigned char	*encrypt_data = NULL;
     
     printf(" TPM_RSAPublicEncrypt_Common: Data size %lu bytes\n", (unsigned long)decrypt_data_size);
-    TPM_PrintFour(" TPM_RSAPublicEncrypt_Common: Decrypt data", decrypt_data);
+    TPM_PrintFourLimit(" TPM_RSAPublicEncrypt_Common: Decrypt data", decrypt_data, decrypt_data_size);
     /* check the key size vs the data size */
     if (rc == 0) {
 	if (decrypt_data_size > nbytes) {
@@ -1901,7 +1901,7 @@ TPM_RESULT TPM_RSASignH(unsigned char *signature,		/* output */
     uint32_t		dbytes;
     
     printf(" TPM_RSASignH: Message size %lu bytes\n", (unsigned long)message_size);
-    TPM_PrintFour("  TPM_RSASignH: Message", message);
+    TPM_PrintFourLimit("  TPM_RSASignH: Message", message, message_size);
     /* extract the public key from TPM_KEY */
     if (rc == 0) {
 	rc = TPM_Key_GetPublicKey(&nbytes, &narr, tpm_key);
@@ -2070,7 +2070,7 @@ TPM_RESULT TPM_RSA_padding_add_PKCS1_OAEP(unsigned char *em, uint32_t emLen,
     unsigned char *maskedSeed;
 
     printf(" TPM_RSA_padding_add_PKCS1_OAEP: fLen %d emLen %d\n", fLen, emLen);
-    TPM_PrintFour("  TPM_RSA_padding_add_PKCS1_OAEP: from", from);
+    TPM_PrintFourLimit("  TPM_RSA_padding_add_PKCS1_OAEP: from", from, fLen);
     TPM_PrintFour("  TPM_RSA_padding_add_PKCS1_OAEP: pHash", pHash);
     TPM_PrintFour("  TPM_RSA_padding_add_PKCS1_OAEP: seed", seed);
     
@@ -2140,7 +2140,7 @@ TPM_RESULT TPM_RSA_padding_add_PKCS1_OAEP(unsigned char *em, uint32_t emLen,
 	/* NOTE Created directly in em */
 	
 	/* 12. Output EM. */
-	TPM_PrintFour("  TPM_RSA_padding_add_PKCS1_OAEP: em", em);
+	TPM_PrintFourLimit("  TPM_RSA_padding_add_PKCS1_OAEP: em", em, emLen);
     }
     free(dbMask);		/* @1 */
     return rc;
@@ -2184,7 +2184,7 @@ TPM_RESULT TPM_RSA_padding_check_PKCS1_OAEP(unsigned char *to, uint32_t *tLen, u
     size_t		i;
 
     printf(" TPM_RSA_padding_check_PKCS1_OAEP: emLen %d tSize %d\n", emLen, tSize);
-    TPM_PrintFour("  TPM_RSA_padding_check_PKCS1_OAEP: em", em);
+    TPM_PrintFourLimit("  TPM_RSA_padding_check_PKCS1_OAEP: em", em, emLen);
 
     dbMask = NULL;			/* freed @1 */
     
@@ -2264,7 +2264,7 @@ TPM_RESULT TPM_RSA_padding_check_PKCS1_OAEP(unsigned char *to, uint32_t *tLen, u
     if (rc == 0) {
 	memcpy(to, db + i, *tLen);
 	printf("  TPM_RSA_padding_check_PKCS1_OAEP: tLen %d \n", *tLen);
-	TPM_PrintFour("  TPM_RSA_padding_check_PKCS1_OAEP: to", to);
+	TPM_PrintFourLimit("  TPM_RSA_padding_check_PKCS1_OAEP: to", to, *tLen);
 	TPM_PrintFour("  TPM_RSA_padding_check_PKCS1_OAEP: pHash", pHash);
 	TPM_PrintFour("  TPM_RSA_padding_check_PKCS1_OAEP: seed", seed);
     }

--- a/src/tpm12/tpm_debug.c
+++ b/src/tpm12/tpm_debug.c
@@ -57,22 +57,52 @@ int tpm_swallow_printf_args(const char *format, ...)
 
 #else
 
-/* TPM_PrintFour() prints a prefix plus 4 bytes of a buffer */
-
-void TPM_PrintFour(const char *string, const unsigned char* buff)
+void TPM_PrintFourLimit(const char *string,
+                        const unsigned char *buff, size_t buflen)
 {
     if (buff != NULL) {
-        TPMLIB_LogPrintf("%s %02x %02x %02x %02x\n",
-               string,
-               buff[0],
-               buff[1],
-               buff[2],
-               buff[3]);
+        switch (buflen) {
+        case 0:
+            TPMLIB_LogPrintf("%s (no data)\n", string);
+            break;
+        case 1:
+            TPMLIB_LogPrintf("%s %02x\n",
+                   string,
+                   buff[0]);
+            break;
+        case 2:
+            TPMLIB_LogPrintf("%s %02x %02x\n",
+                   string,
+                   buff[0],
+                   buff[1]);
+            break;
+        case 3:
+            TPMLIB_LogPrintf("%s %02x %02x %02x\n",
+                   string,
+                   buff[0],
+                   buff[1],
+                   buff[2]);
+            break;
+        default:
+            TPMLIB_LogPrintf("%s %02x %02x %02x %02x\n",
+                   string,
+                   buff[0],
+                   buff[1],
+                   buff[2],
+                   buff[3]);
+        }
     }
     else {
         TPMLIB_LogPrintf("%s null\n", string);
     }
     return;
+}
+
+/* TPM_PrintFour() prints a prefix plus 4 bytes of a buffer */
+
+void TPM_PrintFour(const char *string, const unsigned char* buff)
+{
+    TPM_PrintFourLimit(string, buff, 4);
 }
 
 #endif

--- a/src/tpm12/tpm_debug.h
+++ b/src/tpm12/tpm_debug.h
@@ -46,6 +46,8 @@
 /* prototypes */
 
 void TPM_PrintFour(const char *string, const unsigned char* buff);
+void TPM_PrintFourLimit(const char *string,
+                        const unsigned char* buff, size_t bufflen);
 void TPM_PrintAll(const char *string, const unsigned char* buff, uint32_t length);
 
 #if 0

--- a/src/tpm12/tpm_key.c
+++ b/src/tpm12/tpm_key.c
@@ -2455,8 +2455,9 @@ TPM_RESULT TPM_StoreAsymkey_LoadO1(TPM_STORE_ASYMKEY	*tpm_store_asymkey,	/* outp
 	rc = TPM_MigrateAsymkey_Load(&tpm_migrate_asymkey, &stream, &stream_size);
 	printf("  TPM_StoreAsymkey_LoadO1: partPrivKey length %u\n",
 	       tpm_migrate_asymkey.partPrivKey.size);
-	TPM_PrintFour("  TPM_StoreAsymkey_LoadO1: partPrivKey -",
-		      tpm_migrate_asymkey.partPrivKey.buffer);
+	TPM_PrintFourLimit("  TPM_StoreAsymkey_LoadO1: partPrivKey -",
+		      tpm_migrate_asymkey.partPrivKey.buffer,
+		      tpm_migrate_asymkey.partPrivKey.size);
     }
     /* create k1k2 by combining seed (k1) and TPM_MIGRATE_ASYMKEY.partPrivKey (k2) field */
     if (rc == 0) {
@@ -2475,7 +2476,7 @@ TPM_RESULT TPM_StoreAsymkey_LoadO1(TPM_STORE_ASYMKEY	*tpm_store_asymkey,	/* outp
 	TPM_Digest_Copy(tpm_store_asymkey->pubDataDigest, tpm_migrate_asymkey.pubDataDigest);
 	TPM_Sbuffer_Get(&k1k2_sbuffer, &k1k2_buffer, &k1k2_length);
 	printf("  TPM_StoreAsymkey_LoadO1: k1k2 length %u\n", k1k2_length);
-	TPM_PrintFour("  TPM_StoreAsymkey_LoadO1: k1k2", k1k2_buffer);
+	TPM_PrintFourLimit("  TPM_StoreAsymkey_LoadO1: k1k2", k1k2_buffer, k1k2_length);
 	rc = TPM_SizedBuffer_Load(&(tpm_store_asymkey->privKey.p_key),
 				  (unsigned char **)&k1k2_buffer, &k1k2_length);
     }

--- a/src/tpm12/tpm_migration.c
+++ b/src/tpm12/tpm_migration.c
@@ -844,9 +844,9 @@ TPM_RESULT TPM_CreateBlobCommon(TPM_SIZED_BUFFER *outData,	/* The modified, encr
     }
     /* e. Create x1 by XOR of o1 with r1 */
     if (rc == 0) {
-	TPM_PrintFour("TPM_CreateBlobCommon: r1 -", r1);
+	TPM_PrintFourLimit("TPM_CreateBlobCommon: r1 -", r1, o1_size);
 	TPM_XOR(x1, o1, r1, o1_size);
-	TPM_PrintFour("TPM_CreateBlobCommon: x1 -", x1);
+	TPM_PrintFourLimit("TPM_CreateBlobCommon: x1 -", x1, o1_size);
 	/* f. Copy r1 into the output field "random".*/
 	rc = TPM_SizedBuffer_Set(random, o1_size, r1);
     }
@@ -1513,7 +1513,7 @@ TPM_RESULT TPM_Process_ConvertMigrationBlob(tpm_state_t *tpm_state,
     /* 3. Create d1 by decrypting the inData area using the key in parentHandle */
     if (returnCode == TPM_SUCCESS) {
 	printf("TPM_Process_ConvertMigrationBlob: Decrypting inData\n");
-	TPM_PrintFour("TPM_Process_ConvertMigrationBlob: inData", inData.buffer);
+	TPM_PrintFourLimit("TPM_Process_ConvertMigrationBlob: inData", inData.buffer, inData.size);
 	returnCode = TPM_RSAPrivateDecryptMalloc(&d1Decrypt,		/* decrypted data */
 						 &d1DecryptLength,	/* actual size of d1 data */
 						 inData.buffer,		/* encrypted data */
@@ -1535,7 +1535,7 @@ TPM_RESULT TPM_Process_ConvertMigrationBlob(tpm_state_t *tpm_state,
     }
     if (returnCode == TPM_SUCCESS) {
 	printf("TPM_Process_ConvertMigrationBlob: d1 length %u\n", d1DecryptLength);
-	TPM_PrintFour("TPM_Process_ConvertMigrationBlob: d1 -", d1Decrypt);
+	TPM_PrintFourLimit("TPM_Process_ConvertMigrationBlob: d1 -", d1Decrypt, d1DecryptLength);
 	/* 4. Create o1 by XOR d1 and random parameter */
 	TPM_XOR(o1Oaep, d1Decrypt, random.buffer, d1DecryptLength);
 	/* 5. Create m1 a TPM_MIGRATE_ASYMKEY structure, seed and pHash by OAEP decoding o1 */

--- a/src/tpm12/tpm_nvram.c
+++ b/src/tpm12/tpm_nvram.c
@@ -1537,8 +1537,8 @@ TPM_RESULT TPM_Process_NVReadValue(tpm_state_t *tpm_state,
 	    }
 	    /* c. Set data to area pointed to by offset */
 	    if ((returnCode == TPM_SUCCESS) && !isGPIO) {
-		TPM_PrintFour("TPM_Process_NVReadValue: read data",
-			      d1NvdataSensitive->data + offset);
+		TPM_PrintFourLimit("TPM_Process_NVReadValue: read data",
+			      d1NvdataSensitive->data + offset, dataSize);
 		returnCode = TPM_SizedBuffer_Set(&data,
 						 dataSize, d1NvdataSensitive->data + offset);
 	    }
@@ -1861,8 +1861,8 @@ TPM_RESULT TPM_Process_NVReadValueAuth(tpm_state_t *tpm_state,
 	    }
 	    /* c. Set data to area pointed to by offset */
 	    if ((returnCode == TPM_SUCCESS) && !isGPIO) {
-		TPM_PrintFour("TPM_Process_NVReadValueAuth: read data",
-			      d1NvdataSensitive->data + offset);
+		TPM_PrintFourLimit("TPM_Process_NVReadValueAuth: read data",
+			      d1NvdataSensitive->data + offset, dataSize);
 		returnCode = TPM_SizedBuffer_Set(&data, dataSize, d1NvdataSensitive->data + offset);
 	    }
 	    /* GPIO */
@@ -2078,7 +2078,7 @@ TPM_RESULT TPM_Process_NVWriteValue(tpm_state_t *tpm_state,
     if (returnCode == TPM_SUCCESS) {
 	printf("TPM_Process_NVWriteValue: index %08x offset %u dataSize %u\n",
 	       nvIndex, offset, data.size);
-	TPM_PrintFour("TPM_Process_NVWriteValue: data", data.buffer);
+	TPM_PrintFourLimit("TPM_Process_NVWriteValue: data", data.buffer, data.size);
 	/* 1. If TPM_PERMANENT_FLAGS -> nvLocked is FALSE then all authorization checks except for
 	   the max NV writes are ignored */
 	/* a. Ignored checks include physical presence, owner authorization, TPM_NV_PER_OWNERWRITE,
@@ -2569,7 +2569,7 @@ TPM_RESULT TPM_Process_NVWriteValueAuth(tpm_state_t *tpm_state,
     if (returnCode == TPM_SUCCESS) {
 	printf("TPM_Process_NVWriteValueAuth: index %08x offset %u dataSize %u\n",
 	       nvIndex, offset, data.size);
-	TPM_PrintFour("TPM_Process_NVWriteValueAuth: data", data.buffer);
+	TPM_PrintFourLimit("TPM_Process_NVWriteValueAuth: data", data.buffer, data.size);
 	printf("TPM_Process_NVWriteValueAuth: Loading data from NVRAM\n");
 	returnCode = TPM_NVIndexEntries_GetEntry(&d1NvdataSensitive,
 						 &(tpm_state->tpm_nv_index_entries),

--- a/src/tpm12/tpm_storage.c
+++ b/src/tpm12/tpm_storage.c
@@ -650,7 +650,7 @@ static TPM_RESULT TPM_SealCryptCommon(BYTE **o1,	/* freed by caller */
 	rc = TPM_Malloc(o1, inData->size);	/* freed by caller */
     }
     if (rc == TPM_SUCCESS) {
-	TPM_PrintFour("  TPM_SealCryptCommon: input data", inData->buffer);
+	TPM_PrintFourLimit("  TPM_SealCryptCommon: input data", inData->buffer, inData->size);
     }
     switch (adipEncScheme) {
       case TPM_ET_XOR:
@@ -1227,7 +1227,7 @@ TPM_RESULT TPM_Process_Sealx(tpm_state_t *tpm_state,
     }	
     if (returnCode == TPM_SUCCESS) {
 	printf("TPM_Process_Sealx: Sealing %u bytes\n", inData.size);
-	TPM_PrintFour("TPM_Process_Sealx: Sealing data", inData.buffer);
+	TPM_PrintFourLimit("TPM_Process_Sealx: Sealing data", inData.buffer, inData.size);
     }	
     /* save the ending point of inParam's for authorization and auditing */
     inParamEnd = command;


### PR DESCRIPTION
This series of patches fixes some possible out of bounds data accesses when printing up to 4 bytes of debugging data.