### PR TITLE
Add a missing break statement and always test symmetric modes

### DIFF
--- a/src/tpm2/AlgorithmTests.c
+++ b/src/tpm2/AlgorithmTests.c
@@ -310,7 +310,7 @@ TestSymmetric(
 				mode <= TPM_SYM_MODE_LAST;
 				mode++)
 				{
-				    if(TEST_BIT(mode, *toTest))
+				    if(TEST_BIT(mode, g_implementedAlgorithms)) // libtpms always test implemented modes
 					TestSymmetricAlgorithm(&c_symTestValues[index], mode);
 				}
 			}

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -184,13 +184,16 @@ evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
             evpfn = (evpfunc[]){EVP_des_ede3_ecb, EVP_des_ede3_ecb, NULL}[i];
             break;
 #endif
-	}
+        }
+        break;
 #endif
+
 #if ALG_SM4
 #error Missing implementation of EVP for SM4
     case TPM_ALG_SM4:
         break;
 #endif
+
 #if ALG_CAMELLIA
 #error Missing implementation of EVP for Camellia
     case TPM_ALG_CAMELLIA:


### PR DESCRIPTION
This series of patches adds a missing break statement to the TDES function selector part and makes sure that all symmetric crypto modes are always tested.