### PR TITLE
tpm2: Clarify that PRIMARY_SEED_SIZE is 64 per USE_SPEC_COMPLIANT_PROOFS

### DIFF
--- a/src/tpm2/Implementation.h
+++ b/src/tpm2/Implementation.h
@@ -230,7 +230,7 @@
 #define  MIN_COUNTER_INDICES            8
 #define  NUM_STATIC_PCR                 16
 #define  MAX_ALG_LIST_SIZE              64
-#define  PRIMARY_SEED_SIZE              32
+#define  PRIMARY_SEED_SIZE              64	/* libtpms: 64 per define USE_SPEC_COMPLIANT_PROOFS */
 #define  CONTEXT_ENCRYPT_ALGORITHM      AES
 #define  NV_CLOCK_UPDATE_INTERVAL       12
 #define  NUM_POLICY_PCR                 1


### PR DESCRIPTION
We define USE_SPEC_COMPLIANT_PROOFS which overrides PRIMARY_SEED_SIZE in
Implentation.h and cause PRIMARY_SEED_SIZE to be set to 64. Nevertheless,
adjust the value in Implementation.h.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>