### PR TITLE
tpm12: Replace strcpy with safer strncpy

### DIFF
--- a/src/tpm12/tpm_nvfile.c
+++ b/src/tpm12/tpm_nvfile.c
@@ -135,7 +135,7 @@ TPM_RESULT TPM_NVRAM_Init(void)
         }
     }
     if (rc == 0) {
-        strcpy(state_directory, tpm_state_path);
+        strncpy(state_directory, tpm_state_path, sizeof(state_directory));
         printf("TPM_NVRAM_Init: Rooted state path %s\n", state_directory);
     }
     return rc;


### PR DESCRIPTION
Replace the strcpy with the safer strncpy version.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>