### PR TITLE
tpm2: Fix TDES key creation by adding missing un-/marshalling functions

### DIFF
--- a/src/tpm2/Marshal.c
+++ b/src/tpm2/Marshal.c
@@ -1147,6 +1147,14 @@ TPMI_AES_KEY_BITS_Marshal(TPMI_AES_KEY_BITS *source, BYTE **buffer, INT32 *size)
     return written;
 }
 
+UINT16			// libtpms added begin
+TPMI_TDES_KEY_BITS_Marshal(TPMI_TDES_KEY_BITS *source, BYTE **buffer, INT32 *size)
+{
+    UINT16 written = 0;
+    written += TPM_KEY_BITS_Marshal(source, buffer, size);
+    return written;
+}			// libtpms added end
+
 /* Table 2:128 - Definition of TPMU_SYM_KEY_BITS Union (StructuresTable()) */
 
 UINT16
@@ -1170,6 +1178,11 @@ TPMU_SYM_KEY_BITS_Marshal(TPMU_SYM_KEY_BITS *source, BYTE **buffer, INT32 *size,
 	written += TPMI_CAMELLIA_KEY_BITS_Marshal(&source->camellia, buffer, size);
 	break;
 #endif
+#if ALG_TDES	// libtpms added begin
+      case TPM_ALG_TDES:
+	written += TPMI_TDES_KEY_BITS_Marshal(&source->tdes, buffer, size);
+	break;
+#endif		// libtpms added end
 #if ALG_XOR
       case TPM_ALG_XOR:
 	written += TPMI_ALG_HASH_Marshal(&source->xorr, buffer, size);
@@ -1206,6 +1219,11 @@ TPMU_SYM_MODE_Marshal(TPMU_SYM_MODE *source, BYTE **buffer, INT32 *size, UINT32 
 	written += TPMI_ALG_SYM_MODE_Marshal(&source->camellia, buffer, size);
 	break;
 #endif
+#if ALG_TDES		// libtpms added begin
+      case TPM_ALG_TDES:
+	written += TPMI_ALG_SYM_MODE_Marshal(&source->tdes, buffer, size);
+	break;
+#endif			// libtpms added end
 #if ALG_XOR
       case TPM_ALG_XOR:
 #endif

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -1105,6 +1105,9 @@ TPMI_ALG_SYM_Unmarshal(TPMI_ALG_SYM *target, BYTE **buffer, INT32 *size, BOOL al
 #if ALG_CAMELLIA
 	  case TPM_ALG_CAMELLIA:	
 #endif
+#if ALG_TDES		// libtpms added begin
+	  case TPM_ALG_TDES:
+#endif			// libtpms added end
 #if ALG_XOR
 	  case TPM_ALG_XOR:		
 #endif
@@ -1141,6 +1144,9 @@ TPMI_ALG_SYM_OBJECT_Unmarshal(TPMI_ALG_SYM_OBJECT *target, BYTE **buffer, INT32 
 #if ALG_CAMELLIA
 	  case TPM_ALG_CAMELLIA:	
 #endif
+#if ALG_TDES		// libtpms added begin
+          case TPM_ALG_TDES:
+#endif			// iibtpms added end
 	    break;
 	  case TPM_ALG_NULL:
 	    if (allowNull) {
@@ -2498,6 +2504,28 @@ TPMI_SM4_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *siz
 }
 #endif
 
+#if ALG_TDES		// libtpms added begin
+TPM_RC
+TPMI_TDES_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *size)
+{
+    TPM_RC rc = TPM_RC_SUCCESS;
+
+    if (rc == TPM_RC_SUCCESS) {
+	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);
+    }
+    if (rc == TPM_RC_SUCCESS) {
+	switch (*target) {
+	  case 128:
+	  case 192:
+	    break;
+	  default:
+	    rc = TPM_RC_VALUE;
+	}
+    }
+    return rc;
+}
+#endif			// libtpms added end
+
 /* Table 125 - Definition of TPMU_SYM_KEY_BITS Union */
 
 TPM_RC
@@ -2521,6 +2549,11 @@ TPMU_SYM_KEY_BITS_Unmarshal(TPMU_SYM_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	rc = TPMI_CAMELLIA_KEY_BITS_Unmarshal(&target->camellia, buffer, size);
 	break;
 #endif
+#if ALG_TDES		// libtpms added beging
+      case TPM_ALG_TDES:
+	rc = TPMI_TDES_KEY_BITS_Unmarshal(&target->tdes, buffer, size);
+	break;
+#endif			// libtpms added end
 #if ALG_XOR
       case TPM_ALG_XOR:
 	rc = TPMI_ALG_HASH_Unmarshal(&target->xorr, buffer, size, NO);
@@ -2557,6 +2590,11 @@ TPMU_SYM_MODE_Unmarshal(TPMU_SYM_MODE *target, BYTE **buffer, INT32 *size, UINT3
 	rc = TPMI_ALG_SYM_MODE_Unmarshal(&target->camellia, buffer, size, YES);
 	break;
 #endif
+#if ALG_TDES		// libtpms added begin
+      case TPM_ALG_TDES:
+	rc = TPMI_ALG_SYM_MODE_Unmarshal(&target->tdes, buffer, size, YES);
+	break;
+#endif			// libtpms added end
       case TPM_ALG_XOR:
       case TPM_ALG_NULL:
 	break;


### PR DESCRIPTION
This is a backport of 2da6f27c33.

Some TDES related marshalling and unmarshalling functions were
missing, so add them. Now TDES keys can be created.

Signed-off-by: stefan Berger <stefanb@linux.ibm.com>