### PR TITLE
tpm2: Convert CMAC test to SMAC test for better coverage

### DIFF
--- a/src/tpm2/AlgorithmTests.c
+++ b/src/tpm2/AlgorithmTests.c
@@ -155,13 +155,13 @@ TestHash(
     return TPM_RC_SUCCESS;
 }
 // libtpms added begin
-#if ALG_CMAC
+#if SMAC_IMPLEMENTED && ALG_CMAC
 static TPM_RC
-TestCMAC(
+TestSMAC(
 	 ALGORITHM_VECTOR    *toTest
 	 )
 {
-    SMAC_STATE          state;
+    HMAC_STATE          state;
     UINT16              copied;
     BYTE                out[MAX_SYM_BLOCK_SIZE];
     UINT32              outSize = sizeof(out);
@@ -175,12 +175,12 @@ TestCMAC(
 
     for (i = 0; CMACTests[i].key; i++ )
 	{
-	    blocksize = CryptCmacStart(&state, &cmac_keyParms,
-				       TPM_ALG_CMAC, CMACTests[i].key);
+	    blocksize = CryptMacStart(&state, &cmac_keyParms,
+				      TPM_ALG_CMAC, CMACTests[i].key);
 	    pAssert(blocksize <= outSize);
-	    CryptCmacData(&state.state, CMACTests[i].datalen,
-			  CMACTests[i].data);
-	    copied = CryptCmacEnd(&state.state, outSize, out);
+	    CryptDigestUpdate(&state.hashState, CMACTests[i].datalen,
+			      CMACTests[i].data);
+	    copied = CryptMacEnd(&state, outSize, out);
 	    if((CMACTests[i].outlen != copied)
 	      || (memcmp(out, CMACTests[i].out, CMACTests[i].outlen) != 0)) {
 		SELF_TEST_FAILURE;
@@ -848,12 +848,12 @@ TestAlgorithm(
 #if ALG_AES
 		  case ALG_AES_VALUE:
 // libtpms added begin
-#if ALG_CMAC
-		    if (doTest) {
-		         result = TestCMAC(toTest);
-		         if (result != TPM_RC_SUCCESS)
-		             break;
-	            }
+#if SMAC_IMPLEMENTED && ALG_CMAC
+                    if (doTest) {
+                         result = TestSMAC(toTest);
+                         if (result != TPM_RC_SUCCESS)
+                             break;
+                    }
 #endif
 // libtpms added end
 #endif

--- a/src/tpm2/HashTestData.h
+++ b/src/tpm2/HashTestData.h
@@ -128,7 +128,7 @@ TPM2B_SHA512    c_SHA512_digest = {{64, {
 #endif
 
 // libtpms added begin
-#if ALG_CMAC
+#if SMAC_IMPLEMENTED && ALG_CMAC
 TPM2B_TYPE(AES128, 16);
 static TPM2B_AES128 cmac_aeskey = {{16, {
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,


### PR DESCRIPTION
The SMAC test now covers CMAC as well but covers more code paths.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>