### PR TITLE
tpm12: coverity: Use length + 1 for strncpy() parameter

### DIFF
--- a/src/tpm12/tpm_nvfile.c
+++ b/src/tpm12/tpm_nvfile.c
@@ -135,7 +135,7 @@ TPM_RESULT TPM_NVRAM_Init(void)
         }
     }
     if (rc == 0) {
-        strncpy(state_directory, tpm_state_path, sizeof(state_directory));
+        strncpy(state_directory, tpm_state_path, length + 1);
         printf("TPM_NVRAM_Init: Rooted state path %s\n", state_directory);
     }
     return rc;


### PR DESCRIPTION
Use length + 1 as size parameter to strncpy() to address a Coverity
issue (false positive).

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>