### PR TITLE
tpm12: Revert changes using strncpy to now use strcpy again

### DIFF
--- a/src/tpm12/tpm_nvfile.c
+++ b/src/tpm12/tpm_nvfile.c
@@ -135,7 +135,7 @@ TPM_RESULT TPM_NVRAM_Init(void)
         }
     }
     if (rc == 0) {
-        strncpy(state_directory, tpm_state_path, length + 1);
+        strcpy(state_directory, tpm_state_path);
         printf("TPM_NVRAM_Init: Rooted state path %s\n", state_directory);
     }
     return rc;


### PR DESCRIPTION
Revert the changes trying to use strncpy to now use strcpy again.
Recent compilers complain like this:

tpm12/tpm_nvfile.c: In function ‘TPM_NVRAM_Init’:
tpm12/tpm_nvfile.c:138:9: error: ‘strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  138 |         strncpy(state_directory, tpm_state_path, length + 1);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tpm12/tpm_nvfile.c:130:18: note: length computed here
  130 |         length = strlen(tpm_state_path);
      |                  ^~~~~~~~~~~~~~~~~~~~~~
tpm12/tpm_nvfile.c: At top level:
cc1: error: unrecognized command line option ‘-Wno-self-assign’ [-Werror]
cc1: all warnings being treated as errors

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>