### PR TITLE
tpm2: Initialize variable to address valgrind complaint

### DIFF
--- a/src/tpm2/ObjectCommands.c
+++ b/src/tpm2/ObjectCommands.c
@@ -131,7 +131,7 @@ TPM2_Load(
 	  )
 {
     TPM_RC                   result = TPM_RC_SUCCESS;
-    TPMT_SENSITIVE           sensitive;
+    TPMT_SENSITIVE           sensitive = {0}; // libtpms changed (valgrind)
     OBJECT                  *parentObject;
     OBJECT                  *newObject;
     // Input Validation


### PR DESCRIPTION
This patch addresses the following valgrind issue detetcted by swtpm test suite:

== Syscall param write(buf) points to uninitialised byte(s)
==3515669==    at 0x4DC14B7: write (in /usr/lib64/libc-2.30.so)
==3515669==    by 0x48547FB: write_full (utils.c:242)
==3515669==    by 0x48548F3: writev_full (utils.c:301)
==3515669==    by 0x48520A6: SWTPM_IO_Write (swtpm_io.c:229)
==3515669==    by 0x4850662: mainLoop (mainloop.c:282)
==3515669==    by 0x402BE7: swtpm_main (swtpm.c:497)
==3515669==    by 0x4CF61A2: (below main) (in /usr/lib64/libc-2.30.so)
==3515669==  Address 0x52413a2 is 34 bytes inside a block of size 2,006 alloc'd
==3515669==    at 0x483980B: malloc (vg_replace_malloc.c:309)
==3515669==    by 0x48548A1: writev_full (utils.c:287)
==3515669==    by 0x48520A6: SWTPM_IO_Write (swtpm_io.c:229)
==3515669==    by 0x4850662: mainLoop (mainloop.c:282)
==3515669==    by 0x402BE7: swtpm_main (swtpm.c:497)
==3515669==    by 0x4CF61A2: (below main) (in /usr/lib64/libc-2.30.so)
==3515669==  Uninitialised value was created by a stack allocation
==3515669==    at 0x4953993: TPM2_Load (ObjectCommands.c:132)
==3515669==

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>