### PR TITLE
tpm12: Initialize some variables for gcc-5 ppc64el compiler

### DIFF
--- a/src/tpm12/tpm_nvram.c
+++ b/src/tpm12/tpm_nvram.c
@@ -1288,7 +1288,7 @@ TPM_RESULT TPM_Process_NVReadValue(tpm_state_t *tpm_state,
     TPM_BOOL			ignore_auth = FALSE;
     TPM_BOOL			dir = FALSE;
     TPM_BOOL			physicalPresence;
-    TPM_BOOL			isGPIO;
+    TPM_BOOL			isGPIO = FALSE;
     BYTE 			*gpioData = NULL;
     TPM_NV_DATA_SENSITIVE	*d1NvdataSensitive;
     uint32_t			s1Last;
@@ -2000,7 +2000,7 @@ TPM_RESULT TPM_Process_NVWriteValue(tpm_state_t *tpm_state,
     TPM_NV_DATA_SENSITIVE	*d1NvdataSensitive;
     uint32_t			s1Last;
     TPM_BOOL			physicalPresence;
-    TPM_BOOL			isGPIO;
+    TPM_BOOL			isGPIO = FALSE;
     uint32_t			nv1 = tpm_state->tpm_permanent_data.noOwnerNVWrite;
 							/* temp for noOwnerNVWrite, initialize to
 							   silence compiler */

--- a/src/tpm12/tpm_process.c
+++ b/src/tpm12/tpm_process.c
@@ -4844,7 +4844,7 @@ TPM_RESULT TPM_Process_GetCapabilitySigned(tpm_state_t *tpm_state,
     unsigned char *	inParamEnd;		/* ending point of inParam's */
     TPM_DIGEST		inParamDigest;
     TPM_BOOL		auditStatus;		/* audit the ordinal */
-    TPM_BOOL		transportEncrypt;	/* wrapped in encrypted transport session */
+    TPM_BOOL		transportEncrypt = FALSE;/* wrapped in encrypted transport session */
     TPM_BOOL		authHandleValid = FALSE;
     TPM_AUTH_SESSION_DATA *auth_session_data;	/* session data for authHandle */
     TPM_SECRET		*hmacKey;
@@ -5144,7 +5144,7 @@ TPM_RESULT TPM_Process_SetCapability(tpm_state_t *tpm_state,
     unsigned char *	inParamEnd;		/* ending point of inParam's */
     TPM_DIGEST		inParamDigest;
     TPM_BOOL		auditStatus;		/* audit the ordinal */
-    TPM_BOOL		transportEncrypt;	/* wrapped in encrypted transport session */
+    TPM_BOOL		transportEncrypt = FALSE;/* wrapped in encrypted transport session */
     TPM_BOOL		authHandleValid = FALSE;
     TPM_AUTH_SESSION_DATA *auth_session_data;	/* session data for authHandle */
     TPM_SECRET		*hmacKey;

--- a/src/tpm12/tpm_session.c
+++ b/src/tpm12/tpm_session.c
@@ -3053,7 +3053,7 @@ TPM_RESULT TPM_Process_SaveContext(tpm_state_t *tpm_state,
     TPM_CONTEXT_SENSITIVE	c1ContextSensitive;
     TPM_CONTEXT_BLOB		b1ContextBlob;
     TPM_STORE_BUFFER		c1_sbuffer;		/* serialization of c1ContextSensitive */
-    uint32_t			contextIndex;		/* free index in context list */
+    uint32_t			contextIndex = 0;	/* free index in context list */
     uint32_t			space;			/* free space in context list */
     TPM_BOOL			isZero;
     
@@ -4931,7 +4931,7 @@ TPM_RESULT TPM_Process_SaveAuthContext(tpm_state_t *tpm_state,
     TPM_AUTH_SESSION_DATA	*tpm_auth_session_data; /* session table entry for the handle */
     TPM_BOOL			isZero;			/* contextNonceSession not set yet */
     TPM_STCLEAR_DATA		*v1StClearData = NULL;
-    uint32_t			contextIndex;		/* free index in context list */
+    uint32_t			contextIndex = 0;	/* free index in context list */
     uint32_t			space;			/* free space in context list */
     TPM_CONTEXT_SENSITIVE	contextSensitive;
     TPM_STORE_BUFFER		contextSensitive_sbuffer; /* serialization of contextSensitive */

--- a/src/tpm12/tpm_transport.c
+++ b/src/tpm12/tpm_transport.c
@@ -2599,7 +2599,7 @@ TPM_RESULT TPM_Process_ReleaseTransportSigned(tpm_state_t *tpm_state,
     TPM_BOOL			authHandleValid = FALSE;
     TPM_BOOL			transHandleValid = FALSE;
     TPM_AUTH_SESSION_DATA	*auth_session_data = NULL;	/* session data for authHandle */
-    TPM_TRANSPORT_INTERNAL	*t1TpmTransportInternal;
+    TPM_TRANSPORT_INTERNAL	*t1TpmTransportInternal = NULL;
     TPM_SECRET			*hmacKey;
     TPM_KEY			*sigKey = NULL;		/* the key specified by keyHandle */
     TPM_BOOL			parentPCRStatus;

--- a/src/tpm2/Marshal.c
+++ b/src/tpm2/Marshal.c
@@ -2020,7 +2020,7 @@ UINT16
 TPM2B_PUBLIC_Marshal(TPM2B_PUBLIC *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    BYTE *sizePtr;
+    BYTE *sizePtr = NULL; // libtpms changes for ppc64el gcc-5 -O3
 
     if (buffer != NULL) {
 	sizePtr = *buffer;


### PR DESCRIPTION
The -O3 passed to the ppc64el gcc-5 compiler on Ubuntu 16.04 causes
the following false positives:

gcc-5 -DHAVE_CONFIG_H -I. -I.. -include tpm_library_conf.h -I../include/libtpms -I../include/libtpms -fstack-protector-strong -DTPM_V12 -DTPM_PCCLIENT -DTPM_VOLATILE_LOAD -DTPM_ENABLE_ACTIVATE -DTPM_AES -DTPM_LIBTPMS_CALLBACKS -DTPM_NV_DISK -DTPM_POSIX -DTPM_NOMAINTENANCE_COMMANDS -g -O3 -fstack-protector-strong -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=1 -DUSE_OPENSSL_FUNCTIONS_EC=1 -DUSE_OPENSSL_FUNCTIONS_ECDSA=0 -DUSE_OPENSSL_FUNCTIONS_RSA=0 -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign -MT tpm12/libtpms_tpm12_la-tpm_session.lo -MD -MP -MF tpm12/.deps/libtpms_tpm12_la-tpm_session.Tpo -c tpm12/tpm_session.c -o tpm12/libtpms_tpm12_la-tpm_session.o
tpm12/tpm_session.c: In function ‘TPM_Process_SaveContext’:
tpm12/tpm_session.c:3056:16: error: ‘contextIndex’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     uint32_t   contextIndex;  /* free index in context list */
                ^
tpm12/tpm_session.c: In function ‘TPM_Process_SaveAuthContext’:
tpm12/tpm_session.c:4934:16: error: ‘contextIndex’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     uint32_t   contextIndex;  /* free index in context list */
                ^

This patch initializes these variables to 0.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>