### PR TITLE
make debhelper play nice with autotools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,9 @@ Standards-Version: 3.9.7
 Build-Depends:
  autoconf,
  automake,
+ autotools-dev,
  debhelper (>= 9),
+ dh-autoreconf,
  dh-exec,
  gawk,
  libssl-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,13 @@
 #!/usr/bin/make -f
 
+# export DH_VERBOSE=1
+
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --parallel 
+	dh $@ --parallel --with autotools-dev --with autoreconf
 
 override_dh_auto_configure:
-	NOCONFIGURE=1 ./autogen.sh
 	dh_auto_configure -- --with-openssl --with-tpm2
 
 override_dh_usrlocal:


### PR DESCRIPTION
We need to inform debhelper that it will be driving the action using autotools.

edit `debian/control` field `Build-Depends`: add `autotools-dev` and
`dh-autoreconf`

edit `debian/rules`:

* change the default target `%` to invoke `dh` with `autotools-dev` and
  `autoreconf`

* remove from `override_dh_auto_configure` the invocation to `./autogen.sh`
  obsoleted by `dh-autoreconf`