### PR TITLE
build-sys: Remove 'experimental' tag from --with-tpm2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,7 @@ esac
 
 AC_ARG_WITH([tpm2],
 	AC_HELP_STRING([--with-tpm2],
-		       [build libtpms with TPM2 support (experimental)]),
+		       [build libtpms with TPM2 support]),
 	AC_MSG_RESULT([Building with TPM2 support])
 	if test "x$cryptolib" = "xfreebl"; then
 		AC_MSG_ERROR([TPM2 support requires openssl crypto library])


### PR DESCRIPTION
TPM 2 support has been in libtpms for quite some time now
and the experimental tag can be removed.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>