### PR TITLE
tpm2: Add a pAssert after a statement causing unfounded Coverity comp…

### DIFF
--- a/src/tpm2/EACommands.c
+++ b/src/tpm2/EACommands.c
@@ -611,6 +611,7 @@ TPM2_PolicyCounterTimer(
     // Input Validation
     // Get a marshaled time structure
     infoDataSize = TimeGetMarshaled(&infoData);
+    pAssert(infoDataSize <= sizeof(infoData));  // libtpms added; 25 < 32 ==> unfounded coverity complaint
     // Make sure that the referenced stays within the bounds of the structure.
     // NOTE: the offset checks are made even for a trial policy because the policy
     // will not make any sense if the references are out of bounds of the timer


### PR DESCRIPTION
…laint

This is the Coverity complaint about the line

infoDataSize = TimeGetMarshaled(&infoData);

CID 1402057: Out-of-bounds access (OVERRUN)
1. overrun-buffer-val: Overrunning array infoData of 32 bytes by passing
  it to a function which accesses it at byte offset 255.

TimeGetMarshaled() correctly serializes into &infoData, which is casted to
a buffer and then the data are written into the buffer. Also only 25 bytes,
as indicated by infoDataSize, are used, which is less than sizeof(infoData),
which is 32.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>