### PR TITLE
tpm2: Fix memory leaks in TPM2_GetInfo()

### DIFF
--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -413,6 +413,8 @@ char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
         if (asprintf(&buffer, fmt,  printed ? "," : "",
                      tpmfeatures, "%s%s%s") < 0)
             goto error;
+        free(fmt);
+        free(tpmfeatures);
         printed = true;
     }
 


### PR DESCRIPTION
This patch fixes two memory leaks in the new code in TPM2_GetInfo().

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>