### PR TITLE
tpm2: Prevent RSA 3072 related out-of-bounds access to sieveMarks[5]

### DIFF
--- a/src/tpm2/crypto/openssl/CryptPrimeSieve.c
+++ b/src/tpm2/crypto/openssl/CryptPrimeSieve.c
@@ -97,7 +97,7 @@ RsaAdjustPrimeLimit(
     if(requestedPrimes < s_PrimeMarkersCount)
 	primeLimit = s_PrimeMarkers[requestedPrimes];
     else
-	primeLimit = s_LastPrimeInTable;
+	primeLimit = s_LastPrimeInTable - 2;  // libtpms: Fix for 3072 bit keys to avoid mark=5
     primeLimit >>= 1;
 }
 


### PR DESCRIPTION
PrimeSieve was accessing the sieveMarks array at out-of-bounds index 5
due to a bug in other parts of the code. This patch fixes the issue
and prevents this access by limiting the values that 'next' can take on.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>