### PR TITLE
Elliptic curve fixes, MANUFACTURER fix and update to 0.6.2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,17 @@
 CHANGES - changes for libtpms
 
+version 0.6.2
+  - compilation fixes for TPM 1.2 and various architectures and gcc versions
+  - Fix support for NIST curves P{192,224,521} and SM2 P256 and BN P648
+    that would not work;
+  - Runtime filter elliptic curves (that OpenSSL does not support) and do
+    not advertise those curves as capabilities
+  - Removed unnecessary space in MANUFACTURER "IBM " -> "IBM"
+
+version 0.6.1
+  - CMAC code fix
+  - Adapt code for OpenSSL 1.2 deprecated elliptic curve API calls
+
 version 0.6.0
   - added TPM 2 support (revision 150)
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms], [0.6.0])
+AC_INIT([libtpms], [0.6.2])
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtpms (0.6.2-1) RELEASED; urgency=medium
+
+  * Backports and other bugfixes
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Mon, 18 May 2020 12:01:00 -0500
+
 libtpms (0.6.0-1) RELEASED; urgency=medium
 
   * Stable release

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.6.0
+%define version   0.6.2
 %define release   1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -112,7 +112,10 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
-* Mon Jan 14 2018 Stefan Berger - 0.6.0-1
+* Mon May 18 2020 Stefan Berger - 0.6.2-1
+- Backports and other bugfixes
+
+* Mon Jan 15 2018 Stefan Berger - 0.6.0-1
 - Release of version 0.6.0 with TPM 2.0 support
 
 * Mon Jun 30 2014 Stefan Berger - 0.5.2-1

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -112,7 +112,10 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
-* Mon Jan 14 2018 Stefan Berger - 0.6.0-1
+* Mon May 18 2020 Stefan Berger - 0.6.2-1
+- Backports and other bugfixes
+
+* Mon Jan 15 2018 Stefan Berger - 0.6.0-1
 - Release of version 0.6.0 with TPM 2.0 support
 
 * Mon Jun 30 2014 Stefan Berger - 0.5.2-1

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 6
-#define TPM_LIBRARY_VER_MICRO 0
+#define TPM_LIBRARY_VER_MICRO 2
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -41,7 +41,9 @@
 
 #include <string.h>
 
+#include "Tpm.h"		// libtpms added
 #include "Unmarshal_fp.h"
+#include "CryptEccMain_fp.h"	// libtpms added
 
 TPM_RC
 UINT8_Unmarshal(UINT8 *target, BYTE **buffer, INT32 *size)
@@ -3602,12 +3604,30 @@ TPMI_ECC_CURVE_Unmarshal(TPMI_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 #if ECC_BN_P256
 	  case TPM_ECC_BN_P256:
 #endif
+#if ECC_BN_P638		// libtpms added begin
+	  case TPM_ECC_BN_P638:
+#endif
+#if ECC_NIST_P192
+	  case TPM_ECC_NIST_P192:
+#endif
+#if ECC_NIST_P224
+	  case TPM_ECC_NIST_P224:
+#endif			// libtpms added end
 #if ECC_NIST_P256
 	  case TPM_ECC_NIST_P256:
 #endif
 #if ECC_NIST_P384
 	  case TPM_ECC_NIST_P384:
 #endif
+#if ECC_NIST_P521	// libtpms added begin
+	  case TPM_ECC_NIST_P521:
+#endif
+#if ECC_SM2_P256
+	  case TPM_ECC_SM2_P256:
+#endif
+	  if (!CryptEccIsCurveRuntimeUsable(*target))
+	      rc = TPM_RC_CURVE;
+			// libtpms added end
 	    break;
 	  default:
 	    rc = TPM_RC_CURVE;

--- a/src/tpm2/VendorString.h
+++ b/src/tpm2/VendorString.h
@@ -65,7 +65,7 @@
 /* Define up to 4-byte values for MANUFACTURER.  This value defines the response for
    TPM_PT_MANUFACTURER in TPM2_GetCapability(). The following line should be un-commented and a
    vendor specific string should be provided here. */
-#define    MANUFACTURER    "IBM "
+#define    MANUFACTURER    "IBM"
 
 /*     The following #if macro may be deleted after a proper MANUFACTURER is provided. */
 #ifndef MANUFACTURER

--- a/src/tpm2/crypto/CryptEccMain_fp.h
+++ b/src/tpm2/crypto/CryptEccMain_fp.h
@@ -213,5 +213,11 @@ CryptEccGenerateKey(
 		    //     RNG state
 		    );
 
+// 		libtpms added begin
+LIB_EXPORT BOOL
+CryptEccIsCurveRuntimeUsable(
+			     TPMI_ECC_CURVE curveId
+			    );
+//		libtpms added end
 
 #endif

--- a/src/tpm2/crypto/openssl/CryptEccMain.c
+++ b/src/tpm2/crypto/openssl/CryptEccMain.c
@@ -242,6 +242,8 @@ CryptCapGetECCCurve(
 	    // If curveID is less than the starting curveID, skip it
 	    if(curve < curveID)
 		continue;
+	    if (!CryptEccIsCurveRuntimeUsable(curve)) // libtpms added: runtime filter supported curves
+		continue;
 	    if(curveList->count < maxCount)
 		{
 		    // If we have not filled up the return list, add more curves to
@@ -745,4 +747,21 @@ CryptEccGenerateKey(
     CURVE_FREE(E);
     return retVal;
 }
+
+//		libtpms added begin
+// Support for some curves may be compiled in but they may not be
+// supported by openssl's crypto library.
+LIB_EXPORT BOOL
+CryptEccIsCurveRuntimeUsable(
+			     TPMI_ECC_CURVE curveId
+			    )
+{
+    CURVE_INITIALIZED(E, curveId);
+    if (E == NULL)
+	return FALSE;
+    CURVE_FREE(E);
+    return TRUE;
+}
+//		libtpms added end
+
 #endif  // TPM_ALG_ECC


### PR DESCRIPTION
This PR fixes two issues with elliptic curves

- support for some elliptic curves is compiled in (via choice of #defines in Implementation.h) but missing OpenSSL support during runtime, so we have to filter the advertised capabilities to only show those curves that are supported
- Unmarshalling of certain elliptic curves was not supported

The MANUFACTURER #define is changed from "IBM " to "IBM".
