### PR TITLE
Elliptic curve fixes

### DIFF
--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -42,6 +42,7 @@
 #include <string.h>
 
 #include "Unmarshal_fp.h"
+#include "CryptEccMain_fp.h"	// libtpms added
 
 TPM_RC
 UINT8_Unmarshal(UINT8 *target, BYTE **buffer, INT32 *size)
@@ -3599,12 +3600,30 @@ TPMI_ECC_CURVE_Unmarshal(TPMI_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 #if ECC_BN_P256
 	  case TPM_ECC_BN_P256:
 #endif
+#if ECC_BN_P638		// libtpms added begin
+	  case TPM_ECC_BN_P638:
+#endif
+#if ECC_NIST_P192
+	  case TPM_ECC_NIST_P192:
+#endif
+#if ECC_NIST_P224
+	  case TPM_ECC_NIST_P224:
+#endif			// libtpms added end
 #if ECC_NIST_P256
 	  case TPM_ECC_NIST_P256:
 #endif
 #if ECC_NIST_P384
 	  case TPM_ECC_NIST_P384:
 #endif
+#if ECC_NIST_P521	// libtpms added begin
+	  case TPM_ECC_NIST_P521:
+#endif
+#if ECC_SM2_P256
+	  case TPM_ECC_SM2_P256:
+#endif
+          if (!CryptEccIsCurveRuntimeUsable(*target))
+              rc = TPM_RC_CURVE;
+                      // libtpms added end
 	    break;
 	  default:
 	    rc = TPM_RC_CURVE;

--- a/src/tpm2/crypto/CryptEccMain_fp.h
+++ b/src/tpm2/crypto/CryptEccMain_fp.h
@@ -220,5 +220,11 @@ CryptEccGenerateKey(
 		    //     RNG state
 		    );
 
+// 		libtpms added begin
+LIB_EXPORT BOOL
+CryptEccIsCurveRuntimeUsable(
+			     TPMI_ECC_CURVE curveId
+			    );
+//		libtpms added end
 
 #endif

--- a/src/tpm2/crypto/openssl/CryptEccMain.c
+++ b/src/tpm2/crypto/openssl/CryptEccMain.c
@@ -253,6 +253,8 @@ CryptCapGetECCCurve(
 	    // If curveID is less than the starting curveID, skip it
 	    if(curve < curveID)
 		continue;
+            if (!CryptEccIsCurveRuntimeUsable(curve)) // libtpms added: runtime filter supported curves
+                continue;
 	    if(curveList->count < maxCount)
 		{
 		    // If we have not filled up the return list, add more curves to
@@ -791,4 +793,21 @@ CryptEccGenerateKey(
     CURVE_FREE(E);
     return retVal;
 }
+
+//		libtpms added begin
+// Support for some curves may be compiled in but they may not be
+// supported by openssl's crypto library.
+LIB_EXPORT BOOL
+CryptEccIsCurveRuntimeUsable(
+			     TPMI_ECC_CURVE curveId
+			    )
+{
+    CURVE_INITIALIZED(E, curveId);
+    if (E == NULL)
+	return FALSE;
+    CURVE_FREE(E);
+    return TRUE;
+}
+//		libtpms added end
+
 #endif  // TPM_ALG_ECC


### PR DESCRIPTION
This PR fixes two issues with elliptic curves

- support for some elliptic curves is compiled in (via choice of #defines in TpmProfile.h) but missing OpenSSL support during runtime, so we have to filter the advertised capabilities to only show those curves that are supported
- Unmarshalling of certain elliptic curves was not supported
