### PR TITLE
tpm2: Fix output buffer parameter and size for RSA decryption

### DIFF
--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -1318,6 +1318,7 @@ CryptRsaDecrypt(
     const char            *digestname;
     size_t                 outlen;
     unsigned char         *tmp = NULL;
+    unsigned char          buffer[MAX_RSA_KEY_BYTES];
 
     // Make sure that the necessary parameters are provided
     pAssert(cIn != NULL && dOut != NULL && key != NULL);
@@ -1372,11 +1373,16 @@ CryptRsaDecrypt(
             break;
 	}
 
-    outlen = cIn->size;
-    if (EVP_PKEY_decrypt(ctx, dOut->buffer, &outlen,
+    /* cannot use cOut->buffer */
+    outlen = sizeof(buffer);
+    if (EVP_PKEY_decrypt(ctx, buffer, &outlen,
                          cIn->buffer, cIn->size) <= 0)
         ERROR_RETURN(TPM_RC_FAILURE);
 
+    if (outlen > dOut->size)
+        ERROR_RETURN(TPM_RC_FAILURE);
+
+    memcpy(dOut->buffer, buffer, outlen);
     dOut->size = outlen;
 
     retVal = TPM_RC_SUCCESS;


### PR DESCRIPTION
For the RSA decryption we have to use an output buffer of the size of the
(largest possible) RSA key for the decryption to always work.

This fixes a stack corruption bug that caused a SIGBUS and termination of
'swtpm'.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>