### PR TITLE
Fix a few issues with symmetric decryption and PSS salt

### DIFF
--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -1459,6 +1459,10 @@ CryptRsaSign(
         EVP_PKEY_CTX_set_signature_md(ctx, md) <= 0)
         ERROR_RETURN(TPM_RC_FAILURE);
 
+    if (padding == RSA_PKCS1_PSS_PADDING &&
+        EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, -1) <= 0)
+        ERROR_RETURN(TPM_RC_FAILURE);
+
     outlen = sigOut->signature.rsapss.sig.t.size;
     if (EVP_PKEY_sign(ctx,
                       sigOut->signature.rsapss.sig.t.buffer, &outlen,

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -700,6 +700,7 @@ CryptSymmetricDecrypt(
     ctx = EVP_CIPHER_CTX_new();
     if (!ctx ||
         EVP_DecryptInit_ex(ctx, evpfn(), NULL, keyToUse, iv) != 1 ||
+        EVP_CIPHER_CTX_set_padding(ctx, 0) != 1 ||
         EVP_DecryptUpdate(ctx, pOut, &outlen1, dIn, dSize) != 1)
         ERROR_RETURN(TPM_RC_FAILURE);
 

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -660,6 +660,21 @@ CryptSymmetricDecrypt(
     else
 	iv = defaultIv;
 
+    switch(mode)
+	{
+#if ALG_CBC || ALG_ECB
+	  case ALG_CBC_VALUE:
+	  case ALG_ECB_VALUE:
+	    // For ECB and CBC, the data size must be an even multiple of the
+	    // cipher block size
+	    if((dSize % blockSize) != 0)
+		return TPM_RC_SIZE;
+	    break;
+#endif
+	  default:
+	    break;
+	}
+
     evpfn = GetEVPCipher(algorithm, keySizeInBits, mode, key,
                          keyToUse, &keyToUseLen);
     if (evpfn ==  NULL)


### PR DESCRIPTION
This series of patches fixes a few potential issues with symmetric decryption
- add check for CBC and ECB for input size being multiple of block size and return TPM_RC_SIZE in case it is not the case
- add missing EVP_CIPHER_CTX_set_padding(ctx,0) call that is needed for CBC end ECB decryption
- always use a temporary buffer for decryption; the size of this buffer meets the requirements for the EVP_DecryptUpdate() call. 

For RSA signing we set the PSS salt length to the digest length. Previously it was at the maximum possible length, but this is not how TPM 2 implements it.