### PR TITLE
Fix a few issues with symmetric decryption and PSS salt

### DIFF
--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -1540,6 +1540,10 @@ CryptRsaSign(
         EVP_PKEY_CTX_set_signature_md(ctx, md) <= 0)
         ERROR_RETURN(TPM_RC_FAILURE);
 
+    if (padding == RSA_PKCS1_PSS_PADDING &&
+        EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, -1) <= 0)
+        ERROR_RETURN(TPM_RC_FAILURE);
+
     outlen = sigOut->signature.rsapss.sig.t.size;
     if (EVP_PKEY_sign(ctx,
                       sigOut->signature.rsapss.sig.t.buffer, &outlen,

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -701,6 +701,7 @@ CryptSymmetricDecrypt(
     ctx = EVP_CIPHER_CTX_new();
     if (!ctx ||
         EVP_DecryptInit_ex(ctx, evpfn(), NULL, keyToUse, iv) != 1 ||
+        EVP_CIPHER_CTX_set_padding(ctx, 0) != 1 ||
         EVP_DecryptUpdate(ctx, pOut, &outlen1, dIn, dSize) != 1)
         ERROR_RETURN(TPM_RC_FAILURE);
 

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -632,8 +632,7 @@ CryptSymmetricDecrypt(
     EVP_CIPHER_CTX      *ctx = NULL;
     int                  outlen1 = 0;
     int                  outlen2 = 0;
-    BYTE                *pOut = dOut;
-    BYTE                *buffer = NULL;
+    BYTE                *buffer;
     UINT32               buffersize = 0;
     BYTE                 keyToUse[MAX_SYM_KEY_BYTES];
     UINT16               keyToUseLen = (UINT16)sizeof(keyToUse);
@@ -681,18 +680,15 @@ CryptSymmetricDecrypt(
     if (evpfn ==  NULL)
         return TPM_RC_FAILURE;
 
-    if (dIn == dOut) {
-        // in-place encryption; we use a temp buffer
-        buffersize = TPM2_ROUNDUP(dSize, blockSize);
-        buffer = malloc(buffersize);
-        if (buffer == NULL)
-            ERROR_RETURN(TPM_RC_FAILURE);
-        pOut = buffer;
-    }
+    /* a buffer with a 'safety margin' for EVP_DecryptUpdate */
+    buffersize = TPM2_ROUNDUP(dSize + blockSize, blockSize);
+    buffer = malloc(buffersize);
+    if (buffer == NULL)
+        ERROR_RETURN(TPM_RC_FAILURE);
 
 #if ALG_TDES && ALG_CTR
     if (algorithm == TPM_ALG_TDES && mode == ALG_CTR_VALUE) {
-        TDES_CTR(keyToUse, keyToUseLen * 8, dSize, dIn, iv, pOut, blockSize);
+        TDES_CTR(keyToUse, keyToUseLen * 8, dSize, dIn, iv, buffer, blockSize);
         outlen1 = dSize;
         ERROR_RETURN(TPM_RC_SUCCESS);
     }
@@ -702,17 +698,21 @@ CryptSymmetricDecrypt(
     if (!ctx ||
         EVP_DecryptInit_ex(ctx, evpfn(), NULL, keyToUse, iv) != 1 ||
         EVP_CIPHER_CTX_set_padding(ctx, 0) != 1 ||
-        EVP_DecryptUpdate(ctx, pOut, &outlen1, dIn, dSize) != 1)
+        EVP_DecryptUpdate(ctx, buffer, &outlen1, dIn, dSize) != 1)
         ERROR_RETURN(TPM_RC_FAILURE);
 
-    pAssert(outlen1 <= dSize || dSize >= outlen1 + blockSize);
+    pAssert((int)buffersize >= outlen1);
 
-    if (EVP_DecryptFinal(ctx, pOut + outlen1, &outlen2) != 1)
+    if (EVP_DecryptFinal(ctx, &buffer[outlen1], &outlen2) != 1)
         ERROR_RETURN(TPM_RC_FAILURE);
+
+    pAssert((int)buffersize >= outlen1 + outlen2);
 
  Exit:
-    if (retVal == TPM_RC_SUCCESS && pOut != dOut)
-        memcpy(dOut, pOut, outlen1 + outlen2);
+    if (retVal == TPM_RC_SUCCESS) {
+        pAssert(dSize >= outlen1 + outlen2);
+        memcpy(dOut, buffer, outlen1 + outlen2);
+    }
 
     clear_and_free(buffer, buffersize);
     EVP_CIPHER_CTX_free(ctx);

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -661,6 +661,21 @@ CryptSymmetricDecrypt(
     else
 	iv = defaultIv;
 
+    switch(mode)
+	{
+#if ALG_CBC || ALG_ECB
+	  case ALG_CBC_VALUE:
+	  case ALG_ECB_VALUE:
+	    // For ECB and CBC, the data size must be an even multiple of the
+	    // cipher block size
+	    if((dSize % blockSize) != 0)
+		return TPM_RC_SIZE;
+	    break;
+#endif
+	  default:
+	    break;
+	}
+
     evpfn = GetEVPCipher(algorithm, keySizeInBits, mode, key,
                          keyToUse, &keyToUseLen);
     if (evpfn ==  NULL)


### PR DESCRIPTION
This series of patches fixes a few potential issues with symmetric decryption

- add check for CBC and ECB for input size being multiple of block size and return TPM_RC_SIZE in case it is not the case
- add missing EVP_CIPHER_CTX_set_padding(ctx,0) call that is needed for CBC end ECB decryption
- always use a temporary buffer for decryption; the size of this buffer meets the requirements for the EVP_DecryptUpdate() call.

For RSA signing we set the PSS salt length to the digest length. Previously it was at the maximum possible length, but this is not how TPM 2 implements it.