### PR TITLE
[build-sys] Add -Wmissing-prototypes to CFLAGS and clean up

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,7 @@ if test "x$enable_hardening" != "xno"; then
 fi
 
 CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign"
+CFLAGS="$CFLAGS -Wmissing-prototypes"
 LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
 
 AC_CONFIG_FILES(Makefile                   \

--- a/src/tpm12/tpm_identity.c
+++ b/src/tpm12/tpm_identity.c
@@ -380,7 +380,7 @@ void TPM_IdentityContents_Init(TPM_IDENTITY_CONTENTS *tpm_identity_contents)
 
    NOTE: Never called.
 */
-
+#if 0
 TPM_RESULT TPM_IdentityContents_Load(TPM_IDENTITY_CONTENTS *tpm_identity_contents,
 				     unsigned char **stream,
 				     uint32_t *stream_size)
@@ -410,6 +410,7 @@ TPM_RESULT TPM_IdentityContents_Load(TPM_IDENTITY_CONTENTS *tpm_identity_content
     }
     return rc;
 }
+#endif
 
 /* TPM_IdentityContents_Store()
    

--- a/src/tpm2/Marshal_fp.h
+++ b/src/tpm2/Marshal_fp.h
@@ -232,6 +232,8 @@ extern "C" {
     TPM2B_ATTEST_Marshal(TPM2B_ATTEST *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMI_AES_KEY_BITS_Marshal(TPMI_AES_KEY_BITS *source, BYTE **buffer, INT32 *size);
+    UINT16			// libtpms added
+    TPMI_TDES_KEY_BITS_Marshal(TPMI_TDES_KEY_BITS *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMI_CAMELLIA_KEY_BITS_Marshal(TPMI_CAMELLIA_KEY_BITS *source, BYTE **buffer, INT32 *size);
     UINT16

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -204,7 +204,7 @@ block_skip_read(BOOL needs_block, BYTE **buffer, INT32 *size,
             goto SKIP_MARK;						\
     }
 
-unsigned int _ffsll(long long bits)
+static unsigned int _ffsll(long long bits)
 {
     size_t i = 0;
 
@@ -274,7 +274,7 @@ TPM2B_Cmp(const TPM2B *t1, const TPM2B *t2)
     return memcmp(t1->buffer, t2->buffer, t1->size);
 }
 
-UINT16
+static UINT16
 TPM2B_PROOF_Marshal(TPM2B_PROOF *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
@@ -282,7 +282,7 @@ TPM2B_PROOF_Marshal(TPM2B_PROOF *source, BYTE **buffer, INT32 *size)
     return written;
 }
 
-TPM_RC
+static TPM_RC
 TPM2B_PROOF_Unmarshal(TPM2B_PROOF *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
@@ -293,7 +293,7 @@ TPM2B_PROOF_Unmarshal(TPM2B_PROOF *target, BYTE **buffer, INT32 *size)
     return rc;
 }
 
-TPM_RC
+static TPM_RC
 UINT32_Unmarshal_Check(UINT32 *data, UINT32 exp, BYTE **buffer, INT32 *size,
                        const char *msg)
 {
@@ -335,7 +335,7 @@ NV_HEADER_Marshal(BYTE **buffer, INT32 *size, UINT16 version, UINT32 magic,
     return written;
 }
 
-TPM_RC
+static TPM_RC
 NV_HEADER_Unmarshal(NV_HEADER *data, BYTE **buffer, INT32 *size,
                     UINT16 cur_version, UINT32 exp_magic)
 {
@@ -606,7 +606,7 @@ skip_future_versions:
 #define ORDERLY_DATA_MAGIC      0x56657887
 #define ORDERLY_DATA_VERSION 2
 
-UINT16
+static UINT16
 ORDERLY_DATA_Marshal(ORDERLY_DATA *data, BYTE **buffer, INT32 *size)
 {
     UINT16 written;
@@ -645,7 +645,7 @@ ORDERLY_DATA_Marshal(ORDERLY_DATA *data, BYTE **buffer, INT32 *size)
     return written;
 }
 
-TPM_RC
+static TPM_RC
 ORDERLY_DATA_Unmarshal(ORDERLY_DATA *data, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
@@ -782,7 +782,8 @@ PCR_SAVE_Marshal(PCR_SAVE *data, BYTE **buffer, INT32 *size)
  * restored. Only data for active PCR banks needs to restored, inactive PCR
  * banks need no data restored.
  */
-UINT64 pcrbanks_algs_active(const TPML_PCR_SELECTION *pcrAllocated)
+static UINT64
+pcrbanks_algs_active(const TPML_PCR_SELECTION *pcrAllocated)
 {
     UINT64 algs_active = 0;
     unsigned i, j;
@@ -1158,7 +1159,7 @@ skip_future_versions:
 #define STATE_CLEAR_DATA_MAGIC  0x98897667
 #define STATE_CLEAR_DATA_VERSION 2
 
-UINT16
+static UINT16
 STATE_CLEAR_DATA_Marshal(STATE_CLEAR_DATA *data, BYTE **buffer, INT32 *size)
 {
     UINT16 written;
@@ -1186,7 +1187,7 @@ STATE_CLEAR_DATA_Marshal(STATE_CLEAR_DATA *data, BYTE **buffer, INT32 *size)
     return written;
 }
 
-TPM_RC
+static TPM_RC
 STATE_CLEAR_DATA_Unmarshal(STATE_CLEAR_DATA *data, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
@@ -1237,7 +1238,7 @@ skip_future_versions:
 #define STATE_RESET_DATA_MAGIC  0x01102332
 #define STATE_RESET_DATA_VERSION 3
 
-TPM_RC
+static TPM_RC
 STATE_RESET_DATA_Unmarshal(STATE_RESET_DATA *data, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
@@ -1349,7 +1350,7 @@ skip_future_versions:
     return rc;
 }
 
-UINT16
+static UINT16
 STATE_RESET_DATA_Marshal(STATE_RESET_DATA *data, BYTE **buffer, INT32 *size)
 {
     UINT16 written;
@@ -2994,7 +2995,7 @@ VolatileState_Marshal(BYTE **buffer, INT32 *size)
     return written;
 }
 
-TPM_RC
+static TPM_RC
 VolatileState_TailV4_Unmarshal(BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
@@ -3017,7 +3018,7 @@ VolatileState_TailV4_Unmarshal(BYTE **buffer, INT32 *size)
     return rc;
 }
 
-TPM_RC
+static TPM_RC
 VolatileState_TailV3_Unmarshal(BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
@@ -4070,7 +4071,7 @@ skip_future_versions:
 
 #define INDEX_ORDERLY_RAM_VERSION 2
 #define INDEX_ORDERLY_RAM_MAGIC   0x5346feab
-UINT32
+static UINT32
 INDEX_ORDERLY_RAM_Marshal(void *array, size_t array_size,
                           BYTE **buffer, INT32 *size)
 {
@@ -4131,7 +4132,7 @@ INDEX_ORDERLY_RAM_Marshal(void *array, size_t array_size,
     return written;
 }
 
-TPM_RC
+static TPM_RC
 INDEX_ORDERLY_RAM_Unmarshal(void *array, size_t array_size,
                             BYTE **buffer, INT32 *size)
 {
@@ -4279,7 +4280,7 @@ USER_NVRAM_Display(const char *msg)
 
 #define USER_NVRAM_VERSION 2
 #define USER_NVRAM_MAGIC   0x094f22c3
-UINT32
+static UINT32
 USER_NVRAM_Marshal(BYTE **buffer, INT32 *size)
 {
     UINT32 written;
@@ -4368,7 +4369,7 @@ USER_NVRAM_Marshal(BYTE **buffer, INT32 *size)
  * This function fails if there's not enough NVRAM to write the data into
  * or if an unknown handle type was encountered.
  */
-TPM_RC
+static TPM_RC
 USER_NVRAM_Unmarshal(BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;

--- a/src/tpm2/TpmFail.c
+++ b/src/tpm2/TpmFail.c
@@ -508,6 +508,7 @@ TpmFailureMode(
     *outResponse = (unsigned char *)response;
     return;
 }
+#if 0		// libtpms added
 /* 9.17.6 UnmarshalFail() */
 /* This is a stub that is used to catch an attempt to unmarshal an entry that is not defined. Don't
    ever expect this to be called but... */
@@ -523,3 +524,4 @@ UnmarshalFail(
     NOT_REFERENCED(size);
     FAIL(FATAL_ERROR_INTERNAL);
 }
+#endif		// libtpms added

--- a/src/tpm2/Unmarshal_fp.h
+++ b/src/tpm2/Unmarshal_fp.h
@@ -297,6 +297,8 @@ extern "C" {
     TPMI_AES_KEY_BITS_Unmarshal(TPMI_AES_KEY_BITS *target, BYTE **buffer, INT32 *size);
     LIB_EXPORT TPM_RC
     TPMI_CAMELLIA_KEY_BITS_Unmarshal(TPMI_CAMELLIA_KEY_BITS *target, BYTE **buffer, INT32 *size);
+    LIB_EXPORT TPM_RC /* libtpms added */
+    TPMI_TDES_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *size);
     LIB_EXPORT TPM_RC
     TPMU_SYM_KEY_BITS_Unmarshal(TPMU_SYM_KEY_BITS *target, BYTE **buffer, INT32 *size, UINT32 selector);
     LIB_EXPORT TPM_RC

--- a/src/tpm2/Utils.h
+++ b/src/tpm2/Utils.h
@@ -44,7 +44,7 @@
 #define TPM2_ROUNDUP(VAL, SIZE) \
   ( ( (VAL) + (SIZE) - 1) / (SIZE) ) * (SIZE)
 
-static inline void clear_and_free(void *ptr, size_t size) {
+__attribute__((unused)) static inline void clear_and_free(void *ptr, size_t size) {
     if (ptr) {
         MemorySet(ptr, 0, size);
         free(ptr);

--- a/src/tpm_library.c
+++ b/src/tpm_library.c
@@ -65,6 +65,7 @@
 #include "tpm_library.h"
 #include "tpm_library_intern.h"
 #include "tpm_nvfilename.h"
+#include "tpm_tis.h"
 
 static const struct tags_and_indices {
     const char    *starttag;

--- a/src/tpm_tpm12_interface.c
+++ b/src/tpm_tpm12_interface.c
@@ -55,29 +55,29 @@
 #include "tpm12/tpm_permanent.h"
 #include "tpm12/tpm_nvfile.h"
 
-TPM_RESULT TPM12_MainInit(void)
+static TPM_RESULT TPM12_MainInit(void)
 {
     return TPM_MainInit();
 }
 
-void TPM12_Terminate(void)
+static void TPM12_Terminate(void)
 {
     TPM_Global_Delete(tpm_instances[0]);
     free(tpm_instances[0]);
     tpm_instances[0] = NULL;
 }
 
-TPM_RESULT TPM12_Process(unsigned char **respbuffer, uint32_t *resp_size,
-                         uint32_t *respbufsize,
-		         unsigned char *command, uint32_t command_size)
+static TPM_RESULT TPM12_Process(unsigned char **respbuffer, uint32_t *resp_size,
+                                uint32_t *respbufsize,
+                                unsigned char *command, uint32_t command_size)
 {
     *resp_size = 0;
     return TPM_ProcessA(respbuffer, resp_size, respbufsize,
                         command, command_size);
 }
 
-TPM_RESULT TPM12_VolatileAllStore(unsigned char **buffer,
-                                  uint32_t *buflen)
+static TPM_RESULT TPM12_VolatileAllStore(unsigned char **buffer,
+                                         uint32_t *buflen)
 {
     TPM_RESULT rc;
     TPM_STORE_BUFFER tsb;
@@ -102,13 +102,13 @@ TPM_RESULT TPM12_VolatileAllStore(unsigned char **buffer,
     return rc;
 }
 
-TPM_RESULT TPM12_CancelCommand(void)
+static TPM_RESULT TPM12_CancelCommand(void)
 {
     return TPM_FAIL; /* not supported */
 }
 
 
-TPM_RESULT TPM12_GetTPMProperty(enum TPMLIB_TPMProperty prop,
+static TPM_RESULT TPM12_GetTPMProperty(enum TPMLIB_TPMProperty prop,
                                 int *result)
 {
     switch (prop) {
@@ -184,7 +184,7 @@ TPM_RESULT TPM12_GetTPMProperty(enum TPMLIB_TPMProperty prop,
  *
  * Return a JSON document with contents queried for by the user's passed flags
  */
-char *TPM12_GetInfo(enum TPMLIB_InfoFlags flags)
+static char *TPM12_GetInfo(enum TPMLIB_InfoFlags flags)
 {
     const char *tpmspec =
     "\"TPMSpecification\":{"
@@ -240,9 +240,9 @@ error:
 
 static uint32_t tpm12_buffersize = TPM_BUFFER_MAX;
 
-uint32_t TPM12_SetBufferSize(uint32_t wanted_size,
-                             uint32_t *min_size,
-                             uint32_t *max_size)
+static uint32_t TPM12_SetBufferSize(uint32_t wanted_size,
+                                    uint32_t *min_size,
+                                    uint32_t *max_size)
 {
     if (min_size)
         *min_size = TPM_BUFFER_MIN;
@@ -267,8 +267,8 @@ uint32_t TPM12_GetBufferSize(void)
     return TPM12_SetBufferSize(0, NULL, NULL);
 }
 
-TPM_RESULT TPM12_ValidateState(enum TPMLIB_StateType st,
-                               unsigned int flags)
+static TPM_RESULT TPM12_ValidateState(enum TPMLIB_StateType st,
+                                      unsigned int flags)
 {
     TPM_RESULT ret = TPM_SUCCESS;
     tpm_state_t tpm_state;
@@ -367,8 +367,8 @@ static TPM_RESULT TPM_PermanentAll_NVLoad_Preserve(tpm_state_t *tpm_state)
  * it from files. In case the TPM is running, we get it from the running
  * TPM.
  */
-TPM_RESULT TPM12_GetState(enum TPMLIB_StateType st,
-                          unsigned char **buffer, uint32_t *buflen)
+static TPM_RESULT TPM12_GetState(enum TPMLIB_StateType st,
+                                 unsigned char **buffer, uint32_t *buflen)
 {
     TPM_RESULT ret = TPM_FAIL;
     TPM_STORE_BUFFER tsb;
@@ -433,8 +433,8 @@ TPM_RESULT TPM12_GetState(enum TPMLIB_StateType st,
  *          previous state
  * @buflen: length of the buffer
  */
-TPM_RESULT TPM12_SetState(enum TPMLIB_StateType st,
-                          const unsigned char *buffer, uint32_t buflen)
+static TPM_RESULT TPM12_SetState(enum TPMLIB_StateType st,
+                                 const unsigned char *buffer, uint32_t buflen)
 {
     TPM_RESULT ret = TPM_SUCCESS;
     unsigned char *stream = NULL, *orig_stream = NULL;

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -72,7 +72,7 @@ static BOOL      reportedFailureCommand;
 /*
  * Check whether the main NVRAM file exists. Return TRUE if it doesn, FALSE otherwise
  */
-TPM_BOOL _TPM2_CheckNVRAMFileExists(bool *has_nvram_loaddata_callback)
+static TPM_BOOL _TPM2_CheckNVRAMFileExists(bool *has_nvram_loaddata_callback)
 {
 #ifdef TPM_LIBTPMS_CALLBACKS
     struct libtpms_callbacks *cbs = TPMLIB_GetCallbacks();
@@ -97,7 +97,7 @@ TPM_BOOL _TPM2_CheckNVRAMFileExists(bool *has_nvram_loaddata_callback)
     return FALSE;
 }
 
-TPM_RESULT TPM2_MainInit(void)
+static TPM_RESULT TPM2_MainInit(void)
 {
     TPM_RESULT ret = TPM_SUCCESS;
     bool has_cached_state;
@@ -164,16 +164,16 @@ TPM_RESULT TPM2_MainInit(void)
     return ret;
 }
 
-void TPM2_Terminate(void)
+static void TPM2_Terminate(void)
 {
     TPM_TearDown();
 
     _rpc__Signal_PowerOff();
 }
 
-TPM_RESULT TPM2_Process(unsigned char **respbuffer, uint32_t *resp_size,
-                        uint32_t *respbufsize,
-		        unsigned char *command, uint32_t command_size)
+static TPM_RESULT TPM2_Process(unsigned char **respbuffer, uint32_t *resp_size,
+                               uint32_t *respbufsize,
+                               unsigned char *command, uint32_t command_size)
 {
     uint8_t locality = 0;
     _IN_BUFFER req;
@@ -273,8 +273,8 @@ TPM_RESULT TPM2_PersistentAllStore(unsigned char **buf,
     return ret;
 }
 
-TPM_RESULT TPM2_VolatileAllStore(unsigned char **buffer,
-                                 uint32_t *buflen)
+static TPM_RESULT TPM2_VolatileAllStore(unsigned char **buffer,
+                                        uint32_t *buflen)
 {
     TPM_RESULT rc = 0;
     INT32 size = NV_MEMORY_SIZE;
@@ -303,15 +303,15 @@ TPM_RESULT TPM2_VolatileAllStore(unsigned char **buffer,
     return rc;
 }
 
-TPM_RESULT TPM2_CancelCommand(void)
+static TPM_RESULT TPM2_CancelCommand(void)
 {
     _rpc__Signal_CancelOn();
 
     return TPM_SUCCESS;
 }
 
-TPM_RESULT TPM2_GetTPMProperty(enum TPMLIB_TPMProperty prop,
-                               int *result)
+static TPM_RESULT TPM2_GetTPMProperty(enum TPMLIB_TPMProperty prop,
+                                      int *result)
 {
     switch (prop) {
     case  TPMPROP_TPM_RSA_KEY_LENGTH_MAX:
@@ -350,7 +350,7 @@ TPM_RESULT TPM2_GetTPMProperty(enum TPMLIB_TPMProperty prop,
  *
  * Return a JSON document with contents queried for by the user's passed flags
  */
-char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
+static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
 {
     const char *tpmspec =
     "\"TPMSpecification\":{"
@@ -440,9 +440,9 @@ error:
 
 static uint32_t tpm2_buffersize = TPM_BUFFER_MAX;
 
-uint32_t TPM2_SetBufferSize(uint32_t wanted_size,
-                            uint32_t *min_size,
-                            uint32_t *max_size)
+static uint32_t TPM2_SetBufferSize(uint32_t wanted_size,
+                                   uint32_t *min_size,
+                                   uint32_t *max_size)
 {
     const uint32_t min = MAX_CONTEXT_SIZE + 128;
     const uint32_t max = TPM_BUFFER_MAX;
@@ -474,8 +474,8 @@ uint32_t TPM2_GetBufferSize(void)
  * Validate the state blobs to check whether they can be
  * successfully used by a TPM_INIT.
 */
-TPM_RESULT TPM2_ValidateState(enum TPMLIB_StateType st,
-                              unsigned int flags)
+static TPM_RESULT TPM2_ValidateState(enum TPMLIB_StateType st,
+                                     unsigned int flags)
 {
     TPM_RESULT ret = TPM_SUCCESS;
     TPM_RC rc = TPM_RC_SUCCESS;
@@ -537,8 +537,8 @@ TPM_RESULT TPM2_ValidateState(enum TPMLIB_StateType st,
  * it from files. In case the TPM is running, we get it from the running
  * TPM.
  */
-TPM_RESULT TPM2_GetState(enum TPMLIB_StateType st,
-                         unsigned char **buffer, uint32_t *buflen)
+static TPM_RESULT TPM2_GetState(enum TPMLIB_StateType st,
+                                unsigned char **buffer, uint32_t *buflen)
 {
     TPM_RESULT ret = TPM_FAIL;
 
@@ -592,8 +592,8 @@ TPM_RESULT TPM2_GetState(enum TPMLIB_StateType st,
  *          previous state
  * @buflen: length of the buffer
  */
-TPM_RESULT TPM2_SetState(enum TPMLIB_StateType st,
-                         const unsigned char *buffer, uint32_t buflen)
+static TPM_RESULT TPM2_SetState(enum TPMLIB_StateType st,
+                                const unsigned char *buffer, uint32_t buflen)
 {
     TPM_RESULT ret = TPM_SUCCESS;
     TPM_RC rc = TPM_RC_SUCCESS;


### PR DESCRIPTION
Add -Wmissing-prototypes to CFLAGS and make functions static add #include
where necessary.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>