### PR TITLE
tpm2: fix PCRBelongsTCBGroup for PCClient (bugfix) 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms], [0.6.2])
+AC_INIT([libtpms], [0.6.3])
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.6.2
+%define version   0.6.3
 %define release   1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 6
-#define TPM_LIBRARY_VER_MICRO 2
+#define TPM_LIBRARY_VER_MICRO 3
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/PCR.c
+++ b/src/tpm2/PCR.c
@@ -163,12 +163,19 @@ PCRBelongsTCBGroup(
 		   )
 {
 #if ENABLE_PCR_NO_INCREMENT == YES
+#if 0
     // Platform specification decides if a PCR belongs to a TCB group.  In this
     // implementation, we assume PCR[20-22] belong to TCB group.  If the platform
     // specification requires differently, the implementation should be
     // changed accordingly
     if(handle >= 20 && handle <= 22)
 	return TRUE;
+#endif
+    /* kgold - changed for PC Client, 16, 21-23 no increment */
+    if ((handle == 16) ||
+	((handle >= 21) && (handle <= 23))) {
+	return  TRUE;
+    }
 #endif
     return FALSE;
 }

--- a/tests/tpm2_pcr_read.c
+++ b/tests/tpm2_pcr_read.c
@@ -6,6 +6,19 @@
 #include <libtpms/tpm_error.h>
 #include <libtpms/tpm_memory.h>
 
+static void dump_array(const char *h, const unsigned char *d, size_t dlen)
+{
+    size_t i;
+
+    fprintf(stderr, "%s\n", h);
+    for (i = 0; i < dlen; i++) {
+        fprintf(stderr, "%02x ", d[i]);
+        if ((i & 0xf) == 0xf)
+            fprintf(stderr, "\n");
+    }
+    fprintf(stderr, "\n");
+}
+
 int main(void)
 {
     unsigned char *rbuffer = NULL;
@@ -38,7 +51,7 @@ int main(void)
     };
     const unsigned char tpm2_pcr_read_exp_resp[] = {
         0x80, 0x01, 0x00, 0x00, 0x01, 0x86, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x15, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00,
         0x00, 0x04, 0x00, 0x04, 0x03, 0x01, 0x00, 0x10,
         0x00, 0x0b, 0x03, 0x01, 0x00, 0x10, 0x00, 0x0c,
         0x03, 0x01, 0x00, 0x10, 0x00, 0x0d, 0x03, 0x01,
@@ -118,6 +131,8 @@ int main(void)
 
     if (memcmp(rbuffer, tpm2_pcr_read_exp_resp, rlength)) {
         fprintf(stderr, "Expected response is different than received one.\n");
+        dump_array("actual:", rbuffer, rlength);
+        dump_array("expected:", tpm2_pcr_read_exp_resp, sizeof(tpm2_pcr_read_exp_resp));
         goto exit;
     }
 


### PR DESCRIPTION
Fix PCRBelongsTCBGroup by adjusting the set of PCRs that belong to the TCB
Group. The effect of this is that PCR changes to PCR 16 (for example) do
not change the pcrUpdateCounter anymore. The effect *should not* have any
negative side effects when using the TPM.

We also need to update the test cases that now show a different
pcrUpdateCounter in the responses. Also 'swtpm' test cases need
to be fixed to expect the changed result.