### PR TITLE
Prepare for libtpms 0.6.3 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 CHANGES - changes for libtpms
 
+version 0.6.3
+  - Fixed the set of PCRs belonging to the TCB group. This affects the
+    pcrUpdateCounter in TPM2_Pcrread() responses, thus needs latest `swtpm`
+    (master, stable branches) for test cases to succeed there.
+
 version 0.6.2
   - compilation fixes for TPM 1.2 and various architectures and gcc versions
   - Fix support for NIST curves P{192,224,521} and SM2 P256 and BN P648

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtpms (0.6.3-1) RELEASED; urgency=medium
+
+  * Fixed set of PCRs belonging to TCB group
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Fri, 10 July 2020 12:01:00 -0500
+
 libtpms (0.6.2-1) RELEASED; urgency=medium
 
   * Backports and other bugfixes

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Fri Jul 10 2020 Stefan Berger - 0.6.3-1
+- Fixed set of PCRs belonging to TCB group
+
 * Mon May 18 2020 Stefan Berger - 0.6.2-1
 - Backports and other bugfixes
 

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Fri Jul 10 2020 Stefan Berger - 0.6.3-1
+- Fixed set of PCRs belonging to TCB group
+
 * Mon May 18 2020 Stefan Berger - 0.6.2-1
 - Backports and other bugfixes
 


### PR DESCRIPTION
This PR prepares for libtpms 0.6.3 release.