### PR TITLE
Prepare for libtpms 0.7.3 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 CHANGES - changes for libtpms
 
+version 0.7.3
+  - Fixed the set of PCRs belonging to the TCB group. This affects the
+    pcrUpdateCounter in TPM2_Pcrread() responses, thus needs latest `swtpm`
+    (master, stable branches) for test cases to succeed there.
+
 version 0.7.2
   - Fix output buffer parameter and size for RSA decryption that could cause
     stack corruption under certain circumstances

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtpms (0.7.3-1) RELEASED; urgency=medium
+
+  * Fixed set of PCRs belonging to TCB group
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Fri, 10 Jul 2020 12:01:00 -0500
+
 libtpms (0.7.2-1) RELEASE; urgency=high
 
   * Bugfixes related to RSA signing, decryption, and symmetric decryption.

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Fri Jul 10 2020 Stefan Berger - 0.7.3-1
+- Fixed set of PCRs belonging to TCB group
+
 * Wed May 27 2020 Stefan Berger - 0.7.2-1
 - Bugfixes related to RSA signing, decryption, and symmetric decryption.
 

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Fri Jul 10 2020 Stefan Berger - 0.7.3-1
+- Fixed set of PCRs belonging to TCB group
+
 * Wed May 27 2020 Stefan Berger - 0.7.2-1
 - Bugfixes related to RSA signing, decryption, and symmetric decryption.
 


### PR DESCRIPTION
This PR prepares for the libtpms 0.7.3 release.