### PR TITLE
Fix s390x compilation errors on Fedora 32

### DIFF
--- a/src/tpm12/tpm_nvram.c
+++ b/src/tpm12/tpm_nvram.c
@@ -1997,7 +1997,7 @@ TPM_RESULT TPM_Process_NVWriteValue(tpm_state_t *tpm_state,
     TPM_BOOL			done = FALSE;
     TPM_BOOL			dir = FALSE;
     TPM_BOOL			writeAllNV = FALSE;	/* flag to write back NV */
-    TPM_NV_DATA_SENSITIVE	*d1NvdataSensitive;
+    TPM_NV_DATA_SENSITIVE	*d1NvdataSensitive = NULL;
     uint32_t			s1Last;
     TPM_BOOL			physicalPresence;
     TPM_BOOL			isGPIO = FALSE;

--- a/src/tpm2/Marshal.c
+++ b/src/tpm2/Marshal.c
@@ -2256,7 +2256,7 @@ UINT16
 TPM2B_CREATION_DATA_Marshal(TPM2B_CREATION_DATA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    BYTE *sizePtr;
+    BYTE *sizePtr = NULL; // libtpms added for s390x on Fedora 32
 
     if (buffer != NULL) {
 	sizePtr = *buffer;


### PR DESCRIPTION
This series of patches fixes compilation errors on s390x on Fedora 32.