### PR TITLE
Fix s390x compilation errors on Fedora 32

### DIFF
--- a/src/tpm12/tpm_nvram.c
+++ b/src/tpm12/tpm_nvram.c
@@ -1997,7 +1997,7 @@ TPM_RESULT TPM_Process_NVWriteValue(tpm_state_t *tpm_state,
     TPM_BOOL			done = FALSE;
     TPM_BOOL			dir = FALSE;
     TPM_BOOL			writeAllNV = FALSE;	/* flag to write back NV */
-    TPM_NV_DATA_SENSITIVE	*d1NvdataSensitive;
+    TPM_NV_DATA_SENSITIVE	*d1NvdataSensitive = NULL;
     uint32_t			s1Last;
     TPM_BOOL			physicalPresence;
     TPM_BOOL			isGPIO = FALSE;

--- a/src/tpm2/Marshal.c
+++ b/src/tpm2/Marshal.c
@@ -2198,7 +2198,7 @@ UINT16
 TPM2B_CREATION_DATA_Marshal(TPM2B_CREATION_DATA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    BYTE *sizePtr;
+    BYTE *sizePtr = NULL; // libtpms added for s390x on Fedora 32
 
     if (buffer != NULL) {
 	sizePtr = *buffer;

--- a/src/tpm2/Marshal_fp.h
+++ b/src/tpm2/Marshal_fp.h
@@ -228,6 +228,8 @@ extern "C" {
     TPM2B_ATTEST_Marshal(TPM2B_ATTEST *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMI_AES_KEY_BITS_Marshal(TPMI_AES_KEY_BITS *source, BYTE **buffer, INT32 *size);
+    UINT16		// libtpms added
+    TPMI_TDES_KEY_BITS_Marshal(TPMI_TDES_KEY_BITS *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMU_SYM_KEY_BITS_Marshal(TPMU_SYM_KEY_BITS *source, BYTE **buffer, INT32 *size, UINT32 selector);
     UINT16
@@ -262,6 +264,8 @@ extern "C" {
     TPMS_SIG_SCHEME_ECSCHNORR_Marshal(TPMS_SIG_SCHEME_ECSCHNORR *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMS_SIG_SCHEME_ECDAA_Marshal(TPMS_SIG_SCHEME_ECDAA *source, BYTE **buffer, INT32 *size);
+    UINT16		// libtpms added
+    TPMS_SIG_SCHEME_SM2_Marshal(TPMS_SIG_SCHEME_SM2 *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMS_ENC_SCHEME_OAEP_Marshal(TPMS_ENC_SCHEME_OAEP *source, BYTE **buffer, INT32 *size);
     UINT16
@@ -322,6 +326,8 @@ extern "C" {
     TPMS_SIGNATURE_ECDSA_Marshal(TPMS_SIGNATURE_ECDSA *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMS_SIGNATURE_ECDAA_Marshal(TPMS_SIGNATURE_ECDAA *source, BYTE **buffer, INT32 *size);
+    UINT16		// libtpms added
+    TPMS_SIGNATURE_SM2_Marshal(TPMS_SIGNATURE_SM2 *source, BYTE **buffer, INT32 *size);
     UINT16
     TPMS_SIGNATURE_ECSCHNORR_Marshal(TPMS_SIGNATURE_ECSCHNORR *source, BYTE **buffer, INT32 *size);
     UINT16


### PR DESCRIPTION
This series of patches fixes compilation errors on s390x on Fedora 32.