### PR TITLE
tpm2: Fix the returned number in the JSON

### DIFF
--- a/src/tpm2/TpmTypes.h
+++ b/src/tpm2/TpmTypes.h
@@ -317,6 +317,7 @@ typedef  UINT32             TPM_SPEC;
 #define SPEC_FAMILY             0x322E3000
 #define TPM_SPEC_FAMILY         (TPM_SPEC)(SPEC_FAMILY)
 #define SPEC_LEVEL              00
+#define SPEC_LEVEL_NUM          0  // libtpms added: SPEC_LEVEL without leading zeros
 #define TPM_SPEC_LEVEL          (TPM_SPEC)(SPEC_LEVEL)
 #define SPEC_VERSION            162
 #define TPM_SPEC_VERSION        (TPM_SPEC)(SPEC_VERSION)

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -355,7 +355,7 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
     const char *tpmspec =
     "\"TPMSpecification\":{"
         "\"family\":\"2.0\","
-        "\"level\":" STRINGIFY(SPEC_LEVEL) ","
+        "\"level\":" STRINGIFY(SPEC_LEVEL_NUM) ","
         "\"revision\":" STRINGIFY(SPEC_VERSION)
     "}";
     const char *tpmattrs_temp =


### PR DESCRIPTION
The JSON returned by TPM2_GetInfo contains a leading zero in the level.

$> swtpm_ioctl --tcp :10000 --info 1
{"TPMSpecification":{"family":"2.0","level":00,"revision":162+0}}

This patch fixes this to:

$> swtpm_ioctl --tcp :10000 --info 1
{"TPMSpecification":{"family":"2.0","level":0,"revision":162+0}}