### PR TITLE
build-sys: Use AC_LINK_IFELSE to check for understood linker flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -276,13 +276,25 @@ if test "x$enable_hardening" != "xno"; then
 	if test -z "$TMP1" && test -n "$TPM2"; then
 		HARDENING_CFLAGS="$HARDENING_CFLAGS -D_FORTIFY_SOURCE=2 "
 	fi
-	dnl Check ld for 'relro' and 'now'
-	if $LD --help 2>&1 | $GREP '\-z relro ' > /dev/null; then
-		HARDENING_LDFLAGS="$HARDENING_LDFLAGS -Wl,-z,relro "
-	fi
-	if $LD --help 2>&1 | $GREP '\-z now ' > /dev/null; then
-		HARDENING_LDFLAGS="$HARDENING_LDFLAGS -Wl,-z,now "
-	fi
+	dnl Check linker for 'relro' and 'now'
+	save_CFLAGS="$CFLAGS"
+	CFLAGS="-Wl,-z,relro -Werror"
+	AC_MSG_CHECKING([whether linker supports -Wl,-z,relro])
+	AC_LINK_IFELSE(
+		[AC_LANG_SOURCE([[int main() { return 0; }]])],
+		[HARDENING_LDFLAGS="$HARDENING_LDFLAGS -Wl,-z,relro"
+		 AC_MSG_RESULT(yes)],
+		[AC_MSG_RESULT(no)]
+	)
+	CFLAGS="-Wl,-z,now -Werror"
+	AC_MSG_CHECKING([whether linker supports -Wl,-z,now])
+	AC_LINK_IFELSE(
+		[AC_LANG_SOURCE([[int main() { return 0; }]])],
+		[HARDENING_LDFLAGS="$HARDENING_LDFLAGS -Wl,-z,now"
+		 AC_MSG_RESULT(yes)],
+		[AC_MSG_RESULT(no)]
+	)
+	CFLAGS="$save_CFLAGS"
 	AC_SUBST([HARDENING_CFLAGS])
 	AC_SUBST([HARDENING_LDFLAGS])
 fi


### PR DESCRIPTION
Use AC_LINK_IFELSE to check whether linker flags like 'now' and
'relro' are understood or remain unused (= useless), and only add them
to the set of HARDENING_LDFLAGS, if they are used by the linker. clang
for example does not seem to use them and Cygwin's linker does not
understand them.

Note: This patch merely improves on the handling of these flags but does
not solve a compilation issue when clang is used, unlike swtpm where
this created issues.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>