### PR TITLE
debian: Fix typo in changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-litpmss (0.7.4) RELEASED; urgency=medium
+libtpms (0.7.4) RELEASED; urgency=medium
 
   * Addressed potential constant-time issues in TPM 1.2 and TPM 2 code
 


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>