### PR TITLE
tpm2: Address issues detected by cppcheck (false positives)

### DIFF
--- a/src/tpm2/Session.c
+++ b/src/tpm2/Session.c
@@ -406,8 +406,11 @@ SessionCreate(
 		}
 	}
     // if no spot found, then this is an internal error
-    if(slotIndex >= MAX_LOADED_SESSIONS)
+    if(slotIndex >= MAX_LOADED_SESSIONS) {		// libtpms changed
 	FAIL(FATAL_ERROR_INTERNAL);
+	// should never get here due to longjmp	in FAIL()  libtpms added begin; cppcheck
+	return TPM_RC_FAILURE;
+    }							// libtpms added end
     // Call context ID function to get a handle.  TPM_RC_SESSION_HANDLE may be
     // returned from ContextIdHandelAssign()
     result = ContextIdSessionCreate(sessionHandle, slotIndex);
@@ -572,6 +575,12 @@ SessionContextLoad(
 	if(s_sessions[slotIndex].occupied == FALSE) break;
     // if no spot found, then this is an internal error
     pAssert(slotIndex < MAX_LOADED_SESSIONS);
+    // libtpms: besides the s_freeSessionSlots guard add another array index guard
+    if (slotIndex >= MAX_LOADED_SESSIONS) {	// libtpms added begin; cppcheck
+	FAIL(FATAL_ERROR_INTERNAL);
+	// should never get here due to longjmp	in FAIL()
+	return TPM_RC_FAILURE;
+    }						// libtpms added end
     contextIndex = *handle & HR_HANDLE_MASK;   // extract the index
     // If there is only one slot left, and the gap is at maximum, the only session
     // context that we can safely load is the oldest one.


### PR DESCRIPTION
cppcheck has detected the following issues in 2 functions. However,
neither one of the out-of-bounds array access can happen with the
existing code (see comments in patch).

src/tpm2/Session.c:399:5: note: After for loop, slotIndex has value 3
    for(slotIndex = 0; slotIndex < MAX_LOADED_SESSIONS; slotIndex++)
    ^
src/tpm2/Session.c:414:15: note: Assuming condition is false
    if(result != TPM_RC_SUCCESS)
              ^
src/tpm2/Session.c:419:15: note: Array index out of bounds
    s_sessions[slotIndex].occupied = TRUE;
              ^
src/tpm2/Session.c:591:27: error: Array 's_sessions[3]' accessed at index 3, which is out of bounds. [arrayIndexOutOfBounds]
    MemoryCopy(&s_sessions[slotIndex].session, session, sizeof(SESSION));
                          ^
src/tpm2/Session.c:571:5: note: After for loop, slotIndex has value 3
    for(slotIndex = 0; slotIndex < MAX_LOADED_SESSIONS; slotIndex++)
    ^
src/tpm2/Session.c:581:8: note: Assuming condition is false
       && contextIndex != s_oldestSavedSession)
       ^
src/tpm2/Session.c:591:27: note: Array index out of bounds
    MemoryCopy(&s_sessions[slotIndex].session, session, sizeof(SESSION));
                          ^

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>