### PR TITLE
tpm2: Support compile-time enablement of HLK compliance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,6 +304,17 @@ if test "x$enable_hardening" != "xno"; then
 	AC_SUBST([HARDENING_LDFLAGS])
 fi
 
+AC_ARG_ENABLE([hlk-compliance],
+  AS_HELP_STRING([--enable-hlk-compliance],
+                 [Build libtpms in such a way that it will pass certain HLK TPM 2 tests; default is 'disabled']),
+                 [],
+                 [enable_hlk_compliance=no])
+AS_IF([test "x$enable_hlk_compliance" != "xno"], [
+	CFLAGS="$CFLAGS -DTPM2_HLK_COMPLIANCE=1"
+], [
+	CFLAGS="$CFLAGS -DTPM2_HLK_COMPLIANCE=0"
+])
+
 CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign"
 CFLAGS="$CFLAGS -Wmissing-prototypes"
 LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"

--- a/src/tpm2/crypto/openssl/CryptEccMain.c
+++ b/src/tpm2/crypto/openssl/CryptEccMain.c
@@ -855,6 +855,10 @@ CryptEccIsCurveRuntimeUsable(
 			     TPMI_ECC_CURVE curveId
 			    )
 {
+#if TPM2_HLK_COMPLIANCE
+    if (curveId == TPM_ECC_NIST_P521) /* make HLK 2004 happy; FIXME: remove once NIST P521 accepted */
+	return FALSE;
+#endif
     CURVE_INITIALIZED(E, curveId);
     if (E == NULL)
 	return FALSE;


### PR DESCRIPTION
Some HLK 2004 tests will fail if the NIST P521 curve is supported
by the TPM 2. This patch allows to compile-time disable this.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>