### PR TITLE
Extend API to support dynamic selection of HLK compliance

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,12 @@ version 0.8.0
   - Fixes to symmetric decrytion related to input size check,
     defer padding to the user [EVP_CIPHER_CTX_set_padding(ctx, 0)] and
     to always use a temporary malloc'ed buffer for decryption
+  - Extended API to support setting and clearing of flags that modify the behavior
+    of libtpms to for example be HLK compliant
+  - New API calls:
+    - TPMLIB_ClearFlags
+    - TPMLIB_GetFlags
+    - TPMLIB_SetFlags
 
 version 0.7.0
   - use OpenSSL crypto for AES, TDES, EC, and RSA operations when possible

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -166,6 +166,12 @@ TPM_RESULT TPMLIB_SetState(enum TPMLIB_StateType st,
 TPM_RESULT TPMLIB_GetState(enum TPMLIB_StateType st,
                            unsigned char **buffer, uint32_t *buflen);
 
+TPM_RESULT TPMLIB_SetFlags(uint64_t flags_to_set);
+TPM_RESULT TPMLIB_ClearFlags(uint64_t flags_to_clear);
+uint64_t TPMLIB_GetFlags(uint64_t *supported_flags);
+
+#define TPMLIB_FLAG_HLK_COMPLIANCE  (1 << 0)
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libtpms/tpm_library.h.in
+++ b/include/libtpms/tpm_library.h.in
@@ -166,6 +166,12 @@ TPM_RESULT TPMLIB_SetState(enum TPMLIB_StateType st,
 TPM_RESULT TPMLIB_GetState(enum TPMLIB_StateType st,
                            unsigned char **buffer, uint32_t *buflen);
 
+TPM_RESULT TPMLIB_SetFlags(uint64_t flags_to_set);
+TPM_RESULT TPMLIB_ClearFlags(uint64_t flags_to_clear);
+uint64_t TPMLIB_GetFlags(uint64_t *supported_flags);
+
+#define TPMLIB_FLAG_HLK_COMPLIANCE  (1 << 0)
+
 #ifdef __cplusplus
 }
 #endif

--- a/man/man3/Makefile.am
+++ b/man/man3/Makefile.am
@@ -10,6 +10,7 @@ man3_PODS = \
 	TPM_IO_TpmEstablished_Get.pod \
 	TPMLIB_CancelCommand.pod \
 	TPMLIB_ChooseTPMVersion.pod \
+	TPMLIB_ClearFlags.pod \
 	TPMLIB_DecodeBlob.pod \
 	TPMLIB_GetInfo.pod \
 	TPMLIB_GetTPMProperty.pod \
@@ -28,9 +29,11 @@ man3_MANS = \
 	TPM_Free.3 \
 	TPM_IO_Hash_Data.3 \
 	TPM_IO_Hash_End.3 \
+	TPMLIB_GetFlags.3 \
 	TPMLIB_GetState.3 \
 	TPMLIB_SetDebugPrefix.3 \
 	TPMLIB_SetDebugLevel.3 \
+	TPMLIB_SetFlags.3 \
 	TPM_IO_TpmEstablished_Reset.3 \
 	TPMLIB_Terminate.3 \
 	TPM_Realloc.3
@@ -40,6 +43,7 @@ man3_MANS_generated = \
 	TPM_IO_TpmEstablished_Get.3 \
 	TPMLIB_CancelCommand.3 \
 	TPMLIB_ChooseTPMVersion.3 \
+	TPMLIB_ClearFlags.3 \
 	TPMLIB_DecodeBlob.3 \
 	TPMLIB_GetInfo.3 \
 	TPMLIB_GetTPMProperty.3 \

--- a/man/man3/TPMLIB_ClearFlags.pod
+++ b/man/man3/TPMLIB_ClearFlags.pod
@@ -1,0 +1,70 @@
+=head1 NAME
+
+TPMLIB_ClearFlags   - Clear flags (since v0.8.0)
+
+TPMLIB_GetFlags     - Get supported and set flags (since v0.8.0)
+
+TPMLIB_SetFlags     - Set flags (since v0.8.0)
+
+=head1 LIBRARY
+
+TPM library (libtpms, -ltpms)
+
+=head1 SYNOPSIS
+
+B<#include> <libtpms/tpm_library.h>
+
+B<TPM_RESULT TPMLIB_ClearFlags(uint64_t flags_to_clear);>
+
+B<uint64_t TPMLIB_GetFlags(uint64_t *supported_flags);>
+
+B<TPM_RESULT TPMLIB_SetFlags(uint64_t flags_to_set);>
+
+=head1 DESCRIPTION
+
+This set of API calls allows to set and get flags that influcence
+the behavior of libtpms.
+
+B<TPMLIB_ClearFlags> can be used to clear currently set flags. Some flags
+may only be cleared at a certain time relative to other calls, such as
+B<TPMLIB_MainInit>.
+
+B<TPMLIB_GetFlags> returns the currently set flags. The I<supported_flags>
+parameter is optional and returns the set of flags supported by this
+version of libtpms if a non-NULL pointer is passed.
+
+B<TPMLIB_SetFlags> allows to set flags. Some flags may only be set at
+certain time relative to other calls, such as B<TPMLIB_MainInit>.
+
+The following flags are supported:
+
+=over 4
+
+=item B<TPMLIB_FLAG_HLK_COMPLIANCE>
+
+This flag modifies the behavior of the TPM 2 code so that HLK tests
+(of a certain version) are passing while they would fail if this flag was
+not set. This flag can be set and cleared at any time.
+
+=back
+
+=head1 ERRORS
+
+=over 4
+
+=item B<TPM_SUCCESS>
+
+The function completed successfully.
+
+=item B<TPM_FAIL>
+
+General failure indicating that the flag is not supported or cannot
+currently be modified.
+
+=back
+
+=head1 SEE ALSO
+
+B<TPMLIB_MainInit>(3)
+
+=cut

--- a/man/man3/TPMLIB_GetFlags.3
+++ b/man/man3/TPMLIB_GetFlags.3
@@ -1,0 +1,1 @@
+.so man3/TPMLIB_ClearFlags.3

--- a/man/man3/TPMLIB_SetFlags.3
+++ b/man/man3/TPMLIB_SetFlags.3
@@ -1,0 +1,1 @@
+.so man3/TPMLIB_ClearFlags.3

--- a/src/libtpms.syms
+++ b/src/libtpms.syms
@@ -37,3 +37,12 @@ LIBTPMS_0.6.0 {
     local:
 	*;
 } LIBTPMS_0.5.1;
+
+LIBTPMS_0.8.0 {
+    global:
+	TPMLIB_ClearFlags;
+	TPMLIB_GetFlags;
+	TPMLIB_SetFlags;
+    local:
+        *;
+} LIBTPMS_0.6.0;

--- a/src/tpm2/crypto/openssl/CryptEccMain.c
+++ b/src/tpm2/crypto/openssl/CryptEccMain.c
@@ -64,6 +64,7 @@
 #include "Tpm.h"
 #include "Helpers_fp.h"                // libtpms added
 #include "TpmToOsslMath_fp.h"          // libtpms added
+#include "tpm_library.h"               // libtpms added
 #if ALG_ECC
 /* This version requires that the new format for ECC data be used */
 #if !USE_BN_ECC_DATA
@@ -855,6 +856,13 @@ CryptEccIsCurveRuntimeUsable(
 			     TPMI_ECC_CURVE curveId
 			    )
 {
+    uint64_t flags = TPMLIB_GetFlags(NULL);
+
+    if (flags & TPMLIB_FLAG_HLK_COMPLIANCE) {  /* make HLK 2004 happy; FIXME: remove once NIST P521 accepted */
+        if (curveId == TPM_ECC_NIST_P521)
+            return FALSE;
+    }
+
     CURVE_INITIALIZED(E, curveId);
     if (E == NULL)
 	return FALSE;

--- a/src/tpm_library.c
+++ b/src/tpm_library.c
@@ -95,6 +95,8 @@ static struct sized_buffer cached_blobs[TPMLIB_STATE_SAVE_STATE + 1];
 static int tpmvers_choice = 0; /* default is TPM1.2 */
 static TPM_BOOL tpmvers_locked = FALSE;
 
+static uint64_t TPMLIB_Flags;
+
 uint32_t TPMLIB_GetVersion(void)
 {
     return TPM_LIBRARY_VERSION;
@@ -666,4 +668,31 @@ enum TPMLIB_StateType TPMLIB_NameToStateType(const char *name)
     if (!strcmp(name, TPM_SAVESTATE_NAME))
         return TPMLIB_STATE_SAVE_STATE;
     return 0;
+}
+
+TPM_RESULT TPMLIB_SetFlags(uint64_t flags_to_set)
+{
+    uint64_t supported_flags;
+
+    TPMLIB_GetFlags(&supported_flags);
+    if (flags_to_set & ~supported_flags)
+        return TPM_FAIL;
+
+    TPMLIB_Flags |= flags_to_set;
+
+    return TPM_SUCCESS;
+}
+
+TPM_RESULT TPMLIB_ClearFlags(uint64_t flags_to_clear)
+{
+    TPMLIB_Flags &= ~flags_to_clear;
+
+    return TPM_SUCCESS;
+}
+
+uint64_t TPMLIB_GetFlags(uint64_t *supported_flags)
+{
+    if (supported_flags)
+        *supported_flags = TPMLIB_FLAG_HLK_COMPLIANCE;
+    return TPMLIB_Flags;
 }


### PR DESCRIPTION
This PR extends the API to support a dynamic selection of HLK compliance (certain tests otherwise run into issues with NIST P521 curve if it is supported by a TPM 2). New API calls allow to set, get, and clear flags. One new flag is defined that handles the HLK compliance.