### PR TITLE
tpm2: Return properly sized array for b parameter for NIST P521 (HLK)

### DIFF
--- a/src/tpm2/crypto/openssl/CryptEccMain.c
+++ b/src/tpm2/crypto/openssl/CryptEccMain.c
@@ -413,8 +413,8 @@ CryptEccGetParameters(
 	    parameters->sign = curve->sign;
 	    /* BnTo2B(data->prime, &parameters->p.b, 0); */
 	    BnTo2B(data->prime, &parameters->p.b, parameters->p.t.size);
-	    BnTo2B(data->a, &parameters->a.b, 0);
-	    BnTo2B(data->b, &parameters->b.b, 0);
+	    BnTo2B(data->a, &parameters->a.b, parameters->p.t.size /* libtpms changed for HLK */);
+	    BnTo2B(data->b, &parameters->b.b, parameters->p.t.size /* libtpms changed for HLK */);
 	    BnTo2B(data->base.x, &parameters->gX.b, parameters->p.t.size);
 	    BnTo2B(data->base.y, &parameters->gY.b, parameters->p.t.size);
 	    BnTo2B(data->order, &parameters->n.b, 0);


### PR DESCRIPTION
This patch ensures that the leading zeros in the b parameter for NIST P521
are being kept so that HLK accepts the return parameters. Now 66 bytes are
reported for 'b' rather than only 65. Do the same for the 'a' parameter,
though that one was properly reported already because it didn't have any
leading zeros.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>