### PR TITLE
This PR addresses a few Coverity scan detected issues which are mostl false positives

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -4173,6 +4173,7 @@ INDEX_ORDERLY_RAM_Unmarshal(void *array, size_t array_size,
     }
 
     while (rc == TPM_RC_SUCCESS) {
+        memset(&nrh, 0, sizeof(nrh)); /* coverity */
         /* nrhp may point to misaligned address (ubsan)
          * we read 'into' nrh and copy to nrhp at end
          */
@@ -4188,7 +4189,7 @@ INDEX_ORDERLY_RAM_Unmarshal(void *array, size_t array_size,
 
         if (rc == TPM_RC_SUCCESS) {
             rc = UINT32_Unmarshal(&nrh.size, buffer, size);
-            if (nrh.size == 0) {
+            if (rc == TPM_RC_SUCCESS && nrh.size == 0) {
                 memcpy(nrhp, &nrh, sizeof(nrh.size));
                 break;
             }

--- a/src/tpm2/crypto/openssl/CryptCmac.c
+++ b/src/tpm2/crypto/openssl/CryptCmac.c
@@ -121,6 +121,7 @@ CryptCmacData(
     tpmCryptKeySchedule_t    keySchedule;
     TpmCryptSetSymKeyCall_t  encrypt;
     //
+    memset(&keySchedule, 0, sizeof(keySchedule)); /* libtpms added: coverity */
     SELECT(ENCRYPT);
     while(size > 0)
 	{
@@ -157,6 +158,7 @@ CryptCmacEnd(
     TPM2B_IV                 subkey = {{0, {0}}};
     BOOL                     xorVal;
     UINT16                   i;
+    memset(&keySchedule, 0, sizeof(keySchedule)); /* libtpms added: coverity */
     subkey.t.size = cState->iv.t.size;
     // Encrypt a block of zero
     SELECT(ENCRYPT);

--- a/src/tpm2/crypto/openssl/CryptRand.c
+++ b/src/tpm2/crypto/openssl/CryptRand.c
@@ -363,6 +363,7 @@ DRBG_Update(
     DRBG_KEY            *key = pDRBG_KEY(&drbgState->seed);
     DRBG_IV             *iv = pDRBG_IV(&drbgState->seed);
     DRBG_KEY_SCHEDULE    localKeySchedule;
+    memset(&localKeySchedule, 0, sizeof(localKeySchedule)); /* libtpms added: coverity */
     //
     pAssert(drbgState->magic == DRBG_MAGIC);
     // If an key schedule was not provided, make one
@@ -783,6 +784,7 @@ DRBG_Generate(
 	    DRBG_STATE          *drbgState = (DRBG_STATE *)state;
 	    DRBG_KEY_SCHEDULE    keySchedule;
 	    DRBG_SEED           *seed = &drbgState->seed;
+	    memset(&keySchedule, 0, sizeof(keySchedule)); /* libtpms added: coverity */
 	    if(drbgState->reseedCounter >= CTR_DRBG_MAX_REQUESTS_PER_RESEED)
 		{
 		    if(drbgState == &drbgDefault)

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -703,7 +703,8 @@ CryptSymmetricDecrypt(
 
     pAssert((int)buffersize >= outlen1);
 
-    if (EVP_DecryptFinal(ctx, &buffer[outlen1], &outlen2) != 1)
+    if ((int)buffersize <= outlen1 /* coverity */ ||
+        EVP_DecryptFinal(ctx, &buffer[outlen1], &outlen2) != 1)
         ERROR_RETURN(TPM_RC_FAILURE);
 
     pAssert((int)buffersize >= outlen1 + outlen2);

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -414,7 +414,6 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
                      tpmfeatures, "%s%s%s") < 0)
             goto error;
         free(fmt);
-        free(tpmfeatures);
         printed = true;
     }
 
@@ -426,6 +425,7 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
 
     free(fmt);
     free(tpmattrs);
+    free(tpmfeatures);
 
     return buffer;
 


### PR DESCRIPTION
Coverity seems to have gotten a bit more picky since its last run. Many of the detected issues are false positive. The double-free is very unlikely to occur since it happens only if an error branch is taken. See patch description.