### PR TITLE
debian: Add missing pkg-config to debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,8 @@ Build-Depends:
  dh-exec,
  gawk,
  libssl-dev,
- libtool
+ libtool,
+ pkg-config
 
 Package: libtpms0
 Architecture: any


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>