### PR TITLE
CryptSym: fix AES output IV and prepare for 0.7.7 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 CHANGES - changes for libtpms
 
+version 0.7.7
+ - CryptSym: fix AES output IV
+   A CVE has been filed for this bugfix. Unfortunately multi-step encrypted
+   data won't decrypt anymore but are now compatible with other TPM 2 devices.
+
 version 0.7.6
   - tpm2: Fix public key context save due to ANY_OBJECT_Marshal usage
     This fixes a suspend/resume problem when public keys are

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms], [0.7.6])
+AC_INIT([libtpms], [0.7.7])
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,7 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 	AC_CHECK_LIB([crypto], [EVP_aes_128_cbc],, not_found=1)
 	AC_CHECK_LIB([crypto], [EVP_des_ede3_cbc],, not_found=1)
 	AC_CHECK_LIB([crypto], [DES_random_key],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_iv],, not_found=1)
 	if test "x$not_found" = "x0"; then
 		use_openssl_functions_symmetric=1
 		use_openssl_functions_for="symmetric (AES, TDES) "

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtpms (0.7.7) RELEASED; urgency=high
+
+  * tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Mon, 01 Mar 2021 11:31:00 -0500
+
 libtpms (0.7.6) RELEASED; urgency=medium
 
   * Fixed a suspend/resume problem when public keys are loaded

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Mon Mar 01 2021 Stefan Berger - 0.7.7-1
+- tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
+
 * Fri Deb 26 2021 Stefan Berger - 0.7.6-1
 - Fixed a suspend/resume problem when public keys are loaded
 - Addressed Coverity issues

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.7.6
+%define version   0.7.7
 %define release   0
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Mon Mar 01 2021 Stefan Berger - 0.7.7-1
+- tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
+
 * Fri Deb 26 2021 Stefan Berger - 0.7.6-1
 - Fixed a suspend/resume problem when public keys are loaded
 - Addressed Coverity issues

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 7
-#define TPM_LIBRARY_VER_MICRO 6
+#define TPM_LIBRARY_VER_MICRO 7
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -531,6 +531,7 @@ CryptSymmetricEncrypt(
     BYTE                 keyToUse[MAX_SYM_KEY_BYTES];
     UINT16               keyToUseLen = (UINT16)sizeof(keyToUse);
     TPM_RC               retVal = TPM_RC_SUCCESS;
+    int                  ivLen;
 
     pAssert(dOut != NULL && key != NULL && dIn != NULL);
     if(dSize == 0)
@@ -595,6 +596,14 @@ CryptSymmetricEncrypt(
     if (EVP_EncryptFinal_ex(ctx, pOut + outlen1, &outlen2) != 1)
         ERROR_RETURN(TPM_RC_FAILURE);
 
+    if (ivInOut) {
+        ivLen = EVP_CIPHER_CTX_iv_length(ctx);
+        if (ivLen < 0 || (size_t)ivLen > sizeof(ivInOut->t.buffer))
+            ERROR_RETURN(TPM_RC_FAILURE);
+
+        ivInOut->t.size = ivLen;
+        memcpy(ivInOut->t.buffer, EVP_CIPHER_CTX_iv(ctx), ivInOut->t.size);
+    }
  Exit:
     if (retVal == TPM_RC_SUCCESS && pOut != dOut)
         memcpy(dOut, pOut, outlen1 + outlen2);
@@ -636,6 +645,7 @@ CryptSymmetricDecrypt(
     BYTE                 keyToUse[MAX_SYM_KEY_BYTES];
     UINT16               keyToUseLen = (UINT16)sizeof(keyToUse);
     TPM_RC               retVal = TPM_RC_SUCCESS;
+    int                  ivLen;
 
     // These are used but the compiler can't tell because they are initialized
     // in case statements and it can't tell if they are always initialized
@@ -707,6 +717,15 @@ CryptSymmetricDecrypt(
         ERROR_RETURN(TPM_RC_FAILURE);
 
     pAssert((int)buffersize >= outlen1 + outlen2);
+
+    if (ivInOut) {
+        ivLen = EVP_CIPHER_CTX_iv_length(ctx);
+        if (ivLen < 0 || (size_t)ivLen > sizeof(ivInOut->t.buffer))
+            ERROR_RETURN(TPM_RC_FAILURE);
+
+        ivInOut->t.size = ivLen;
+        memcpy(ivInOut->t.buffer, EVP_CIPHER_CTX_iv(ctx), ivInOut->t.size);
+    }
 
  Exit:
     if (retVal == TPM_RC_SUCCESS) {


### PR DESCRIPTION
- This PR fixes the AES output IV.
- Prepares for the 0.7.7 release.