### PR TITLE
CryptSym: fix AES output IV and prepare for 0.8.2 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 CHANGES - changes for libtpms
 
+version 0.8.2
+ - CryptSym: fix AES output IV
+   A CVE has been filed for this bugfix. Unfortunately multi-step encrypted
+   data won't decrypt anymore but are now compatible with other TPM 2 devices.
+
 version 0.8.1
   - tpm2: Fix public key context save due to ANY_OBJECT_Marshal usage
     This also fixed a context save and suspend/resume problem when public keys

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms], [0.8.1])
+AC_INIT([libtpms], [0.8.2])
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/configure.ac
+++ b/configure.ac
@@ -173,6 +173,7 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 	AC_CHECK_LIB([crypto], [EVP_des_ede3_cbc],, not_found=1)
 	AC_CHECK_LIB([crypto], [EVP_camellia_128_cbc],, not_found=1)
 	AC_CHECK_LIB([crypto], [DES_random_key],, not_found=1)
+	AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_iv],, not_found=1)
 	if test "x$not_found" = "x0"; then
 		use_openssl_functions_symmetric=1
 		use_openssl_functions_for="symmetric (AES, TDES) "

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtpms (0.8.2) RELEASED; urgency=high
+
+  * tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Mon, 01 Mar 2021 11:25:00 -0500
+
 libtpms (0.8.1) RELEASED; urgency=medium
 
   * Fixed a context save and suspend/resume problem when public keys are loaded

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Mon Mar 01 2021 Stefan Berger - 0.8.2-1
+- tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
+
 * Fri Feb 26 2021 Stefan Berger - 0.8.1-1
 - Fixed a context save and suspend/resume problem when public keys are loaded
 

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.8.1
+%define version   0.8.2
 %define release   1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Mon Mar 01 2021 Stefan Berger - 0.8.2-1
+- tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
+
 * Fri Feb 26 2021 Stefan Berger - 0.8.1-1
 - Fixed a context save and suspend/resume problem when public keys are loaded
 

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 8
-#define TPM_LIBRARY_VER_MICRO 1
+#define TPM_LIBRARY_VER_MICRO 2
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))


### PR DESCRIPTION
- This PR fixes the AES output IV.
- Prepares for the 0.8.2 release.
