### PR TITLE
Fix many misspellings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,7 +10,7 @@ version 0.8.0
     possible to downgrade from libtpms version 0.8.0 to some previous version.
     The seeds are now associated with an age so that older seeds use the old
     TPM 2 prime number generation code while newer seed use the newer code.
-  - Update to TPM 2 code relase 162
+  - Update to TPM 2 code release 162
     - ECC encryption / decryption is disabled
   - Fix support for elliptic curve due to missing unmarshalling code
   - Runtime filter supported elliptic curves supported by OpenSSL

--- a/INSTALL
+++ b/INSTALL
@@ -111,7 +111,7 @@ ldd /usr/lib/libtpms.so   or  ldd /usr/lib64/libtpms.so
 	/lib64/ld-linux-x86-64.so.2 (0x0000003a1c000000)
 
 The fact that the libraries libgmp, libnspr4, libnssutil3, libnss3,
-libpc4, and libplds4 are linked agaist is an indication that the freebl
+libpc4, and libplds4 are linked against is an indication that the freebl
 library was used for linking.
 
 In case of openssl's libcrypto the output would be the following:

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -193,7 +193,7 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 - Adding LICENSE, README and CHANGELOG file into tar ball and main rpm
 - Removing clean section
 - removed command to clean the build root
-- adding library version to the libries required for building and during
+- adding library version to the libraries required for building and during
   runtime
 - Extended Requires in devel package with {?_isa}
 

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -193,7 +193,7 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 - Adding LICENSE, README and CHANGELOG file into tar ball and main rpm
 - Removing clean section
 - removed command to clean the build root
-- adding library version to the libries required for building and during
+- adding library version to the libraries required for building and during
   runtime
 - Extended Requires in devel package with {?_isa}
 

--- a/man/man3/TPMLIB_DecodeBlob.pod
+++ b/man/man3/TPMLIB_DecodeBlob.pod
@@ -43,7 +43,7 @@ See I<TPMLIB_RegisterCallbacks>(3).
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_SIZE>
 

--- a/man/man3/TPMLIB_GetTPMProperty.pod
+++ b/man/man3/TPMLIB_GetTPMProperty.pod
@@ -77,8 +77,8 @@ The number of delegate entries.
 
 =item B<TPMPROP_TPM_SPACE_SAFETY_MARGIN>
 
-The space saftey margin used for the worst-case sizes of the savestate and
-volatile state blobs. This safety marging is not used for the size of the
+The space safety margin used for the worst-case sizes of the savestate and
+volatile state blobs. This safety margin is not used for the size of the
 permanent data blob.
 
 =item B<TPMPROP_TPM_MAX_NV_SPACE>
@@ -102,7 +102,7 @@ margin).
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_FAIL>
 

--- a/man/man3/TPMLIB_MainInit.pod
+++ b/man/man3/TPMLIB_MainInit.pod
@@ -40,7 +40,7 @@ portable format.
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_FAIL>
 

--- a/man/man3/TPMLIB_Process.pod
+++ b/man/man3/TPMLIB_Process.pod
@@ -30,7 +30,7 @@ The I<respbuffer> is a pointer to a buffer where the TPM will return its
 result. If no buffer is given (I<respbuffer> is NULL), the TPM will
 allocate a buffer. The parameter I<resp_size> returns the number of valid
 TPM response bytes in the buffer. The number of valid bytes in the response
-is guranteed to not exceed the maximum I/O buffer size. Use the
+is guaranteed to not exceed the maximum I/O buffer size. Use the
 I<TPMLIB_GetTPMProperty()> API and parameter I<TPMPROP_TPM_BUFFER_MAX> for
 getting the maximum size.
 The user must indicate the size of a provided buffer with the I<respbufsize>
@@ -45,7 +45,7 @@ as explained for I<TPM_Malloc()>.
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_FAIL>
 

--- a/man/man3/TPMLIB_RegisterCallbacks.pod
+++ b/man/man3/TPMLIB_RegisterCallbacks.pod
@@ -136,7 +136,7 @@ The I<tpm_number> is always 0 and can be ignored.
 The I<name> parameter is either one of B<TPM_SAVESTATE_NAME>,
 B<TPM_VOLATILESTATE_NAME>, or B<TPM_PERMANENT_ALL_NAME> and indicates
 which one of the 3 types of state is supposed to be deleted.
-The I<mustExist> parameter indicates wheteher the given data must exist
+The I<mustExist> parameter indicates whether the given data must exist
 and the implementing function should return B<TPM_FAIL> if the data did
 not exist.
 
@@ -193,7 +193,7 @@ an error value otherwise.
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_FAIL>
 

--- a/man/man3/TPMLIB_ValidateState.pod
+++ b/man/man3/TPMLIB_ValidateState.pod
@@ -29,7 +29,7 @@ migration.
 The B<tpmlib_state> parameter can be a logical 'or' of one or
 multiple of of the following: B<TPMLIB_STATE_PERMANENT>,
 B<TPMLIB_STATE_VOLATILE>, or B<TPMLIB_STATE_SAVE_STATE>.
-The B<flags> parameter is curretnly not used and should be set to 0.
+The B<flags> parameter is currently not used and should be set to 0.
 
 The first state blob that should be loaded is the permanent state,
 since for example the volatile state requires it to be available

--- a/man/man3/TPMLIB_VolatileAll_Store.pod
+++ b/man/man3/TPMLIB_VolatileAll_Store.pod
@@ -27,7 +27,7 @@ the number of bytes of state information in the I<buflen> variable.
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_FAIL>
 

--- a/man/man3/TPM_IO_Hash_Start.pod
+++ b/man/man3/TPM_IO_Hash_Start.pod
@@ -49,7 +49,7 @@ caller.
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_FAIL>
 

--- a/man/man3/TPM_IO_TpmEstablished_Get.pod
+++ b/man/man3/TPM_IO_TpmEstablished_Get.pod
@@ -34,7 +34,7 @@ flag.
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_FAIL>
 

--- a/man/man3/TPM_Malloc.pod
+++ b/man/man3/TPM_Malloc.pod
@@ -32,7 +32,7 @@ the buffer is given in the I<size> parameter. The reallocated buffer will
 contain the data from the original buffer.
 
 Both functions have the restriction that the buffer they can allocate
-is limited to B<TPM_ALLOC_MAX> (64k) bytes. This size is sufficent
+is limited to B<TPM_ALLOC_MAX> (64k) bytes. This size is sufficient
 for all buffers needed by the TPM.
 
 Upon successful completion, the functions return B<TPM_SUCCESS>. In case the
@@ -48,7 +48,7 @@ either B<TPM_Malloc()> or B<TPM_Realloc()>.
 
 =item B<TPM_SUCCESS>
 
-The function completed sucessfully.
+The function completed successfully.
 
 =item B<TPM_SIZE>
 

--- a/src/tpm12/tpm_constants.h
+++ b/src/tpm12/tpm_constants.h
@@ -847,7 +847,7 @@
                                               indicates that the asymmetric algorithm is not
                                               supported for these types of commands. The TPM MAY
                                               return TRUE or FALSE for other than asymmetric
-                                              algoroithms that it supports. Unassigned and
+                                              algorithms that it supports. Unassigned and
                                               unsupported algorithm IDs return FALSE.*/
 
 #define TPM_CAP_PID             0x00000003 /* Boolean value. TRUE indicates that the TPM supports

--- a/src/tpm12/tpm_crypto_freebl.c
+++ b/src/tpm12/tpm_crypto_freebl.c
@@ -1927,7 +1927,7 @@ TPM_RESULT TPM_Sha1Context_Load(void **context,
 	/* sanity check that the freebl library and TPM structure here are in sync */
 	if (flattenSize != sizeof(SHA1SaveContextStr)) {
 	    printf("TPM_Sha1Context_Load: Error, "
-		   "SHA1 context size %u from SHA1_FlattenSize not equal %lu from struture\n",
+		   "SHA1 context size %u from SHA1_FlattenSize not equal %lu from structure\n",
 		   flattenSize, (unsigned long)sizeof(SHA1SaveContextStr));
 	    rc = TPM_BAD_PARAM_SIZE;
 	}
@@ -2005,7 +2005,7 @@ TPM_RESULT TPM_Sha1Context_Store(TPM_STORE_BUFFER *sbuffer,
 	/* sanity check that the freebl library and TPM structure here are in sync */
 	if (flattenSize != sizeof(SHA1SaveContextStr)) {
 	    printf("TPM_Sha1Context_Store: Error (fatal), "
-		   "SHA1 context size %u from SHA1_FlattenSize not equal %lu from struture\n",
+		   "SHA1 context size %u from SHA1_FlattenSize not equal %lu from structure\n",
 		   flattenSize, (unsigned long)sizeof(SHA1SaveContextStr));
 	    rc = TPM_FAIL;
 	}

--- a/src/tpm12/tpm_nvram.c
+++ b/src/tpm12/tpm_nvram.c
@@ -2291,7 +2291,7 @@ TPM_RESULT TPM_Process_NVWriteValue(tpm_state_t *tpm_state,
 	    if (!d1NvdataSensitive->pubInfo.bWriteDefine) {	/* save wearout, only write if
 								   FALSE */
 		d1NvdataSensitive->pubInfo.bWriteDefine = TRUE;
-		/* must write TPM_PERMANENT_DATA back to NVRAM, set this flag after strucuture is
+		/* must write TPM_PERMANENT_DATA back to NVRAM, set this flag after structure is
 		   written */
 		writeAllNV = TRUE;
 	    }
@@ -2328,7 +2328,7 @@ TPM_RESULT TPM_Process_NVWriteValue(tpm_state_t *tpm_state,
 			/* d. Write the new value into the NV storage area */
 			memcpy((d1NvdataSensitive->data) + offset, data.buffer, data.size);
 			/* must write TPM_PERMANENT_DATA back to NVRAM, set this flag after
-			   strucuture is written */
+			   structure is written */
 			writeAllNV = TRUE;
 		    }
 		    else {
@@ -2675,7 +2675,7 @@ TPM_RESULT TPM_Process_NVWriteValueAuth(tpm_state_t *tpm_state,
 	    if (!d1NvdataSensitive->pubInfo.bWriteDefine) {	/* save wearout, only write if
 								   FALSE */
 		d1NvdataSensitive->pubInfo.bWriteDefine = TRUE;
-		/* must write TPM_PERMANENT_DATA back to NVRAM, set this flag after strucuture is
+		/* must write TPM_PERMANENT_DATA back to NVRAM, set this flag after structure is
 		   written */
 		writeAllNV = TRUE;
 	    }
@@ -2712,7 +2712,7 @@ TPM_RESULT TPM_Process_NVWriteValueAuth(tpm_state_t *tpm_state,
 			printf("TPM_Process_NVWriteValueAuth: Copying data\n");
 			memcpy((d1NvdataSensitive->data) + offset, data.buffer, data.size);
 			/* must write TPM_PERMANENT_DATA back to NVRAM, set this flag after
-			   strucuture is written */
+			   structure is written */
 			writeAllNV = TRUE;
 		    }
 		    else {
@@ -2977,7 +2977,7 @@ TPM_RESULT TPM_Process_NVDefineSpace(tpm_state_t *tpm_state,
 	}
 	else {
 	    /* b. Set TPM_PERMANENT_FLAGS -> nvLocked to TRUE */
-	    /* writeAllNV set to TRUE if nvLocked is beng set, not if already set */
+	    /* writeAllNV set to TRUE if nvLocked is being set, not if already set */
 	    printf("TPM_Process_NVDefineSpace: Setting nvLocked\n");
 	    TPM_SetCapability_Flag(&writeAllNV,					/* altered */
 				   &(tpm_state->tpm_permanent_flags.nvLocked ), /* flag */
@@ -3121,7 +3121,7 @@ TPM_RESULT TPM_Process_NVDefineSpace(tpm_state_t *tpm_state,
 	    foundOld = TRUE;
 	}
 	else if (returnCode == TPM_BADINDEX) {
-	    returnCode = TPM_SUCCESS;	/* non-existant index is not an error */
+	    returnCode = TPM_SUCCESS;	/* non-existent index is not an error */
 	    foundOld = FALSE;
 	    printf("TPM_Process_NVDefineSpace: Index %08x is new\n", newNVIndex);
 	}

--- a/src/tpm12/tpm_owner.c
+++ b/src/tpm12/tpm_owner.c
@@ -1093,7 +1093,7 @@ TPM_RESULT TPM_OwnerClearCommon(tpm_state_t *tpm_state,
 	    TPM_NVDataSensitive_Delete(tpm_nv_data_sensitive);
 	}
 	else if (rc == TPM_BADINDEX) {
-	    rc = TPM_SUCCESS;	/* non-existant index is not an error */
+	    rc = TPM_SUCCESS;	/* non-existent index is not an error */
 	}
     }
 #endif

--- a/src/tpm12/tpm_process.c
+++ b/src/tpm12/tpm_process.c
@@ -3764,7 +3764,7 @@ static TPM_RESULT TPM_GetCapability_CapOrd(TPM_STORE_BUFFER *capabilityResponse,
    Boolean value. TRUE means that the TPM supports the asymmetric algorithm for TPM_Sign, TPM_Seal,
    TPM_UnSeal and TPM_UnBind and related commands. FALSE indicates that the asymmetric algorithm is
    not supported for these types of commands. The TPM MAY return TRUE or FALSE for other than
-   asymmetric algoroithms that it supports. Unassigned and unsupported algorithm IDs return FALSE.
+   asymmetric algorithms that it supports. Unassigned and unsupported algorithm IDs return FALSE.
 */
 
 static TPM_RESULT TPM_GetCapability_CapAlg(TPM_STORE_BUFFER *capabilityResponse,

--- a/src/tpm12/tpm_startup.c
+++ b/src/tpm12/tpm_startup.c
@@ -538,7 +538,7 @@ TPM_RESULT TPM_VolatileAll_Store(TPM_STORE_BUFFER *sbuffer,
 
    If the file does not exist (a normal startup), returns success.
 
-   0 on success or non-existant file
+   0 on success or non-existent file
    TPM_FAIL on failure to load (fatal), since it should never occur
 */
 

--- a/src/tpm12/tpm_structures.h
+++ b/src/tpm12/tpm_structures.h
@@ -903,7 +903,7 @@ typedef struct tdTPM_PUBKEY {
 #error "TPM_KEY_HANDLES must be less than 0x10000"
 #endif
 
-/* The TPM does not have to support any minumum number of owner evict keys.  Adjust this value to
+/* The TPM does not have to support any minimum number of owner evict keys.  Adjust this value to
    match the amount of NV space available.  An owner evict key consumes about 512 bytes.
 
    A value greater than (TPM_KEY_HANDLES - 2) is useless, as the TPM reserves 2 key slots for
@@ -1154,7 +1154,7 @@ typedef struct tdTPM_FAMILY_TABLE_ENTRY {
 #endif
     TPM_FAMILY_LABEL familyLabel;       /* A sequence number that software can map to a string of
                                            bytes that can be displayed of used by the applications.
-                                           This MUST not contain sensitive informations. */
+                                           This MUST not contain sensitive information. */
     TPM_FAMILY_ID familyID;             /* The family ID in use to tie values together. This is not
                                            a sensitive value. */
     TPM_FAMILY_VERIFICATION verificationCount;  /* The value inserted into delegation rows to
@@ -1874,7 +1874,7 @@ typedef struct tdTPM_STANY_FLAGS {
 
 #ifdef TPM_MIN_COUNTERS
 #if (TPM_MIN_COUNTERS < 4)
-#error "TPM_MIN_COUNTERS minumum is 4"
+#error "TPM_MIN_COUNTERS minimum is 4"
 #endif
 #endif
 

--- a/src/tpm2/Clock.c
+++ b/src/tpm2/Clock.c
@@ -216,7 +216,7 @@ _plat__TimerRead(
 		 )
 {
 #ifdef HARDWARE_CLOCK
-#error      "need a defintion for reading the hardware clock"
+#error      "need a definition for reading the hardware clock"
     return HARDWARE_CLOCK
 #else
     clock64_t         timeDiff;

--- a/src/tpm2/CryptUtil.c
+++ b/src/tpm2/CryptUtil.c
@@ -1042,7 +1042,7 @@ CryptGetSignHashAlg(
 #if ALG_ECC
 	    // If ECC is defined, ECDSA is mandatory
 #   ifndef  TPM_ALG_ECDSA
-#       error "ECDSA is requried for ECC"
+#       error "ECDSA is required for ECC"
 #   endif
 	  case TPM_ALG_ECDSA:
 	    // SM2 and ECSCHNORR are optional

--- a/src/tpm2/Entity.c
+++ b/src/tpm2/Entity.c
@@ -502,6 +502,6 @@ EntityGetHierarchy(
 	    break;
 	}
     // this is unreachable but it provides a return value for the default
-    // case which makes the complier happy
+    // case which makes the compiler happy
     return hierarchy;
 }

--- a/src/tpm2/Global.h
+++ b/src/tpm2/Global.h
@@ -490,7 +490,7 @@ typedef UINT32           NV_REF;
 typedef BYTE            *NV_RAM_REF;
 
 /* 5.9.8.3	NV_PIN */
-/* This structure deals with the possible endianess differences between the canonical form of the
+/* This structure deals with the possible endianness differences between the canonical form of the
    TPMS_NV_PIN_COUNTER_PARAMETERS structure and the internal value. The structures allow the data in
    a PIN index to be read as an 8-octet value using NvReadUINT64Data(). That function will byte swap
    all the values on a little endian system. This will put the bytes with the 4-octet values in the
@@ -864,7 +864,7 @@ typedef struct orderly_data
 #endif // ACCUMULATE_SELF_HEAL_TIMER
 
 #ifndef __ACT_DISABLED	// libtpms added
-#error ACT not suported in ORDERLY_DATA!
+#error ACT not supported in ORDERLY_DATA!
     // These are the ACT Timeout values. They are saved with the other timers
 #define DefineActData(N)  ACT_STATE      ACT_##N;
     FOR_EACH_ACT(DefineActData)

--- a/src/tpm2/HierarchyCommands.c
+++ b/src/tpm2/HierarchyCommands.c
@@ -240,7 +240,7 @@ TPM2_SetPrimaryPolicy(
     if(in->authPolicy.t.size != CryptHashGetDigestSize(in->hashAlg))
 	return TPM_RCS_SIZE + RC_SetPrimaryPolicy_authPolicy;
     // The command need NV update for OWNER and ENDORSEMENT hierarchy, and
-    // might need orderlyState update for PLATFROM hierarchy.
+    // might need orderlyState update for PLATFORM hierarchy.
     // Check if NV is available.  A TPM_RC_NV_UNAVAILABLE or TPM_RC_NV_RATE
     // error may be returned at this point
     RETURN_IF_NV_IS_NOT_AVAILABLE;

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -146,7 +146,7 @@ block_skip_write_pop(block_skip *bs, INT32 *size) {
 /*
  * This function must be called when unmarshalling a byte stream and
  * a compile-time optional block follows. In case the compile-time
- * optinal block is there but not in the byte stream, we log an error.
+ * optional block is there but not in the byte stream, we log an error.
  * In case the bytes stream contains the block, but we don't need it
  * we skip it. In the other cases we don't need to do anything since
  * the code is 'in sync' with the byte stream.
@@ -2939,7 +2939,7 @@ VolatileState_Marshal(BYTE **buffer, INT32 *size)
 
     written += UINT64_Marshal(&s_maxCounter, buffer, size); /* line 992 */
     /* the following need not be written; NvIndexCacheInit initializes them partly
-     * and NvIndexCacheInit() is alled during ExecuteCommand()
+     * and NvIndexCacheInit() is called during ExecuteCommand()
      * - s_cachedNvIndex
      * - s_cachedNvRef
      * - s_cachedNvRamRef
@@ -3758,7 +3758,7 @@ UINT32_Unmarshal_CheckConstant(BYTE **buffer, INT32 *size, UINT32 constant,
             break;
         }
         if (op) {
-            TPMLIB_LogTPM2Error("Unexpect value for %s; "
+            TPMLIB_LogTPM2Error("Unexpected value for %s; "
                                 "its value %d is not %s %d; "
                                 "(version: %u)\n",
                                 name, value, op, constant,
@@ -4259,7 +4259,7 @@ INDEX_ORDERLY_RAM_Unmarshal(void *array, size_t array_size,
     }
     if (rc == TPM_RC_SUCCESS) {
         /* get the size of the array on the source side
-           we can accomodate different sizes when rebuilding
+           we can accommodate different sizes when rebuilding
            but if it doesn't fit we'll error out and report the sizes */
         rc = UINT32_Unmarshal(&sourceside_size, buffer, size);
     }

--- a/src/tpm2/RunCommand.c
+++ b/src/tpm2/RunCommand.c
@@ -64,7 +64,7 @@
 /* This module provides the platform specific entry and fail processing. The _plat__RunCommand()
    function is used to call to ExecuteCommand() in the TPM code. This function does whatever
    processing is necessary to set up the platform in anticipation of the call to the TPM including
-   settup for error processing. */
+   setup for error processing. */
 /* The _plat__Fail() function is called when there is a failure in the TPM. The TPM code will have
    set the flag to indicate that the TPM is in failure mode. This call will then recursively call
    ExecuteCommand() in order to build the failure mode response. When ExecuteCommand() returns to

--- a/src/tpm2/crypto/openssl/BnValues.h
+++ b/src/tpm2/crypto/openssl/BnValues.h
@@ -258,7 +258,7 @@ typedef struct
 #define CurveGetG(C)        ((pointConst)&((C)->base))
 #define CurveGetGx(C)       ((C)->base.x)
 #define CurveGetGy(C)       ((C)->base.y)
-/* Convert bytes in initializers according to the endianess of the system. This is used for
+/* Convert bytes in initializers according to the endianness of the system. This is used for
    CryptEccData.c. */
 #define     BIG_ENDIAN_BYTES_TO_UINT32(a, b, c, d)			\
     (    ((UINT32)(a) << 24)						\
@@ -288,7 +288,7 @@ typedef struct
 #endif
 
 /* These macros are used for data initialization of big number ECC constants These two macros
-   combine a macro for data definition with a macro for structure initilization. The a parameter is
+   combine a macro for data definition with a macro for structure initialization. The a parameter is
    a macro that gives numbers to each of the bytes of the initializer and defines where each of the
    numberd bytes will show up in the final structure. The b value is a structure that contains the
    requisite number of bytes in big endian order. S, the MJOIN and JOIND macros will combine a macro

--- a/src/tpm2/crypto/openssl/CryptPrime.c
+++ b/src/tpm2/crypto/openssl/CryptPrime.c
@@ -412,7 +412,7 @@ BnGeneratePrimeForRSA(
     while(!found)
 	{
 	    // The change below is to make sure that all keys that are generated from the same
-	    // seed value will be the same regardless of the endianess or word size of the CPU.
+	    // seed value will be the same regardless of the endianness or word size of the CPU.
 	    //       DRBG_Generate(rand, (BYTE *)prime->d, (UINT16)BITS_TO_BYTES(bits));// old
 	    //       if(g_inFailureMode)                                                // old
 	// libtpms changed begin

--- a/src/tpm2/crypto/openssl/CryptPrimeSieve.c
+++ b/src/tpm2/crypto/openssl/CryptPrimeSieve.c
@@ -338,7 +338,7 @@ PrimeSieve(
 		    // only contains odd numbers and our stride is actually 2 * stride. If the
 		    // quoitent is even, then that means that when we add 2 * stride, we are going
 		    // to hit another even number. So, we have to know if we need to back off
-		    // by 1 stride before we start couting by 2 * stride.
+		    // by 1 stride before we start counting by 2 * stride.
 		    // We can tell from the remainder whether we are on an even or odd
 		    // stride when we hit the beginning of the table. If we are on an odd stride
 		    // (r & 1), we would start half a stride in (next - r)/2. If we are on an

--- a/src/tpm2/crypto/openssl/TpmToOsslHash.h
+++ b/src/tpm2/crypto/openssl/TpmToOsslHash.h
@@ -141,7 +141,7 @@ typedef const BYTE    *PCBYTE;
     (&(((BYTE *)(to))[offsetof(HASH_STATE, state)]),			\
      &(hashStateFrom)->state,						\
      (hashStateFrom)->def->contextSize)
-/* Copy from an external blob to an internal formate (with reformatting when necessary */
+/* Copy from an external blob to an internal format (with reformatting when necessary) */
 #define  HASH_STATE_IMPORT_METHOD_DEF					\
     void (HASH_STATE_IMPORT_METHOD)(PANY_HASH_STATE to,			\
 				    const BYTE *from,			\

--- a/src/tpm_library_conf.h
+++ b/src/tpm_library_conf.h
@@ -85,7 +85,7 @@
 #define TPM_OWNER_EVICT_KEY_HANDLES      10            /* PA, BAL */
 
 /*
- * The largets auth session is DSAP; each such session consumes 119 bytes
+ * The largest auth session is DSAP; each such session consumes 119 bytes
  */
 #define TPM_MIN_AUTH_SESSIONS            16            /* SS, VA, BAL */
 

--- a/tests/nvram_offsets.c
+++ b/tests/nvram_offsets.c
@@ -14,7 +14,7 @@ int main(void)
 #define PD_PP_LIST_EXP_SIZE 14
     if (sizeof(pd.ppList) != PD_PP_LIST_EXP_SIZE) {
         fprintf(stderr,
-                "sizeof(PERSISTENT_DATA.ppList) does not have expecte size "
+                "sizeof(PERSISTENT_DATA.ppList) does not have expected size "
                 "of %u bytes but %zu bytes\n",
                 PD_PP_LIST_EXP_SIZE, sizeof(pd.ppList));
         return EXIT_FAILURE;
@@ -24,7 +24,7 @@ int main(void)
 #define PD_AUDIT_COMMANDS_EXP_SIZE 14
     if (sizeof(pd.auditCommands) != PD_AUDIT_COMMANDS_EXP_SIZE) {
         fprintf(stderr,
-                "sizeof(PERSISTENT_DATA.auditCommands) does not have expecte size "
+                "sizeof(PERSISTENT_DATA.auditCommands) does not have expected size "
                 "of %u bytes but %zu bytes\n",
                 PD_AUDIT_COMMANDS_EXP_SIZE, sizeof(pd.auditCommands));
         return EXIT_FAILURE;
@@ -60,7 +60,7 @@ int main(void)
      * NVRAM fits on all architectures
      */
 #if RSA_4096
-# error Unsuported RSA key size
+# error Unsupported RSA key size
 #elif RSA_3072
 # define OBJECT_EXP_SIZE 2600
 #elif RSA_2048


### PR DESCRIPTION
When testing downgrading from libtpms 0.8 to 0.7 (which is not possible), the error message which is reported is:

    libtpms/tpm2: Unexpect value for MAX_RSA_KEY_BITS; its value 3072 is
    not = 2048; (version: 2).

`codespell` (https://github.com/codespell-project/codespell) reports a misspelling for "Unexpect", which should be "Unexpected". As the project contains many more misspellings in comments, error messages and documentation, fix all misspellings reported by `codespell`.