### PR TITLE
tpm2: Surround all occurrences of BLOCK_SKIP_READ() with tests of 'rc'

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -1366,8 +1366,10 @@ skip_alg_ecc:
                                              buffer, size, "nullSeed");
         }
 
-        BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
-                        "STATE_RESET_DATA", "version 4 or later");
+        if (rc == TPM_RC_SUCCESS) {
+            BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
+                            "STATE_RESET_DATA", "version 4 or later");
+        }
         /* future versions nest-append here */
     }
 
@@ -2490,8 +2492,10 @@ skip_alg_rsa:
                                         "OBJECT seedCompatLevel");
         }
 
-        BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
-                        "OBJECT", "version 4 or later");
+        if (rc == TPM_RC_SUCCESS) {
+            BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
+                            "OBJECT", "version 4 or later");
+        }
         /* future versions nest-append here */
     }
 
@@ -3563,16 +3567,20 @@ skip_hardware_clock:
     if (rc == TPM_RC_SUCCESS && hdr.version >= 2) {
         BLOCK_SKIP_READ(skip_future_versions, hdr.version >= 3, buffer, size,
                         "Volatile State", "version 3 or later");
-        rc = VolatileState_TailV3_Unmarshal(buffer, size);
-
-        BLOCK_SKIP_READ(skip_future_versions, hdr.version >= 4, buffer, size,
-                        "Volatile State", "version 4 or later");
+        if (rc == TPM_RC_SUCCESS) {
+            rc = VolatileState_TailV3_Unmarshal(buffer, size);
+        }
+        if (rc == TPM_RC_SUCCESS) {
+            BLOCK_SKIP_READ(skip_future_versions, hdr.version >= 4, buffer, size,
+                            "Volatile State", "version 4 or later");
+        }
         if (rc == TPM_RC_SUCCESS) {
             rc = VolatileState_TailV4_Unmarshal(buffer, size);
         }
-
-        BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
-                        "Volatile State", "version 5 or later");
+        if (rc == TPM_RC_SUCCESS) {
+            BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
+                            "Volatile State", "version 5 or later");
+        }
         /* future versions append here */
     }
 
@@ -4140,10 +4148,14 @@ skip_num_policy_pcr_group:
     if (rc == TPM_RC_SUCCESS && hdr.version >= 2) {
         BLOCK_SKIP_READ(skip_future_versions, hdr.version >= 3, buffer, size,
                         "PERSISTENT_DATA", "version 3 or later");
-        rc = TPML_PCR_SELECTION_Unmarshal(&shadow.pcrAllocated, buffer, size);
+        if (rc == TPM_RC_SUCCESS) {
+            rc = TPML_PCR_SELECTION_Unmarshal(&shadow.pcrAllocated, buffer, size);
+        }
 
-        BLOCK_SKIP_READ(skip_future_versions, hdr.version >= 4, buffer, size,
-                        "PERSISTENT_DATA", "version 4 or later");
+        if (rc == TPM_RC_SUCCESS) {
+            BLOCK_SKIP_READ(skip_future_versions, hdr.version >= 4, buffer, size,
+                            "PERSISTENT_DATA", "version 4 or later");
+        }
 
         if (rc == TPM_RC_SUCCESS) {
             rc = SEED_COMPAT_LEVEL_Unmarshal(&data->EPSeedCompatLevel,
@@ -4158,8 +4170,10 @@ skip_num_policy_pcr_group:
                                              buffer, size, "PPSeed");
         }
 
-        BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
-                        "PERSISTENT_DATA", "version 5 or later");
+        if (rc == TPM_RC_SUCCESS) {
+            BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
+                            "PERSISTENT_DATA", "version 5 or later");
+        }
         /* future versions nest-append here */
     }
 


### PR DESCRIPTION
Do not call BLOCK_SKIP_READ once rc has been set to any error value.
Therefore, surround all occurrences of BLOCK_SKIP_READ() with tests
of 'rc'.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>