### PR TITLE
tpm2: Switch to UINT16 for CONTEXT_SLOT and 64k context gap

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 CHANGES - changes for libtpms
 
+version 0.9.0:
+  - NOTE: Downgrade to previous versions is not possible. See below.
+  - The size of the context gap has been adjusted to 0xffff from 0xff.
+    As a consequence of this the volatile state's format (STATE_RESET_DATA)
+    has changed and cannot be downgraded.
+
 version 0.8.0
   - NOTE: Downgrade to previous versions is not possible. See below.
   - Update to TPM 2 code release 159

--- a/src/tpm2/Global.h
+++ b/src/tpm2/Global.h
@@ -996,6 +996,28 @@ typedef struct state_reset_data
 } STATE_RESET_DATA;
 EXTERN STATE_RESET_DATA gr;
 
+										// libtpms added begin
+/* The s_ContextSlotMask masks CONTEXT_SLOT values; this variable can have
+ * only two valid values, 0xff or 0xffff. The former is used to simulate
+ * a CONTEXT_SLOT defined as UINT8, the latter is used for the CONTEXT_SLOT
+ * when it is a UINT16. The original TPM 2 code uses a cast to CONTEXT_SLOT
+ * to truncate larger values and has been modified to use CONTEXT_SLOT_MASKED
+ * to achieve the same effect with the above two values.
+ *
+ * Using CONTEXT_SLOT_MASKED we make sure that when we write values into
+ * gr.contextArray that these values are properly masked/truncated so that
+ * when we read values from gr.contextArray that we don't have to mask
+ * them again.
+ *
+ * s_ContextSlotMask may only be initialized to 0xff when resuming an older
+ * state from the time when CONTEXT_SLOT was UINT8, otherwise it must be set
+ * to 0xffff. We set it to 0xffff in SessionStartup(SU_CLEAR) and to be
+ * able to save the TPM state really early (and restore it) also in
+ * TPM_Manufacture().
+ */
+EXTERN CONTEXT_SLOT s_ContextSlotMask;
+#define CONTEXT_SLOT_MASKED(val) ((CONTEXT_SLOT)(val) & s_ContextSlotMask)	// libtpms added end
+
 /* 5.9.12 NV Layout */
 /* The NV data organization is */
 /* a) a PERSISTENT_DATA structure */

--- a/src/tpm2/Manufacture.c
+++ b/src/tpm2/Manufacture.c
@@ -86,6 +86,9 @@ TPM_Manufacture(
 		)
 {
     TPM_SU          orderlyShutdown;
+
+    // Initialize the context slot mask for UINT16
+    s_ContextSlotMask = 0xffff;	// libtpms added
 #if RUNTIME_SIZE_CHECKS
     // Call the function to verify the sizes of values that result from different
     // compile options.

--- a/src/tpm2/PropertyCap.c
+++ b/src/tpm2/PropertyCap.c
@@ -185,7 +185,10 @@ TPMPropertyIsDefined(
 	  case TPM_PT_CONTEXT_GAP_MAX:
 	    // maximum allowed difference (unsigned) between the contextID
 	    // values of two saved session contexts
+#if 0
 	    *value = ((UINT32)1 << (sizeof(CONTEXT_SLOT) * 8)) - 1;
+#endif
+	    *value = s_ContextSlotMask; // libtpms added; the mask is either 0xff (old state) or 0xffff
 	    break;
 	  case TPM_PT_NV_COUNTERS_MAX:
 	    // maximum number of NV indexes that are allowed to have the

--- a/src/tpm2/TpmProfile.h
+++ b/src/tpm2/TpmProfile.h
@@ -219,7 +219,7 @@
 #define MAX_ACTIVE_SESSIONS             64
 #endif
 #ifndef CONTEXT_SLOT
-#define CONTEXT_SLOT                    UINT8   /* libtpms: use 'old' type */
+#define CONTEXT_SLOT                    UINT16   /* libtpms: changed from UINT8 in v0.9.0 */
 #endif
 #ifndef MAX_LOADED_SESSIONS
 #define MAX_LOADED_SESSIONS             3


### PR DESCRIPTION
This patch addresses issue #209.

The context gap for libtpms is currently only 0xff due to the CONTEXT_SLOT
being a UINT8. To extend this to 0xffff, we need to define the CONTEXT_SLOT
as UINT16 and introduce a global variable s_ContextArrayMask that takes on
two valid values, 0xff for simulating the CONTEXT_SLOT when it was UINT8
and 0xffff for usage with the new CONTEXT_SLOT of type UINT16. All
occurrences of casts to CONTEXT_SLOT are replaced with a macro
CONTEXT_SLOT_MASKED that applies this mask to a value instead of using the
cast. We also use it for some calculations to avoid spilling over from
1 byte into 2 bytes for example. The cast with the new code is the same as
applying the mask 0xffff, and using the 0xff mask we can simulate the old
CONTEXT_SLOT (1 byte), which we need for seamlessly resuming old state. We
switch from the 0xff mask to the 0xffff mask when the TPM is reset.

There's one place where the s_ContextArrayMask is initialized to 0xff, and
this is when we resume 'old' STATE_RESET_DATA. The places where it is
intialized to 0xffff are in TPM_Manufacture() and
TPM_SessionStartup(SU_CLEAR), both of which are not called after resuming
state.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>