### PR TITLE
build-sys: leave CFLAGS/LDFLAGS for user to be defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -305,9 +305,11 @@ if test "x$enable_hardening" != "xno"; then
 	AC_SUBST([HARDENING_LDFLAGS])
 fi
 
-CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign"
-CFLAGS="$CFLAGS -Wmissing-prototypes"
-LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
+AM_CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign -Wmissing-prototypes"
+AM_LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
+
+AC_SUBST([AM_CFLAGS])
+AC_SUBST([AM_LDFLAGS])
 
 AC_CONFIG_FILES(Makefile                   \
 		dist/libtpms.spec          \
@@ -330,10 +332,10 @@ if test -z "$with_tpm2"; then
 fi
 
 echo
-echo "CFLAGS=$CFLAGS"
+echo "AM_CFLAGS=$AM_CFLAGS"
 echo "HARDENING_CFLAGS=$HARDENING_CFLAGS"
 echo "HARDENING_LDFLAGS=$HARDENING_LDFLAGS"
-echo "LDFLAGS=$LDFLAGS"
+echo "AM_LDFLAGS=$AM_LDFLAGS"
 echo
 echo "Version to build        : $PACKAGE_VERSION"
 echo "Crypto library          : $cryptolib"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,17 +4,19 @@
 # For the license, see the LICENSE file in the root directory.
 #
 
+AM_CFLAGS = @AM_CFLAGS@
+AM_LDFLAGS = @AM_LDFLAGS@ $(HARDENING_LDFLAGS) $(SANITIZERS) $(FUZZER) 
+
 lib_LTLIBRARIES=libtpms.la
 
 common_CFLAGS = -include tpm_library_conf.h \
                 -I$(top_srcdir)/include/libtpms \
 		-I$(top_builddir)/include/libtpms \
+		$(AM_CFLAGS) \
                 $(HARDENING_CFLAGS) \
                $(SANITIZERS) \
                $(FUZZER)
 
-
-LDFLAGS += $(HARDENING_LDFLAGS) $(SANITIZERS) $(FUZZER)
 
 #
 # TPM1.2
@@ -576,16 +578,16 @@ libtpms_la_SOURCES = \
 libtpms_la_CFLAGS = $(common_CFLAGS)
 
 libtpms_la_LDFLAGS = -version-info $(LIBTPMS_VERSION_INFO) \
-                     -no-undefined
+                     -no-undefined $(AM_LDFLAGS)
 
 if HAVE_VERSION_SCRIPT
 libtpms_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libtpms.syms
 endif
 
-LDFLAGS_ARCH  = $(findstring -m32, $(CFLAGS))
-LDFLAGS_ARCH += $(findstring -m64, $(CFLAGS))
-LDFLAGS_ARCH += $(findstring -m32, $(LDFLAGS))
-LDFLAGS_ARCH += $(findstring -m64, $(LDFLAGS))
+LDFLAGS_ARCH  = $(findstring -m32, $(AM_CFLAGS))
+LDFLAGS_ARCH += $(findstring -m64, $(AM_CFLAGS))
+LDFLAGS_ARCH += $(findstring -m32, $(AM_LDFLAGS))
+LDFLAGS_ARCH += $(findstring -m64, $(AM_LDFLAGS))
 
 check-local: SHELL?="/usr/bin/env bash"
 check-local:


### PR DESCRIPTION
This allows user to set specific flags during compilation, without
overriding configure-time cflags necessary for compilation.

See also:
https://www.gnu.org/software/automake/manual/html_node/User-Variables.html
https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>