### PR TITLE
Travis: Install libjson-glib-dev and drop a few python dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,7 @@ matrix:
          sudo rm -rf /dev/tpm* &&
          sudo apt -y install devscripts equivs python3-twisted expect
            libtasn1-dev socat findutils gnutls-dev gnutls-bin tss2
-           python3-setuptools python3-cryptography python3-pip &&
-         pip3 install --upgrade pip &&
-         pip3 install --upgrade wheel &&
-         pip3 install --upgrade cryptography &&
+           python3-setuptools libjson-glib-dev &&
          ./autogen.sh --with-gnutls --prefix=/usr &&
          export SWTPM_TEST_EXPENSIVE=1 SWTPM_TEST_IBMTSS2=1 &&
          sudo make -j$(nproc) check &&
@@ -75,10 +72,7 @@ matrix:
          sudo rm -rf /dev/tpm* &&
          sudo apt -y install devscripts equivs python3-twisted expect
            libtasn1-dev socat findutils gnutls-dev gnutls-bin tss2
-           python3-setuptools python3-cryptography python3-pip &&
-         pip3 install --upgrade pip &&
-         pip3 install --upgrade wheel &&
-         pip3 install --upgrade cryptography &&
+           python3-setuptools libjson-glib-dev &&
          ./autogen.sh --with-gnutls --prefix=/usr &&
          export SWTPM_TEST_EXPENSIVE=1 SWTPM_TEST_IBMTSS2=1 &&
          sudo make -j$(nproc) check &&


### PR DESCRIPTION
Since swtpm_setup has been rewritten in 'C' now we can drop a few
python dependencies but need libjson-glib-dev as a new dependency
for testing with swtpm's master branch.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>