### PR TITLE
tpm2: Consume padding bytes in TPM2_ContextLoad() (Win2k19, issue #217)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@ version 0.9.0:
   - The size of the context gap has been adjusted to 0xffff from 0xff.
     As a consequence of this the volatile state's format (STATE_RESET_DATA)
     has changed and cannot be downgraded.
+  - Applied work-around for Win 2016 & 2019 server related to
+    TPM2_ContextLoad (issue #217)
 
 version 0.8.0
   - NOTE: Downgrade to previous versions is not possible. See below.


### PR DESCRIPTION
Windows 2019 Server padds the TPM_ContextLoad() command with additional
bytes up to TPM_PT_MAX_OBJECT_CONTEXT for the TPMS_CONTEXT part. Since
libtpms does not use an OBJECT to serialize the keys (anymore) it now
uses less bytes than the MAXimum of TPM_PT_MAX_OBJECT_CONTEXT bytes and
the padding leaves some unconsumed bytes that end up failing the command
since no left-over bytes are allowed in any command.

When unconsumed bytes are left in TPMS_CONTEXT_Unmarshal() we check that
the original passed in size was that of TPM_PT_MAX_OBJECT_CONTEXT and
only then consume the additional padding bytes. Luckily only one command
calls TPMS_CONTEXT_Unmarshal() so that no unwanted side effects should
occur anywhere else, such as no bytes left for unmarshalling the next
structure.

The wisdom behind the padding is not quite clear but it feels like
ill-fixing the code to work around a Windows 2019 server bug...

This patch fixes issed #217

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>