### PR TITLE
Apply work-around for Windows 2016 and 2019 server bug and prepare for 0.8.3 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,7 @@ matrix:
          sudo rm -rf /dev/tpm* &&
          sudo apt -y install devscripts equivs python3-twisted expect
            libtasn1-dev socat findutils gnutls-dev gnutls-bin tss2
-           python3-setuptools python3-cryptography python3-pip &&
-         pip3 install --upgrade pip &&
-         pip3 install --upgrade wheel &&
-         pip3 install --upgrade cryptography &&
+           python3-setuptools libjson-glib-dev &&
          ./autogen.sh --with-gnutls --prefix=/usr &&
          export SWTPM_TEST_EXPENSIVE=1 SWTPM_TEST_IBMTSS2=1 &&
          sudo make -j$(nproc) check &&
@@ -75,10 +72,7 @@ matrix:
          sudo rm -rf /dev/tpm* &&
          sudo apt -y install devscripts equivs python3-twisted expect
            libtasn1-dev socat findutils gnutls-dev gnutls-bin tss2
-           python3-setuptools python3-cryptography python3-pip &&
-         pip3 install --upgrade pip &&
-         pip3 install --upgrade wheel &&
-         pip3 install --upgrade cryptography &&
+           python3-setuptools libjson-glib-dev &&
          ./autogen.sh --with-gnutls --prefix=/usr &&
          export SWTPM_TEST_EXPENSIVE=1 SWTPM_TEST_IBMTSS2=1 &&
          sudo make -j$(nproc) check &&

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 CHANGES - changes for libtpms
 
+version 0.8.3:
+ - Applied work-around for Win 2016 & 2019 server bug related to
+   TPM2_ContextLoad (issue #217)
+ - Surround all occurrences of BLOCK_SKIP_READ() with tests of 'rc'
+
 version 0.8.2
  - CryptSym: fix AES output IV
    A CVE has been filed for this bugfix. Unfortunately multi-step encrypted

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtpms (0.8.3) RELEASED; urgency=medium
+
+  * tpm2: Work-around for Windows 2016 & 2019 bug related to ContextLoad
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Tue, 01 Jun 2021 09:00:00 -0500
+
 libtpms (0.8.2) RELEASED; urgency=high
 
   * tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Mon Jun 01 2021 Stefan Berger - 0.8.3-1
+- tpm2: Work-around for Windows 2016 & 2019 bug related to ContextLoad
+
 * Mon Mar 01 2021 Stefan Berger - 0.8.2-1
 - tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
 

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Mon Jun 01 2021 Stefan Berger - 0.8.3-1
+- tpm2: Work-around for Windows 2016 & 2019 bug related to ContextLoad
+
 * Mon Mar 01 2021 Stefan Berger - 0.8.2-1
 - tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
 

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -4301,6 +4301,7 @@ TPM_RC
 TPMS_CONTEXT_Unmarshal(TPMS_CONTEXT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    INT32 orig_size = *size; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT64_Unmarshal(&target->sequence, buffer, size);
@@ -4314,6 +4315,35 @@ TPMS_CONTEXT_Unmarshal(TPMS_CONTEXT *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM2B_CONTEXT_DATA_Unmarshal(&target->contextBlob, buffer, size);
     }
+    // libtpms added begin
+    if (rc == TPM_RC_SUCCESS) {
+        if (*size > 0) {
+            /* Windows 2019 server pads the command TPM_ContextLoad up to the value of
+             * TPM_PT_MAX_OBJECT_CONTENT for the TPMS_CONTEXT part and we end up with
+             * left-over padding bytes here that will make the TPM2_ContextLoad command
+             * fail. This is because we don't just write an OBJECT as the context but use
+             * ANY_OBJECT_Marshal to write it, which consumes less bytes. We had to do
+             * this due to a Linux TPM resource manager bug that couldn't deal with the
+             * larger context sizes once RSA 3072 was enabled and it ran out of memory
+             * when receiving contexts.
+             * Luckily only one command needs TPMS_CONTEXT unmarshalled, so we can adjust
+             * for the left-over padding here but also ONLY do this if
+             * 'orig_size' == value(TPM_PT_MAX_OBJECT_CONTENT).
+             */
+            static UINT32 tpm_pt_max_object_context;
+
+            if (tpm_pt_max_object_context == 0) {
+                TPML_TAGGED_TPM_PROPERTY tttp;
+
+                TPMCapGetProperties(TPM_PT_MAX_OBJECT_CONTEXT, 1, &tttp);
+                if (tttp.count == 1)
+                    tpm_pt_max_object_context = tttp.tpmProperty[0].value;
+            }
+            if ((UINT32)orig_size == tpm_pt_max_object_context)
+                *size = 0; /* consume the padding bytes */
+        }
+    }
+    // libtpms added end
     return rc;
 }
 


### PR DESCRIPTION
This PR applies a work-around for a Windows 2016 and 2019 server bug and prepares for 0.8.3 release. Also adapt the Travis yaml to the recent changes to swtpm project that now has the json-glib dependency.
