### PR TITLE
Reset buffer size indicators that are too large and check for maximum size on marshalling

### DIFF
--- a/src/tpm2/Marshal.c
+++ b/src/tpm2/Marshal.c
@@ -59,6 +59,7 @@
 /*										*/
 /********************************************************************************/
 
+#include <assert.h> // libtpms added
 #include <string.h>
 
 #include "Tpm.h"
@@ -176,9 +177,10 @@ Array_Marshal(BYTE *sourceBuffer, UINT16 sourceSize, BYTE **buffer, INT32 *size)
 }
 
 UINT16
-TPM2B_Marshal(TPM2B *source, BYTE **buffer, INT32 *size)
+TPM2B_Marshal(TPM2B *source, UINT32 maxSize, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
+    assert(source->size <= maxSize); // libtpms added
     written += UINT16_Marshal(&(source->size), buffer, size);
     written += Array_Marshal(source->buffer, source->size, buffer, size); 
     return written;
@@ -503,7 +505,7 @@ UINT16
 TPM2B_DIGEST_Marshal(TPM2B_DIGEST *source, BYTE **buffer, INT32 *size)
 {
 UINT16 written = 0;
-written += TPM2B_Marshal(&source->b, buffer, size);
+written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
 return written;
 }
 
@@ -513,7 +515,7 @@ UINT16
 TPM2B_DATA_Marshal(TPM2B_DATA *source, BYTE **buffer, INT32 *size)
 {
 UINT16 written = 0;
-written += TPM2B_Marshal(&source->b, buffer, size);
+written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
 return written;
 }
 
@@ -543,7 +545,7 @@ UINT16
 TPM2B_MAX_BUFFER_Marshal(TPM2B_MAX_BUFFER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -553,7 +555,7 @@ UINT16
 TPM2B_MAX_NV_BUFFER_Marshal(TPM2B_MAX_NV_BUFFER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -562,7 +564,7 @@ UINT16
 TPM2B_TIMEOUT_Marshal(TPM2B_TIMEOUT *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -572,7 +574,7 @@ UINT16
 TPM2B_IV_Marshal(TPM2B_IV *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -582,7 +584,7 @@ UINT16
 TPM2B_NAME_Marshal(TPM2B_NAME *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.name), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1163,7 +1165,7 @@ UINT16
 TPM2B_ATTEST_Marshal(TPM2B_ATTEST *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.attestationData), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1294,7 +1296,7 @@ UINT16
 TPM2B_SYM_KEY_Marshal(TPM2B_SYM_KEY *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1315,7 +1317,7 @@ UINT16
 TPM2B_SENSITIVE_DATA_Marshal(TPM2B_SENSITIVE_DATA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1673,7 +1675,7 @@ UINT16
 TPM2B_PUBLIC_KEY_RSA_Marshal(TPM2B_PUBLIC_KEY_RSA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1693,7 +1695,7 @@ UINT16
 TPM2B_PRIVATE_KEY_RSA_Marshal(TPM2B_PRIVATE_KEY_RSA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1703,7 +1705,7 @@ UINT16
 TPM2B_ECC_PARAMETER_Marshal(TPM2B_ECC_PARAMETER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1937,7 +1939,7 @@ UINT16
 TPM2B_ENCRYPTED_SECRET_Marshal(TPM2B_ENCRYPTED_SECRET *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.secret), buffer, size); // libtpms changed
     return written;
 }
  
@@ -2148,7 +2150,7 @@ UINT16
 TPM2B_PRIVATE_Marshal(TPM2B_PRIVATE *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -2158,7 +2160,7 @@ UINT16
 TPM2B_ID_OBJECT_Marshal(TPM2B_ID_OBJECT *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.credential), buffer, size); // libtpms changed
     return written;
 }
 
@@ -2215,7 +2217,7 @@ UINT16
 TPM2B_CONTEXT_DATA_Marshal(TPM2B_CONTEXT_DATA  *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 

--- a/src/tpm2/Marshal_fp.h
+++ b/src/tpm2/Marshal_fp.h
@@ -79,7 +79,7 @@ extern "C" {
     UINT16
     Array_Marshal(BYTE *sourceBuffer, UINT16 sourceSize, BYTE **buffer, INT32 *size);
     UINT16
-    TPM2B_Marshal(TPM2B *source, BYTE **buffer, INT32 *size);
+    TPM2B_Marshal(TPM2B *source, UINT32 maxSize, BYTE **buffer, INT32 *size); // libtpms changed
     UINT16
     TPM_KEY_BITS_Marshal(TPM_KEY_BITS *source, BYTE **buffer, INT32 *size);
     UINT16

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -1528,6 +1528,7 @@ bn_prime_t_Unmarshal(bn_prime_t *data, BYTE **buffer, INT32 *size)
                                 "allocated %zu\n",
                                 (size_t)data->size, (size_t)data->allocated);
             rc = TPM_RC_SIZE;
+            data->size = 0;
         }
     }
 

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -278,7 +278,7 @@ static UINT16
 TPM2B_PROOF_Marshal(TPM2B_PROOF *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size);
     return written;
 }
 
@@ -1414,7 +1414,7 @@ STATE_RESET_DATA_Marshal(STATE_RESET_DATA *data, BYTE **buffer, INT32 *size)
                                 STATE_RESET_DATA_VERSION,
                                 STATE_RESET_DATA_MAGIC, 4);
     written += TPM2B_PROOF_Marshal(&data->nullProof, buffer, size);
-    written += TPM2B_Marshal(&data->nullSeed.b, buffer, size);
+    written += TPM2B_Marshal(&data->nullSeed.b, sizeof(data->nullSeed.t.buffer), buffer, size);
     written += UINT32_Marshal(&data->clearCount, buffer, size);
     written += UINT64_Marshal(&data->objectContextID, buffer, size);
 
@@ -2203,7 +2203,7 @@ TPM2B_HASH_BLOCK_Marshal(TPM2B_HASH_BLOCK *data, BYTE **buffer, INT32 *size)
 {
     UINT16 written;
 
-    written = TPM2B_Marshal(&data->b, buffer, size);
+    written = TPM2B_Marshal(&data->b, sizeof(data->t.buffer), buffer, size);
 
     return written;
 }
@@ -3087,9 +3087,9 @@ VolatileState_Marshal(BYTE **buffer, INT32 *size)
 
     /* tie the volatile state to the EP,SP, and PPSeed */
     NvRead(&pd, NV_PERSISTENT_DATA, sizeof(pd));
-    written += TPM2B_Marshal(&pd.EPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&pd.SPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&pd.PPSeed.b, buffer, size);
+    written += TPM2B_Marshal(&pd.EPSeed.b, sizeof(pd.EPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&pd.SPSeed.b, sizeof(pd.SPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&pd.PPSeed.b, sizeof(pd.PPSeed.t.buffer), buffer, size);
 
     written += BLOCK_SKIP_WRITE_PUSH(TRUE, buffer, size); /* v4 */
 
@@ -3906,9 +3906,9 @@ PERSISTENT_DATA_Marshal(PERSISTENT_DATA *data, BYTE **buffer, INT32 *size)
     written += TPM2B_AUTH_Marshal(&data->ownerAuth, buffer, size);
     written += TPM2B_AUTH_Marshal(&data->endorsementAuth, buffer, size);
     written += TPM2B_AUTH_Marshal(&data->lockoutAuth, buffer, size);
-    written += TPM2B_Marshal(&data->EPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&data->SPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&data->PPSeed.b, buffer, size);
+    written += TPM2B_Marshal(&data->EPSeed.b, sizeof(data->EPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&data->SPSeed.b, sizeof(data->SPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&data->PPSeed.b, sizeof(data->PPSeed.t.buffer), buffer, size);
     written += TPM2B_PROOF_Marshal(&data->phProof, buffer, size);
     written += TPM2B_PROOF_Marshal(&data->shProof, buffer, size);
     written += TPM2B_PROOF_Marshal(&data->ehProof, buffer, size);

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -136,6 +136,7 @@ TPM2B_Unmarshal(TPM2B *target, UINT16 targetSize, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size > targetSize) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1686,6 +1687,7 @@ TPMS_PCR_SELECTION_Unmarshal(TPMS_PCR_SELECTION *target, BYTE **buffer, INT32 *s
 	if ((target->sizeofSelect < PCR_SELECT_MIN) ||
 	    (target->sizeofSelect > PCR_SELECT_MAX)) {
 	    rc = TPM_RC_VALUE;
+	    target->sizeofSelect = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1862,6 +1864,7 @@ TPML_CC_Unmarshal(TPML_CC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_CC) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1902,6 +1905,7 @@ TPML_CCA_Unmarshal(TPML_CCA *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_CC) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1925,6 +1929,7 @@ TPML_ALG_Unmarshal(TPML_ALG *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_ALG_LIST_SIZE) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1948,6 +1953,7 @@ TPML_HANDLE_Unmarshal(TPML_HANDLE *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_HANDLES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1976,11 +1982,13 @@ TPML_DIGEST_Unmarshal(TPML_DIGEST *target, BYTE **buffer, INT32 *size)
 	/* TPM side is hard coded to 2 minimum */
 	if (target->count < 2) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > 8) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2003,6 +2011,7 @@ TPML_DIGEST_VALUES_Unmarshal(TPML_DIGEST_VALUES *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2025,6 +2034,7 @@ TPML_PCR_SELECTION_Unmarshal(TPML_PCR_SELECTION *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2050,6 +2060,7 @@ TPML_ALG_PROPERTY_Unmarshal(TPML_ALG_PROPERTY *target, BYTE **buffer, INT32 *siz
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_ALGS) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2072,6 +2083,7 @@ TPML_TAGGED_TPM_PROPERTY_Unmarshal(TPML_TAGGED_TPM_PROPERTY  *target, BYTE **buf
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_TPM_PROPERTIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2094,6 +2106,7 @@ TPML_TAGGED_PCR_PROPERTY_Unmarshal(TPML_TAGGED_PCR_PROPERTY *target, BYTE **buff
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_PCR_PROPERTIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2116,6 +2129,7 @@ TPML_ECC_CURVE_Unmarshal(TPML_ECC_CURVE *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_ECC_CURVES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2138,6 +2152,7 @@ TPML_TAGGED_POLICY_Unmarshal(TPML_TAGGED_POLICY *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_TAGGED_POLICIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2787,6 +2802,7 @@ TPM2B_SENSITIVE_CREATE_Unmarshal(TPM2B_SENSITIVE_CREATE *target, BYTE **buffer, 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -3546,6 +3562,7 @@ TPM2B_ECC_POINT_Unmarshal(TPM2B_ECC_POINT *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -4069,6 +4086,7 @@ TPM2B_PUBLIC_Unmarshal(TPM2B_PUBLIC *target, BYTE **buffer, INT32 *size, BOOL al
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -4164,6 +4182,7 @@ TPM2B_SENSITIVE_Unmarshal(TPM2B_SENSITIVE *target, BYTE **buffer, INT32 *size)
 	if (rc == TPM_RC_SUCCESS) {
 	    if (target->size != startSize - *size) {
 		rc = TPM_RC_SIZE;
+		target->size = 0; // libtpms added
 	    }
 	}
     }
@@ -4239,6 +4258,7 @@ TPMS_NV_PUBLIC_Unmarshal(TPMS_NV_PUBLIC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->dataSize > MAX_NV_INDEX_SIZE) {
 	    rc = TPM_RC_SIZE;
+	    target->dataSize = 0; // libtpms added
 	}
     }
     return rc;
@@ -4269,6 +4289,7 @@ TPM2B_NV_PUBLIC_Unmarshal(TPM2B_NV_PUBLIC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;


### PR DESCRIPTION
Reset buffer size indicators that are found to be too large so that we don't have bad buffer sizes in memory that can cause issues when marshaling the data upon saving volatile data for example.
Check for the maximum size of a buffer when marshaling data so we do not overstep the TPM2B's buffer size.
 