### PR TITLE
Backport patches resolving issues with bad input values

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 CHANGES - changes for libtpms
 
+version 0.7.8
+ - tpm2: Reset too large size indicators in TPM2B to avoid access beyond buffer
+ - tpm2: Restore original value in buffer if unmarshalled one was illegal
+
 version 0.7.7
  - CryptSym: fix AES output IV
    A CVE has been filed for this bugfix. Unfortunately multi-step encrypted

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms], [0.7.7])
+AC_INIT([libtpms], [0.7.8])
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/configure.ac
+++ b/configure.ac
@@ -3,11 +3,11 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms], [0.7.8])
-AC_PREREQ(2.12)
+AC_INIT([libtpms],[0.7.8])
+AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_TARGET
@@ -27,7 +27,7 @@ AC_SUBST([LIBTPMS_VERSION_INFO])
 
 DEBUG=""
 AC_MSG_CHECKING([for debug-enabled build])
-AC_ARG_ENABLE(debug, AC_HELP_STRING([--enable-debug], [create a debug build]),
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[create a debug build]),
   [if test "$enableval" = "yes"; then
      DEBUG="yes"
      AC_MSG_RESULT([yes])
@@ -70,8 +70,7 @@ cryptolib=freebl
 AC_SUBST(cryptolib, $cryptolib)
 
 AC_ARG_WITH([openssl],
-            AC_HELP_STRING([--with-openssl],
-                           [build libtpms with openssl library]),
+            AS_HELP_STRING([--with-openssl],[build libtpms with openssl library]),
               [AC_CHECK_LIB(crypto,
                             [AES_set_encrypt_key],
                             [],
@@ -134,8 +133,7 @@ openssl)
 esac
 
 AC_ARG_WITH([tpm2],
-	AC_HELP_STRING([--with-tpm2],
-		       [build libtpms with TPM2 support (experimental)]),
+	AS_HELP_STRING([--with-tpm2],[build libtpms with TPM2 support (experimental)]),
 	AC_MSG_RESULT([Building with TPM2 support])
 	if test "x$cryptolib" = "xfreebl"; then
 		AC_MSG_ERROR([TPM2 support requires openssl crypto library])
@@ -241,12 +239,11 @@ LT_INIT
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_INSTALL
-AC_PROG_LIBTOOL
+LT_INIT
 
 #AM_GNU_GETTEXT_VERSION([0.15])
 #AM_GNU_GETTEXT([external])
 
-AC_HEADER_STDC
 AC_C_CONST
 AC_C_INLINE
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtpms (0.7.8) RELEASED; urgency=medium
+
+  * tpm2: Reset too large size indicators in TPM2B to avoid access beyond buffer
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Wed, 23 Jun 2021 09:00:00 -0500
+
 libtpms (0.7.7) RELEASED; urgency=high
 
   * tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.7.7
+%define version   0.7.8
 %define release   0
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Wed Jun 23 2021 Stefan Berger - 0.7.8-1
+- tpm2: Reset too large size indicators in TPM2B to avoid access beyond buffer
+
 * Mon Mar 01 2021 Stefan Berger - 0.7.7-1
 - tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
 

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Wed Jun 23 2021 Stefan Berger - 0.7.8-1
+- tpm2: Reset too large size indicators in TPM2B to avoid access beyond buffer
+
 * Mon Mar 01 2021 Stefan Berger - 0.7.7-1
 - tpm2: CryptSym: fix AES output IV; a CVE has been filed for this issue
 

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 7
-#define TPM_LIBRARY_VER_MICRO 7
+#define TPM_LIBRARY_VER_MICRO 8
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/Marshal.c
+++ b/src/tpm2/Marshal.c
@@ -61,6 +61,7 @@
 
 /* rev 136 */
 
+#include <assert.h> // libtpms added
 #include <string.h>
 
 #include "Tpm.h"
@@ -178,9 +179,10 @@ Array_Marshal(BYTE *sourceBuffer, UINT16 sourceSize, BYTE **buffer, INT32 *size)
 }
 
 UINT16
-TPM2B_Marshal(TPM2B *source, BYTE **buffer, INT32 *size)
+TPM2B_Marshal(TPM2B *source, UINT32 maxSize, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
+    assert(source->size <= maxSize); // libtpms added
     written += UINT16_Marshal(&(source->size), buffer, size);
     written += Array_Marshal(source->buffer, source->size, buffer, size); 
     return written;
@@ -495,7 +497,7 @@ UINT16
 TPM2B_DIGEST_Marshal(TPM2B_DIGEST *source, BYTE **buffer, INT32 *size)
 {
 UINT16 written = 0;
-written += TPM2B_Marshal(&source->b, buffer, size);
+written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
 return written;
 }
 
@@ -505,7 +507,7 @@ UINT16
 TPM2B_DATA_Marshal(TPM2B_DATA *source, BYTE **buffer, INT32 *size)
 {
 UINT16 written = 0;
-written += TPM2B_Marshal(&source->b, buffer, size);
+written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
 return written;
 }
 
@@ -535,7 +537,7 @@ UINT16
 TPM2B_MAX_BUFFER_Marshal(TPM2B_MAX_BUFFER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -545,7 +547,7 @@ UINT16
 TPM2B_MAX_NV_BUFFER_Marshal(TPM2B_MAX_NV_BUFFER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -554,7 +556,7 @@ UINT16
 TPM2B_TIMEOUT_Marshal(TPM2B_TIMEOUT *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -564,7 +566,7 @@ UINT16
 TPM2B_IV_Marshal(TPM2B_IV *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -574,7 +576,7 @@ UINT16
 TPM2B_NAME_Marshal(TPM2B_NAME *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.name), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1111,7 +1113,7 @@ UINT16
 TPM2B_ATTEST_Marshal(TPM2B_ATTEST *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.attestationData), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1232,7 +1234,7 @@ UINT16
 TPM2B_SYM_KEY_Marshal(TPM2B_SYM_KEY *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1253,7 +1255,7 @@ UINT16
 TPM2B_SENSITIVE_DATA_Marshal(TPM2B_SENSITIVE_DATA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1613,7 +1615,7 @@ UINT16
 TPM2B_PUBLIC_KEY_RSA_Marshal(TPM2B_PUBLIC_KEY_RSA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1633,7 +1635,7 @@ UINT16
 TPM2B_PRIVATE_KEY_RSA_Marshal(TPM2B_PRIVATE_KEY_RSA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1643,7 +1645,7 @@ UINT16
 TPM2B_ECC_PARAMETER_Marshal(TPM2B_ECC_PARAMETER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1879,7 +1881,7 @@ UINT16
 TPM2B_ENCRYPTED_SECRET_Marshal(TPM2B_ENCRYPTED_SECRET *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.secret), buffer, size); // libtpms changed
     return written;
 }
  
@@ -2090,7 +2092,7 @@ UINT16
 TPM2B_PRIVATE_Marshal(TPM2B_PRIVATE *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -2100,7 +2102,7 @@ UINT16
 TPM2B_ID_OBJECT_Marshal(TPM2B_ID_OBJECT *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.credential), buffer, size); // libtpms changed
     return written;
 }
 
@@ -2157,7 +2159,7 @@ UINT16
 TPM2B_CONTEXT_DATA_Marshal(TPM2B_CONTEXT_DATA  *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 

--- a/src/tpm2/Marshal_fp.h
+++ b/src/tpm2/Marshal_fp.h
@@ -79,7 +79,7 @@ extern "C" {
     UINT16
     Array_Marshal(BYTE *sourceBuffer, UINT16 sourceSize, BYTE **buffer, INT32 *size);
     UINT16
-    TPM2B_Marshal(TPM2B *source, BYTE **buffer, INT32 *size);
+    TPM2B_Marshal(TPM2B *source, UINT32 maxSize, BYTE **buffer, INT32 *size); // libtpms changed
     UINT16
     TPM_KEY_BITS_Marshal(TPM_KEY_BITS *source, BYTE **buffer, INT32 *size);
     UINT16

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -255,7 +255,7 @@ UINT16
 TPM2B_PROOF_Marshal(TPM2B_PROOF *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size);
     return written;
 }
 
@@ -1332,7 +1332,7 @@ STATE_RESET_DATA_Marshal(STATE_RESET_DATA *data, BYTE **buffer, INT32 *size)
                                 STATE_RESET_DATA_VERSION,
                                 STATE_RESET_DATA_MAGIC, 1);
     written += TPM2B_PROOF_Marshal(&data->nullProof, buffer, size);
-    written += TPM2B_Marshal(&data->nullSeed.b, buffer, size);
+    written += TPM2B_Marshal(&data->nullSeed.b, sizeof(data->nullSeed.t.buffer), buffer, size);
     written += UINT32_Marshal(&data->clearCount, buffer, size);
     written += UINT64_Marshal(&data->objectContextID, buffer, size);
 
@@ -2115,7 +2115,7 @@ TPM2B_HASH_BLOCK_Marshal(TPM2B_HASH_BLOCK *data, BYTE **buffer, INT32 *size)
 {
     UINT16 written;
 
-    written = TPM2B_Marshal(&data->b, buffer, size);
+    written = TPM2B_Marshal(&data->b, sizeof(data->t.buffer), buffer, size);
 
     return written;
 }
@@ -2980,9 +2980,9 @@ VolatileState_Marshal(BYTE **buffer, INT32 *size)
 
     /* tie the volatile state to the EP,SP, and PPSeed */
     NvRead(&pd, NV_PERSISTENT_DATA, sizeof(pd));
-    written += TPM2B_Marshal(&pd.EPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&pd.SPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&pd.PPSeed.b, buffer, size);
+    written += TPM2B_Marshal(&pd.EPSeed.b, sizeof(pd.EPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&pd.SPSeed.b, sizeof(pd.SPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&pd.PPSeed.b, sizeof(pd.PPSeed.t.buffer), buffer, size);
 
     written += BLOCK_SKIP_WRITE_PUSH(TRUE, buffer, size); /* v4 */
 
@@ -3799,9 +3799,9 @@ PERSISTENT_DATA_Marshal(PERSISTENT_DATA *data, BYTE **buffer, INT32 *size)
     written += TPM2B_AUTH_Marshal(&data->ownerAuth, buffer, size);
     written += TPM2B_AUTH_Marshal(&data->endorsementAuth, buffer, size);
     written += TPM2B_AUTH_Marshal(&data->lockoutAuth, buffer, size);
-    written += TPM2B_Marshal(&data->EPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&data->SPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&data->PPSeed.b, buffer, size);
+    written += TPM2B_Marshal(&data->EPSeed.b, sizeof(data->EPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&data->SPSeed.b, sizeof(data->SPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&data->PPSeed.b, sizeof(data->PPSeed.t.buffer), buffer, size);
     written += TPM2B_PROOF_Marshal(&data->phProof, buffer, size);
     written += TPM2B_PROOF_Marshal(&data->shProof, buffer, size);
     written += TPM2B_PROOF_Marshal(&data->ehProof, buffer, size);

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -1440,6 +1440,7 @@ bn_prime_t_Unmarshal(bn_prime_t *data, BYTE **buffer, INT32 *size)
                                 "allocated %zu\n",
                                 (size_t)data->size, (size_t)data->allocated);
             rc = TPM_RC_SIZE;
+            data->size = 0;
         }
     }
 

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -165,6 +165,7 @@ TPM_RC
 TPM_GENERATED_Unmarshal(TPM_GENERATED *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_GENERATED orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal(target, buffer, size);  
@@ -172,6 +173,7 @@ TPM_GENERATED_Unmarshal(TPM_GENERATED *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target != TPM_GENERATED_VALUE) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -197,6 +199,7 @@ TPM_RC
 TPM_ECC_CURVE_Unmarshal(TPM_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ECC_CURVE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT16_Unmarshal(target, buffer, size);
@@ -215,6 +218,7 @@ TPM_ECC_CURVE_Unmarshal(TPM_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_CURVE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -240,6 +244,7 @@ TPM_RC
 TPM_CLOCK_ADJUST_Unmarshal(TPM_CLOCK_ADJUST *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_CLOCK_ADJUST orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = INT8_Unmarshal(target, buffer, size);  
@@ -256,6 +261,7 @@ TPM_CLOCK_ADJUST_Unmarshal(TPM_CLOCK_ADJUST *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -267,6 +273,7 @@ TPM_RC
 TPM_EO_Unmarshal(TPM_EO *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_EO orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT16_Unmarshal(target, buffer, size);  
@@ -288,6 +295,7 @@ TPM_EO_Unmarshal(TPM_EO *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -299,6 +307,7 @@ TPM_RC
 TPM_ST_Unmarshal(TPM_ST *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT16_Unmarshal(target, buffer, size);  
@@ -324,6 +333,7 @@ TPM_ST_Unmarshal(TPM_ST *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -335,6 +345,7 @@ TPM_RC
 TPM_SU_Unmarshal(TPM_SU *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_SU orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT16_Unmarshal(target, buffer, size);  
@@ -346,6 +357,7 @@ TPM_SU_Unmarshal(TPM_SU *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -357,6 +369,7 @@ TPM_RC
 TPM_SE_Unmarshal(TPM_SE *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_SE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT8_Unmarshal(target, buffer, size);  
@@ -369,6 +382,7 @@ TPM_SE_Unmarshal(TPM_SE *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -380,6 +394,7 @@ TPM_RC
 TPM_CAP_Unmarshal(TPM_CAP *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_CAP orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal(target, buffer, size);  
@@ -400,6 +415,7 @@ TPM_CAP_Unmarshal(TPM_CAP *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -450,6 +466,7 @@ TPM_RC
 TPMA_ALGORITHM_Unmarshal(TPMA_ALGORITHM *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_ALGORITHM orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal((UINT32 *)target, buffer, size); /* libtpms changed */
@@ -457,6 +474,7 @@ TPMA_ALGORITHM_Unmarshal(TPMA_ALGORITHM *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_ALGORITHM_reserved) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -468,6 +486,7 @@ TPM_RC
 TPMA_OBJECT_Unmarshal(TPMA_OBJECT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_OBJECT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal((UINT32 *)target, buffer, size); /* libtpms changed */
@@ -475,6 +494,7 @@ TPMA_OBJECT_Unmarshal(TPMA_OBJECT *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_OBJECT_reserved) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -486,6 +506,7 @@ TPM_RC
 TPMA_SESSION_Unmarshal(TPMA_SESSION *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_SESSION orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT8_Unmarshal((UINT8 *)target, buffer, size);  /* libtpms changed */
@@ -493,6 +514,7 @@ TPMA_SESSION_Unmarshal(TPMA_SESSION *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_SESSION_reserved) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -517,6 +539,7 @@ TPM_RC
 TPMA_CC_Unmarshal(TPMA_CC *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_CC orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal((UINT32 *)target, buffer, size); /* libtpms changed */
@@ -524,6 +547,7 @@ TPMA_CC_Unmarshal(TPMA_CC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_CC_reserved) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -535,6 +559,7 @@ TPM_RC
 TPMI_YES_NO_Unmarshal(TPMI_YES_NO *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_YES_NO orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT8_Unmarshal(target, buffer, size);  
@@ -546,6 +571,7 @@ TPMI_YES_NO_Unmarshal(TPMI_YES_NO *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -557,6 +583,7 @@ TPM_RC
 TPMI_DH_OBJECT_Unmarshal(TPMI_DH_OBJECT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_OBJECT orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -569,6 +596,7 @@ TPMI_DH_OBJECT_Unmarshal(TPMI_DH_OBJECT *target, BYTE **buffer, INT32 *size, BOO
 	    isNotPersistent &&
 	    isNotLegalNull) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -580,6 +608,7 @@ TPM_RC
 TPMI_DH_PARENT_Unmarshal(TPMI_DH_PARENT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_PARENT orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -598,6 +627,7 @@ TPMI_DH_PARENT_Unmarshal(TPMI_DH_PARENT *target, BYTE **buffer, INT32 *size, BOO
 	    isNotEndorsement && 
 	    isNotLegalNull) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -609,6 +639,7 @@ TPM_RC
 TPMI_DH_PERSISTENT_Unmarshal(TPMI_DH_PERSISTENT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_PERSISTENT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -617,6 +648,7 @@ TPMI_DH_PERSISTENT_Unmarshal(TPMI_DH_PERSISTENT *target, BYTE **buffer, INT32 *s
 	BOOL isNotPersistent = (*target < PERSISTENT_FIRST) || (*target > PERSISTENT_LAST);
 	if (isNotPersistent) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -628,6 +660,7 @@ TPM_RC
 TPMI_DH_ENTITY_Unmarshal(TPMI_DH_ENTITY *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_ENTITY orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -654,6 +687,7 @@ TPMI_DH_ENTITY_Unmarshal(TPMI_DH_ENTITY *target, BYTE **buffer, INT32 *size, BOO
 	    isNotAuth &&
 	    isNotLegalNull) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -665,6 +699,7 @@ TPM_RC
 TPMI_DH_PCR_Unmarshal(TPMI_DH_PCR *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_PCR orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -675,6 +710,7 @@ TPMI_DH_PCR_Unmarshal(TPMI_DH_PCR *target, BYTE **buffer, INT32 *size, BOOL allo
 	if (isNotPcr &&
 	    isNotLegalNull) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -686,6 +722,7 @@ TPM_RC
 TPMI_SH_AUTH_SESSION_Unmarshal(TPMI_SH_AUTH_SESSION *target, BYTE **buffer, INT32 *size, BOOL allowPwd)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SH_AUTH_SESSION orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -698,6 +735,7 @@ TPMI_SH_AUTH_SESSION_Unmarshal(TPMI_SH_AUTH_SESSION *target, BYTE **buffer, INT3
 	    isNotPolicySession &&
 	    isNotLegalPwd) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -709,6 +747,7 @@ TPM_RC
 TPMI_SH_HMAC_Unmarshal(TPMI_SH_HMAC *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SH_HMAC orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -717,6 +756,7 @@ TPMI_SH_HMAC_Unmarshal(TPMI_SH_HMAC *target, BYTE **buffer, INT32 *size)
 	BOOL isNotHmacSession = (*target < HMAC_SESSION_FIRST ) || (*target > HMAC_SESSION_LAST);
 	if (isNotHmacSession) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -728,6 +768,7 @@ TPM_RC
 TPMI_SH_POLICY_Unmarshal(TPMI_SH_POLICY *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SH_POLICY orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -736,6 +777,7 @@ TPMI_SH_POLICY_Unmarshal(TPMI_SH_POLICY *target, BYTE **buffer, INT32 *size)
 	BOOL isNotPolicySession = (*target < POLICY_SESSION_FIRST) || (*target > POLICY_SESSION_LAST);
 	if (isNotPolicySession) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -747,6 +789,7 @@ TPM_RC
 TPMI_DH_CONTEXT_Unmarshal(TPMI_DH_CONTEXT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_CONTEXT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -759,6 +802,7 @@ TPMI_DH_CONTEXT_Unmarshal(TPMI_DH_CONTEXT *target, BYTE **buffer, INT32 *size)
 	    isNotPolicySession &&
 	    isNotTransient) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -770,6 +814,7 @@ TPM_RC
 TPMI_DH_SAVED_Unmarshal(TPMI_DH_SAVED *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_SAVED orig_target = *target; // libtpms added
     allowNull = allowNull;
 
     if (rc == TPM_RC_SUCCESS) {
@@ -787,6 +832,7 @@ TPMI_DH_SAVED_Unmarshal(TPMI_DH_SAVED *target, BYTE **buffer, INT32 *size, BOOL 
 	    isNotSequenceObject &&
 	    isNotTransientStClear) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -798,6 +844,7 @@ TPM_RC
 TPMI_RH_HIERARCHY_Unmarshal(TPMI_RH_HIERARCHY *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_HIERARCHY orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -814,6 +861,7 @@ TPMI_RH_HIERARCHY_Unmarshal(TPMI_RH_HIERARCHY *target, BYTE **buffer, INT32 *siz
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -825,6 +873,7 @@ TPM_RC
 TPMI_RH_ENABLES_Unmarshal(TPMI_RH_ENABLES *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_ENABLES orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -842,6 +891,7 @@ TPMI_RH_ENABLES_Unmarshal(TPMI_RH_ENABLES *target, BYTE **buffer, INT32 *size, B
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -853,6 +903,7 @@ TPM_RC
 TPMI_RH_HIERARCHY_AUTH_Unmarshal(TPMI_RH_HIERARCHY_AUTH *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_HIERARCHY_AUTH orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -866,6 +917,7 @@ TPMI_RH_HIERARCHY_AUTH_Unmarshal(TPMI_RH_HIERARCHY_AUTH *target, BYTE **buffer, 
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -877,6 +929,7 @@ TPM_RC
 TPMI_RH_PLATFORM_Unmarshal(TPMI_RH_PLATFORM *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_PLATFORM orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -887,6 +940,7 @@ TPMI_RH_PLATFORM_Unmarshal(TPMI_RH_PLATFORM *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -898,6 +952,7 @@ TPM_RC
 TPMI_RH_ENDORSEMENT_Unmarshal(TPMI_RH_ENDORSEMENT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_ENDORSEMENT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -912,6 +967,7 @@ TPMI_RH_ENDORSEMENT_Unmarshal(TPMI_RH_ENDORSEMENT *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -923,6 +979,7 @@ TPM_RC
 TPMI_RH_PROVISION_Unmarshal(TPMI_RH_PROVISION *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_PROVISION orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -934,6 +991,7 @@ TPMI_RH_PROVISION_Unmarshal(TPMI_RH_PROVISION *target, BYTE **buffer, INT32 *siz
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -945,6 +1003,7 @@ TPM_RC
 TPMI_RH_CLEAR_Unmarshal(TPMI_RH_CLEAR *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_CLEAR orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -956,6 +1015,7 @@ TPMI_RH_CLEAR_Unmarshal(TPMI_RH_CLEAR *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -967,6 +1027,7 @@ TPM_RC
 TPMI_RH_NV_AUTH_Unmarshal(TPMI_RH_NV_AUTH *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_NV_AUTH orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -981,6 +1042,7 @@ TPMI_RH_NV_AUTH_Unmarshal(TPMI_RH_NV_AUTH *target, BYTE **buffer, INT32 *size)
 		  BOOL isNotNv = (*target < NV_INDEX_FIRST) || (*target > NV_INDEX_LAST);
 		  if (isNotNv) {
 		      rc = TPM_RC_VALUE;
+		      *target = orig_target; // libtpms added
 		  }
 	      }
 	}
@@ -994,6 +1056,7 @@ TPM_RC
 TPMI_RH_LOCKOUT_Unmarshal(TPMI_RH_LOCKOUT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_LOCKOUT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -1004,6 +1067,7 @@ TPMI_RH_LOCKOUT_Unmarshal(TPMI_RH_LOCKOUT *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1015,6 +1079,7 @@ TPM_RC
 TPMI_RH_NV_INDEX_Unmarshal(TPMI_RH_NV_INDEX *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_NV_INDEX orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -1023,6 +1088,7 @@ TPMI_RH_NV_INDEX_Unmarshal(TPMI_RH_NV_INDEX *target, BYTE **buffer, INT32 *size)
 	BOOL isNotNv = (*target < NV_INDEX_FIRST) || (*target > NV_INDEX_LAST);
 	if (isNotNv) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1034,6 +1100,7 @@ TPM_RC
 TPMI_ALG_HASH_Unmarshal(TPMI_ALG_HASH *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_HASH orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1062,6 +1129,7 @@ TPMI_ALG_HASH_Unmarshal(TPMI_ALG_HASH *target, BYTE **buffer, INT32 *size, BOOL 
 	    }
 	  default:
 	    rc = TPM_RC_HASH;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1073,6 +1141,7 @@ TPM_RC
 TPMI_ALG_SYM_Unmarshal(TPMI_ALG_SYM *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_SYM orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1101,6 +1170,7 @@ TPMI_ALG_SYM_Unmarshal(TPMI_ALG_SYM *target, BYTE **buffer, INT32 *size, BOOL al
 	    }
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1112,6 +1182,7 @@ TPM_RC
 TPMI_ALG_SYM_OBJECT_Unmarshal(TPMI_ALG_SYM_OBJECT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_SYM_OBJECT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1137,6 +1208,7 @@ TPMI_ALG_SYM_OBJECT_Unmarshal(TPMI_ALG_SYM_OBJECT *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1148,6 +1220,7 @@ TPM_RC
 TPMI_ALG_SYM_MODE_Unmarshal(TPMI_ALG_SYM_MODE *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_SYM_MODE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1179,6 +1252,7 @@ TPMI_ALG_SYM_MODE_Unmarshal(TPMI_ALG_SYM_MODE *target, BYTE **buffer, INT32 *siz
 	    }
 	  default:
 	    rc = TPM_RC_MODE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1190,6 +1264,7 @@ TPM_RC
 TPMI_ALG_KDF_Unmarshal(TPMI_ALG_KDF *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_KDF orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1215,6 +1290,7 @@ TPMI_ALG_KDF_Unmarshal(TPMI_ALG_KDF *target, BYTE **buffer, INT32 *size, BOOL al
 	    }
 	  default:
 	    rc = TPM_RC_KDF;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1226,6 +1302,7 @@ TPM_RC
 TPMI_ALG_SIG_SCHEME_Unmarshal(TPMI_ALG_SIG_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_SIG_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1260,6 +1337,7 @@ TPMI_ALG_SIG_SCHEME_Unmarshal(TPMI_ALG_SIG_SCHEME *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_SCHEME;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1271,6 +1349,7 @@ TPM_RC
 TPMI_ECC_KEY_EXCHANGE_Unmarshal(TPMI_ECC_KEY_EXCHANGE *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ECC_KEY_EXCHANGE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1293,6 +1372,7 @@ TPMI_ECC_KEY_EXCHANGE_Unmarshal(TPMI_ECC_KEY_EXCHANGE *target, BYTE **buffer, IN
 	    }
 	  default:
 	    rc = TPM_RC_SCHEME;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1305,6 +1385,7 @@ TPM_RC
 TPMI_ST_COMMAND_TAG_Unmarshal(TPMI_ST_COMMAND_TAG *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ST_COMMAND_TAG orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(target, buffer, size);  
@@ -1316,6 +1397,7 @@ TPMI_ST_COMMAND_TAG_Unmarshal(TPMI_ST_COMMAND_TAG *target, BYTE **buffer, INT32 
 	    break;
 	  default:
 	    rc = TPM_RC_BAD_TAG;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1327,6 +1409,7 @@ TPM_RC
 TPMI_ALG_MAC_SCHEME_Unmarshal(TPMI_ALG_MAC_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_MAC_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1358,6 +1441,7 @@ TPMI_ALG_MAC_SCHEME_Unmarshal(TPMI_ALG_MAC_SCHEME *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1369,6 +1453,7 @@ TPM_RC
 TPMI_ALG_CIPHER_MODE_Unmarshal(TPMI_ALG_CIPHER_MODE*target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_CIPHER_MODE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1397,6 +1482,7 @@ TPMI_ALG_CIPHER_MODE_Unmarshal(TPMI_ALG_CIPHER_MODE*target, BYTE **buffer, INT32
 	    }
 	  default:
 	    rc = TPM_RC_MODE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1633,6 +1719,7 @@ TPM_RC
 TPMT_TK_CREATION_Unmarshal(TPMT_TK_CREATION *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_tag = target->tag; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(&target->tag, buffer, size);
@@ -1640,6 +1727,7 @@ TPMT_TK_CREATION_Unmarshal(TPMT_TK_CREATION *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->tag != TPM_ST_CREATION) {
 	    rc = TPM_RC_TAG;
+	    target->tag = orig_tag; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1657,6 +1745,7 @@ TPM_RC
 TPMT_TK_VERIFIED_Unmarshal(TPMT_TK_VERIFIED *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_tag = target->tag; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(&target->tag, buffer, size);
@@ -1664,6 +1753,7 @@ TPMT_TK_VERIFIED_Unmarshal(TPMT_TK_VERIFIED *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->tag != TPM_ST_VERIFIED) {
 	    rc = TPM_RC_TAG;
+	    target->tag = orig_tag; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1681,6 +1771,7 @@ TPM_RC
 TPMT_TK_AUTH_Unmarshal(TPMT_TK_AUTH *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_tag = target->tag; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(&target->tag, buffer, size);
@@ -1689,6 +1780,7 @@ TPMT_TK_AUTH_Unmarshal(TPMT_TK_AUTH *target, BYTE **buffer, INT32 *size)
 	if ((target->tag != TPM_ST_AUTH_SIGNED) &&
 	    (target->tag != TPM_ST_AUTH_SECRET)) {
 	    rc = TPM_RC_TAG;
+	    target->tag = orig_tag; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1706,6 +1798,7 @@ TPM_RC
 TPMT_TK_HASHCHECK_Unmarshal(TPMT_TK_HASHCHECK *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_tag = target->tag; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(&target->tag, buffer, size);
@@ -1713,6 +1806,7 @@ TPMT_TK_HASHCHECK_Unmarshal(TPMT_TK_HASHCHECK *target, BYTE **buffer, INT32 *siz
     if (rc == TPM_RC_SUCCESS) {
 	if (target->tag != TPM_ST_HASHCHECK) {
 	    rc = TPM_RC_TAG;
+	    target->tag = orig_tag; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -2303,6 +2397,7 @@ TPM_RC
 TPMI_ST_ATTEST_Unmarshal(TPMI_ST_ATTEST *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ST_ATTEST orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(target, buffer, size);
@@ -2319,6 +2414,7 @@ TPMI_ST_ATTEST_Unmarshal(TPMI_ST_ATTEST *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_SELECTOR;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2413,6 +2509,7 @@ TPM_RC
 TPMI_AES_KEY_BITS_Unmarshal(TPMI_AES_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_AES_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);  
@@ -2424,6 +2521,7 @@ TPMI_AES_KEY_BITS_Unmarshal(TPMI_AES_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2435,6 +2533,7 @@ TPM_RC
 TPMI_CAMELLIA_KEY_BITS_Unmarshal(TPMI_CAMELLIA_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_CAMELLIA_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);  
@@ -2445,6 +2544,7 @@ TPMI_CAMELLIA_KEY_BITS_Unmarshal(TPMI_CAMELLIA_KEY_BITS *target, BYTE **buffer, 
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2456,6 +2556,7 @@ TPM_RC
 TPMI_SM4_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SM4_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);  
@@ -2466,6 +2567,7 @@ TPMI_SM4_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2477,6 +2579,7 @@ TPM_RC
 TPMI_TDES_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SM4_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);
@@ -2488,6 +2591,7 @@ TPMI_TDES_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *si
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2760,6 +2864,7 @@ TPM_RC
 TPMI_ALG_KEYEDHASH_SCHEME_Unmarshal(TPMI_ALG_KEYEDHASH_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_KEYEDHASH_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -2779,6 +2884,7 @@ TPMI_ALG_KEYEDHASH_SCHEME_Unmarshal(TPMI_ALG_KEYEDHASH_SCHEME *target, BYTE **bu
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3163,6 +3269,7 @@ TPM_RC
 TPMI_ALG_ASYM_SCHEME_Unmarshal(TPMI_ALG_ASYM_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_ASYM_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3206,6 +3313,7 @@ TPMI_ALG_ASYM_SCHEME_Unmarshal(TPMI_ALG_ASYM_SCHEME *target, BYTE **buffer, INT3
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3284,6 +3392,7 @@ TPM_RC
 TPMI_ALG_RSA_SCHEME_Unmarshal(TPMI_ALG_RSA_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_RSA_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3309,6 +3418,7 @@ TPMI_ALG_RSA_SCHEME_Unmarshal(TPMI_ALG_RSA_SCHEME *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3336,6 +3446,7 @@ TPM_RC
 TPMI_ALG_RSA_DECRYPT_Unmarshal(TPMI_ALG_RSA_DECRYPT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_RSA_DECRYPT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3355,6 +3466,7 @@ TPMI_ALG_RSA_DECRYPT_Unmarshal(TPMI_ALG_RSA_DECRYPT *target, BYTE **buffer, INT3
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3395,6 +3507,7 @@ TPM_RC
 TPMI_RSA_KEY_BITS_Unmarshal(TPMI_RSA_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RSA_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);  
@@ -3406,6 +3519,7 @@ TPMI_RSA_KEY_BITS_Unmarshal(TPMI_RSA_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3490,6 +3604,7 @@ TPM_RC
 TPMI_ALG_ECC_SCHEME_Unmarshal(TPMI_ALG_ECC_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_ECC_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3521,6 +3636,7 @@ TPMI_ALG_ECC_SCHEME_Unmarshal(TPMI_ALG_ECC_SCHEME *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_SCHEME;
+	    *target = orig_target; //  libtpms added
 	}
     }
     return rc;
@@ -3532,6 +3648,7 @@ TPM_RC
 TPMI_ECC_CURVE_Unmarshal(TPMI_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ECC_CURVE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ECC_CURVE_Unmarshal(target, buffer, size);  
@@ -3568,6 +3685,7 @@ TPMI_ECC_CURVE_Unmarshal(TPMI_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_CURVE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3782,6 +3900,7 @@ TPM_RC
 TPMI_ALG_PUBLIC_Unmarshal(TPMI_ALG_PUBLIC *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_PUBLIC orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3803,6 +3922,7 @@ TPMI_ALG_PUBLIC_Unmarshal(TPMI_ALG_PUBLIC *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_TYPE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -4137,6 +4257,7 @@ TPM_RC
 TPMA_NV_Unmarshal(TPMA_NV *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_NV orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal((UINT32 *)target, buffer, size);  /* libtpms changed */
@@ -4144,6 +4265,7 @@ TPMA_NV_Unmarshal(TPMA_NV *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_NV_RESERVED) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -137,6 +137,7 @@ TPM2B_Unmarshal(TPM2B *target, UINT16 targetSize, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size > targetSize) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1617,6 +1618,7 @@ TPMS_PCR_SELECTION_Unmarshal(TPMS_PCR_SELECTION *target, BYTE **buffer, INT32 *s
 	if ((target->sizeofSelect < PCR_SELECT_MIN) ||
 	    (target->sizeofSelect > PCR_SELECT_MAX)) {
 	    rc = TPM_RC_VALUE;
+	    target->sizeofSelect = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1787,6 +1789,7 @@ TPML_CC_Unmarshal(TPML_CC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_CC) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1824,6 +1827,7 @@ TPML_CCA_Unmarshal(TPML_CCA *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_CC) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1846,6 +1850,7 @@ TPML_ALG_Unmarshal(TPML_ALG *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_ALG_LIST_SIZE) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1868,6 +1873,7 @@ TPML_HANDLE_Unmarshal(TPML_HANDLE *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_HANDLES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1895,11 +1901,13 @@ TPML_DIGEST_Unmarshal(TPML_DIGEST *target, BYTE **buffer, INT32 *size)
 	/* TPM side is hard coded to 2 minimum */
 	if (target->count < 2) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > 8) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1922,6 +1930,7 @@ TPML_DIGEST_VALUES_Unmarshal(TPML_DIGEST_VALUES *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1944,6 +1953,7 @@ TPML_PCR_SELECTION_Unmarshal(TPML_PCR_SELECTION *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1967,6 +1977,7 @@ TPML_ALG_PROPERTY_Unmarshal(TPML_ALG_PROPERTY *target, BYTE **buffer, INT32 *siz
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_ALGS) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1989,6 +2000,7 @@ TPML_TAGGED_TPM_PROPERTY_Unmarshal(TPML_TAGGED_TPM_PROPERTY  *target, BYTE **buf
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_TPM_PROPERTIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2011,6 +2023,7 @@ TPML_TAGGED_PCR_PROPERTY_Unmarshal(TPML_TAGGED_PCR_PROPERTY *target, BYTE **buff
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_PCR_PROPERTIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2033,6 +2046,7 @@ TPML_ECC_CURVE_Unmarshal(TPML_ECC_CURVE *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_ECC_CURVES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2055,6 +2069,7 @@ TPML_TAGGED_POLICY_Unmarshal(TPML_TAGGED_POLICY *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_TAGGED_POLICIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2704,6 +2719,7 @@ TPM2B_SENSITIVE_CREATE_Unmarshal(TPM2B_SENSITIVE_CREATE *target, BYTE **buffer, 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -3462,6 +3478,7 @@ TPM2B_ECC_POINT_Unmarshal(TPM2B_ECC_POINT *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -3985,6 +4002,7 @@ TPM2B_PUBLIC_Unmarshal(TPM2B_PUBLIC *target, BYTE **buffer, INT32 *size, BOOL al
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -4080,6 +4098,7 @@ TPM2B_SENSITIVE_Unmarshal(TPM2B_SENSITIVE *target, BYTE **buffer, INT32 *size)
 	if (rc == TPM_RC_SUCCESS) {
 	    if (target->size != startSize - *size) {
 		rc = TPM_RC_SIZE;
+		target->size = 0; // libtpms added
 	    }
 	}
     }
@@ -4155,6 +4174,7 @@ TPMS_NV_PUBLIC_Unmarshal(TPMS_NV_PUBLIC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->dataSize > MAX_NV_INDEX_SIZE) {
 	    rc = TPM_RC_SIZE;
+	    target->dataSize = 0; // libtpms added
 	}
     }
     return rc;
@@ -4185,6 +4205,7 @@ TPM2B_NV_PUBLIC_Unmarshal(TPM2B_NV_PUBLIC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;


### PR DESCRIPTION
This PR backports patches that resolve issues with bad input values and set TPM2B buffer size indicators to '0' if the input value was larger than the actual TPM2B type's buffer and in other cases restore the original value of a field if the unmarshalled value was found to be illegal. This prevents keeping around illegal buffer sizes and illegal values in memory that may cause issues.