### PR TITLE
Backport patches resolving issues with bad input values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,7 @@ matrix:
         pushd swtpm &&
          sudo apt -y install devscripts equivs python3-twisted expect
            libtasn1-dev socat findutils gnutls-dev gnutls-bin
-           python3-setuptools python3-cryptography python3-pip &&
-         pip3 install --upgrade -v pip==20.3.4 &&
-         pip3 install --upgrade wheel &&
-         pip3 install --upgrade cryptography &&
+           python3-setuptools libjson-glib-dev &&
          ./autogen.sh --with-gnutls --prefix=/usr &&
          export SWTPM_TEST_EXPENSIVE=1 &&
          sudo make -j$(nproc) check &&

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 CHANGES - changes for libtpms
 
+version 0.6.5
+  - tpm2: Reset too large size indicators in TPM2B to avoid access beyond buffer
+  - tpm2: Restore original value in buffer if unmarshalled one was illegal
+
 version 0.6.4
   - tpm2: Fix public key context save due to ANY_OBJECT_Marshal usage
     This fixes a suspend/resume problem when public keys are

--- a/configure.ac
+++ b/configure.ac
@@ -3,11 +3,11 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms], [0.6.5])
-AC_PREREQ(2.12)
+AC_INIT([libtpms],[0.6.5])
+AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_TARGET
@@ -27,7 +27,7 @@ AC_SUBST([LIBTPMS_VERSION_INFO])
 
 DEBUG=""
 AC_MSG_CHECKING([for debug-enabled build])
-AC_ARG_ENABLE(debug, AC_HELP_STRING([--enable-debug], [create a debug build]),
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[create a debug build]),
   [if test "$enableval" = "yes"; then
      DEBUG="yes"
      AC_MSG_RESULT([yes])
@@ -70,8 +70,7 @@ cryptolib=freebl
 AC_SUBST(cryptolib, $cryptolib)
 
 AC_ARG_WITH([openssl],
-            AC_HELP_STRING([--with-openssl],
-                           [build libtpms with openssl library]),
+            AS_HELP_STRING([--with-openssl],[build libtpms with openssl library]),
               [AC_CHECK_LIB(crypto,
                             [AES_set_encrypt_key],
                             [],
@@ -134,8 +133,7 @@ openssl)
 esac
 
 AC_ARG_WITH([tpm2],
-	AC_HELP_STRING([--with-tpm2],
-		       [build libtpms with TPM2 support (experimental)]),
+	AS_HELP_STRING([--with-tpm2],[build libtpms with TPM2 support (experimental)]),
 	AC_MSG_RESULT([Building with TPM2 support])
 	if test "x$cryptolib" = "xfreebl"; then
 		AC_MSG_ERROR([TPM2 support requires openssl crypto library])
@@ -161,12 +159,11 @@ AC_ARG_ENABLE([test-coverage],
 LT_INIT
 AC_PROG_CC
 AC_PROG_INSTALL
-AC_PROG_LIBTOOL
+LT_INIT
 
 #AM_GNU_GETTEXT_VERSION([0.15])
 #AM_GNU_GETTEXT([external])
 
-AC_HEADER_STDC
 AC_C_CONST
 AC_C_INLINE
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms], [0.6.4])
+AC_INIT([libtpms], [0.6.5])
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.6.4
+%define version   0.6.5
 %define release   1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 6
-#define TPM_LIBRARY_VER_MICRO 4
+#define TPM_LIBRARY_VER_MICRO 5
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/Marshal.c
+++ b/src/tpm2/Marshal.c
@@ -61,6 +61,7 @@
 
 /* rev 136 */
 
+#include <assert.h> // libtpms added
 #include <string.h>
 
 #include "Tpm.h"
@@ -190,9 +191,10 @@ Array_Marshal(BYTE *sourceBuffer, UINT16 sourceSize, BYTE **buffer, INT32 *size)
 }
 
 UINT16
-TPM2B_Marshal(TPM2B *source, BYTE **buffer, INT32 *size)
+TPM2B_Marshal(TPM2B *source, UINT32 maxSize, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
+    assert(source->size <= maxSize); // libtpms added
     written += UINT16_Marshal(&(source->size), buffer, size);
     written += Array_Marshal(source->buffer, source->size, buffer, size); 
     return written;
@@ -517,7 +519,7 @@ UINT16
 TPM2B_DIGEST_Marshal(TPM2B_DIGEST *source, BYTE **buffer, INT32 *size)
 {
 UINT16 written = 0;
-written += TPM2B_Marshal(&source->b, buffer, size);
+written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
 return written;
 }
 
@@ -527,7 +529,7 @@ UINT16
 TPM2B_DATA_Marshal(TPM2B_DATA *source, BYTE **buffer, INT32 *size)
 {
 UINT16 written = 0;
-written += TPM2B_Marshal(&source->b, buffer, size);
+written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
 return written;
 }
 
@@ -557,7 +559,7 @@ UINT16
 TPM2B_MAX_BUFFER_Marshal(TPM2B_MAX_BUFFER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -567,7 +569,7 @@ UINT16
 TPM2B_MAX_NV_BUFFER_Marshal(TPM2B_MAX_NV_BUFFER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -576,7 +578,7 @@ UINT16
 TPM2B_TIMEOUT_Marshal(TPM2B_TIMEOUT *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -586,7 +588,7 @@ UINT16
 TPM2B_IV_Marshal(TPM2B_IV *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -596,7 +598,7 @@ UINT16
 TPM2B_NAME_Marshal(TPM2B_NAME *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.name), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1133,7 +1135,7 @@ UINT16
 TPM2B_ATTEST_Marshal(TPM2B_ATTEST *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.attestationData), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1254,7 +1256,7 @@ UINT16
 TPM2B_SYM_KEY_Marshal(TPM2B_SYM_KEY *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1275,7 +1277,7 @@ UINT16
 TPM2B_SENSITIVE_DATA_Marshal(TPM2B_SENSITIVE_DATA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1635,7 +1637,7 @@ UINT16
 TPM2B_PUBLIC_KEY_RSA_Marshal(TPM2B_PUBLIC_KEY_RSA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1655,7 +1657,7 @@ UINT16
 TPM2B_PRIVATE_KEY_RSA_Marshal(TPM2B_PRIVATE_KEY_RSA *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1665,7 +1667,7 @@ UINT16
 TPM2B_ECC_PARAMETER_Marshal(TPM2B_ECC_PARAMETER *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -1901,7 +1903,7 @@ UINT16
 TPM2B_ENCRYPTED_SECRET_Marshal(TPM2B_ENCRYPTED_SECRET *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.secret), buffer, size); // libtpms changed
     return written;
 }
  
@@ -2123,7 +2125,7 @@ UINT16
 TPM2B_PRIVATE_Marshal(TPM2B_PRIVATE *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 
@@ -2133,7 +2135,7 @@ UINT16
 TPM2B_ID_OBJECT_Marshal(TPM2B_ID_OBJECT *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.credential), buffer, size); // libtpms changed
     return written;
 }
 
@@ -2190,7 +2192,7 @@ UINT16
 TPM2B_CONTEXT_DATA_Marshal(TPM2B_CONTEXT_DATA  *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size); // libtpms changed
     return written;
 }
 

--- a/src/tpm2/Marshal_fp.h
+++ b/src/tpm2/Marshal_fp.h
@@ -83,7 +83,7 @@ extern "C" {
     UINT16
     Array_Marshal(BYTE *sourceBuffer, UINT16 sourceSize, BYTE **buffer, INT32 *size);
     UINT16
-    TPM2B_Marshal(TPM2B *source, BYTE **buffer, INT32 *size);
+    TPM2B_Marshal(TPM2B *source, UINT32 maxSize, BYTE **buffer, INT32 *size); // libtpms changed
     UINT16
     TPM_KEY_BITS_Marshal(TPM_KEY_BITS *source, BYTE **buffer, INT32 *size);
     UINT16

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -255,7 +255,7 @@ UINT16
 TPM2B_PROOF_Marshal(TPM2B_PROOF *source, BYTE **buffer, INT32 *size)
 {
     UINT16 written = 0;
-    written += TPM2B_Marshal(&source->b, buffer, size);
+    written += TPM2B_Marshal(&source->b, sizeof(source->t.buffer), buffer, size);
     return written;
 }
 
@@ -1328,7 +1328,7 @@ STATE_RESET_DATA_Marshal(STATE_RESET_DATA *data, BYTE **buffer, INT32 *size)
                                 STATE_RESET_DATA_VERSION,
                                 STATE_RESET_DATA_MAGIC, 1);
     written += TPM2B_PROOF_Marshal(&data->nullProof, buffer, size);
-    written += TPM2B_Marshal(&data->nullSeed.b, buffer, size);
+    written += TPM2B_Marshal(&data->nullSeed.b, sizeof(data->nullSeed.t.buffer), buffer, size);
     written += UINT32_Marshal(&data->clearCount, buffer, size);
     written += UINT64_Marshal(&data->objectContextID, buffer, size);
 
@@ -2108,7 +2108,7 @@ TPM2B_HASH_BLOCK_Marshal(TPM2B_HASH_BLOCK *data, BYTE **buffer, INT32 *size)
 {
     UINT16 written;
 
-    written = TPM2B_Marshal(&data->b, buffer, size);
+    written = TPM2B_Marshal(&data->b, sizeof(data->t.buffer), buffer, size);
 
     return written;
 }
@@ -2973,9 +2973,9 @@ VolatileState_Marshal(BYTE **buffer, INT32 *size)
 
     /* tie the volatile state to the EP,SP, and PPSeed */
     NvRead(&pd, NV_PERSISTENT_DATA, sizeof(pd));
-    written += TPM2B_Marshal(&pd.EPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&pd.SPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&pd.PPSeed.b, buffer, size);
+    written += TPM2B_Marshal(&pd.EPSeed.b, sizeof(pd.EPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&pd.SPSeed.b, sizeof(pd.SPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&pd.PPSeed.b, sizeof(pd.PPSeed.t.buffer), buffer, size);
 
     written += BLOCK_SKIP_WRITE_PUSH(TRUE, buffer, size); /* v4 */
 
@@ -3776,9 +3776,9 @@ PERSISTENT_DATA_Marshal(PERSISTENT_DATA *data, BYTE **buffer, INT32 *size)
     written += TPM2B_AUTH_Marshal(&data->ownerAuth, buffer, size);
     written += TPM2B_AUTH_Marshal(&data->endorsementAuth, buffer, size);
     written += TPM2B_AUTH_Marshal(&data->lockoutAuth, buffer, size);
-    written += TPM2B_Marshal(&data->EPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&data->SPSeed.b, buffer, size);
-    written += TPM2B_Marshal(&data->PPSeed.b, buffer, size);
+    written += TPM2B_Marshal(&data->EPSeed.b, sizeof(data->EPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&data->SPSeed.b, sizeof(data->SPSeed.t.buffer), buffer, size);
+    written += TPM2B_Marshal(&data->PPSeed.b, sizeof(data->PPSeed.t.buffer), buffer, size);
     written += TPM2B_PROOF_Marshal(&data->phProof, buffer, size);
     written += TPM2B_PROOF_Marshal(&data->shProof, buffer, size);
     written += TPM2B_PROOF_Marshal(&data->ehProof, buffer, size);

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -1435,6 +1435,7 @@ bn_prime_t_Unmarshal(bn_prime_t *data, BYTE **buffer, INT32 *size)
                                 "allocated %zu\n",
                                 (size_t)data->size, (size_t)data->allocated);
             rc = TPM_RC_SIZE;
+            data->size = 0;
         }
     }
 

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -144,6 +144,7 @@ TPM2B_Unmarshal(TPM2B *target, UINT16 targetSize, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size > targetSize) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1650,6 +1651,7 @@ TPMS_PCR_SELECTION_Unmarshal(TPMS_PCR_SELECTION *target, BYTE **buffer, INT32 *s
 	if ((target->sizeofSelect < PCR_SELECT_MIN) ||
 	    (target->sizeofSelect > PCR_SELECT_MAX)) {
 	    rc = TPM_RC_VALUE;
+	    target->sizeofSelect = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1820,6 +1822,7 @@ TPML_CC_Unmarshal(TPML_CC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_CC) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1857,6 +1860,7 @@ TPML_CCA_Unmarshal(TPML_CCA *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_CC) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1879,6 +1883,7 @@ TPML_ALG_Unmarshal(TPML_ALG *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_ALG_LIST_SIZE) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1901,6 +1906,7 @@ TPML_HANDLE_Unmarshal(TPML_HANDLE *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_HANDLES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1928,11 +1934,13 @@ TPML_DIGEST_Unmarshal(TPML_DIGEST *target, BYTE **buffer, INT32 *size)
 	/* TPM side is hard coded to 2 minimum */
 	if (target->count < 2) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > 8) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1955,6 +1963,7 @@ TPML_DIGEST_VALUES_Unmarshal(TPML_DIGEST_VALUES *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1977,6 +1986,7 @@ TPML_PCR_SELECTION_Unmarshal(TPML_PCR_SELECTION *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > HASH_COUNT) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -1999,6 +2009,7 @@ TPML_ALG_PROPERTY_Unmarshal(TPML_ALG_PROPERTY *target, BYTE **buffer, INT32 *siz
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_CAP_ALGS) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2021,6 +2032,7 @@ TPML_TAGGED_TPM_PROPERTY_Unmarshal(TPML_TAGGED_TPM_PROPERTY  *target, BYTE **buf
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_TPM_PROPERTIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2043,6 +2055,7 @@ TPML_TAGGED_PCR_PROPERTY_Unmarshal(TPML_TAGGED_PCR_PROPERTY *target, BYTE **buff
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_PCR_PROPERTIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2065,6 +2078,7 @@ TPML_ECC_CURVE_Unmarshal(TPML_ECC_CURVE *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_ECC_CURVES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2087,6 +2101,7 @@ TPML_TAGGED_POLICY_Unmarshal(TPML_TAGGED_POLICY *target, BYTE **buffer, INT32 *s
     if (rc == TPM_RC_SUCCESS) {
 	if (target->count > MAX_TAGGED_POLICIES) {
 	    rc = TPM_RC_SIZE;
+	    target->count = 0; // libtpms added
 	}
     }
     for (i = 0 ; (rc == TPM_RC_SUCCESS) && (i < target->count) ; i++) {
@@ -2766,6 +2781,7 @@ TPM2B_SENSITIVE_CREATE_Unmarshal(TPM2B_SENSITIVE_CREATE *target, BYTE **buffer, 
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -3542,6 +3558,7 @@ TPM2B_ECC_POINT_Unmarshal(TPM2B_ECC_POINT *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -4126,6 +4143,7 @@ TPM2B_PUBLIC_Unmarshal(TPM2B_PUBLIC *target, BYTE **buffer, INT32 *size, BOOL al
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;
@@ -4236,6 +4254,7 @@ TPM2B_SENSITIVE_Unmarshal(TPM2B_SENSITIVE *target, BYTE **buffer, INT32 *size)
 	if (rc == TPM_RC_SUCCESS) {
 	    if (target->size != startSize - *size) {
 		rc = TPM_RC_SIZE;
+		target->size = 0; // libtpms added
 	    }
 	}
     }
@@ -4311,6 +4330,7 @@ TPMS_NV_PUBLIC_Unmarshal(TPMS_NV_PUBLIC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->dataSize > MAX_NV_INDEX_SIZE) {
 	    rc = TPM_RC_SIZE;
+	    target->dataSize = 0; // libtpms added
 	}
     }
     return rc;
@@ -4341,6 +4361,7 @@ TPM2B_NV_PUBLIC_Unmarshal(TPM2B_NV_PUBLIC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->size != startSize - *size) {
 	    rc = TPM_RC_SIZE;
+	    target->size = 0; // libtpms added
 	}
     }
     return rc;

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -172,6 +172,7 @@ TPM_RC
 TPM_GENERATED_Unmarshal(TPM_GENERATED *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_GENERATED orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal(target, buffer, size);  
@@ -179,6 +180,7 @@ TPM_GENERATED_Unmarshal(TPM_GENERATED *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target != TPM_GENERATED_VALUE) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -204,6 +206,7 @@ TPM_RC
 TPM_ECC_CURVE_Unmarshal(TPM_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ECC_CURVE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT16_Unmarshal(target, buffer, size);
@@ -222,6 +225,7 @@ TPM_ECC_CURVE_Unmarshal(TPM_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_CURVE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -260,6 +264,7 @@ TPM_RC
 TPM_CLOCK_ADJUST_Unmarshal(TPM_CLOCK_ADJUST *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_CLOCK_ADJUST orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = INT8_Unmarshal(target, buffer, size);  
@@ -276,6 +281,7 @@ TPM_CLOCK_ADJUST_Unmarshal(TPM_CLOCK_ADJUST *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -287,6 +293,7 @@ TPM_RC
 TPM_EO_Unmarshal(TPM_EO *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_EO orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT16_Unmarshal(target, buffer, size);  
@@ -308,6 +315,7 @@ TPM_EO_Unmarshal(TPM_EO *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -319,6 +327,7 @@ TPM_RC
 TPM_ST_Unmarshal(TPM_ST *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT16_Unmarshal(target, buffer, size);  
@@ -344,6 +353,7 @@ TPM_ST_Unmarshal(TPM_ST *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -355,6 +365,7 @@ TPM_RC
 TPM_SU_Unmarshal(TPM_SU *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_SU orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT16_Unmarshal(target, buffer, size);  
@@ -366,6 +377,7 @@ TPM_SU_Unmarshal(TPM_SU *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -377,6 +389,7 @@ TPM_RC
 TPM_SE_Unmarshal(TPM_SE *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_SE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT8_Unmarshal(target, buffer, size);  
@@ -389,6 +402,7 @@ TPM_SE_Unmarshal(TPM_SE *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -400,6 +414,7 @@ TPM_RC
 TPM_CAP_Unmarshal(TPM_CAP *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_CAP orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal(target, buffer, size);  
@@ -420,6 +435,7 @@ TPM_CAP_Unmarshal(TPM_CAP *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -470,6 +486,7 @@ TPM_RC
 TPMA_ALGORITHM_Unmarshal(TPMA_ALGORITHM *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_ALGORITHM orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal((UINT32 *)target, buffer, size); /* libtpms changed */
@@ -477,6 +494,7 @@ TPMA_ALGORITHM_Unmarshal(TPMA_ALGORITHM *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_ALGORITHM_reserved) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -488,6 +506,7 @@ TPM_RC
 TPMA_OBJECT_Unmarshal(TPMA_OBJECT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_OBJECT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal((UINT32 *)target, buffer, size); /* libtpms changed */
@@ -495,6 +514,7 @@ TPMA_OBJECT_Unmarshal(TPMA_OBJECT *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_OBJECT_reserved) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -506,6 +526,7 @@ TPM_RC
 TPMA_SESSION_Unmarshal(TPMA_SESSION *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_SESSION orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT8_Unmarshal((UINT8 *)target, buffer, size);  /* libtpms changed */
@@ -513,6 +534,7 @@ TPMA_SESSION_Unmarshal(TPMA_SESSION *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_SESSION_reserved) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -537,6 +559,7 @@ TPM_RC
 TPMA_CC_Unmarshal(TPMA_CC *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_CC orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal((UINT32 *)target, buffer, size); /* libtpms changed */
@@ -544,6 +567,7 @@ TPMA_CC_Unmarshal(TPMA_CC *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_CC_reserved) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -555,6 +579,7 @@ TPM_RC
 TPMI_YES_NO_Unmarshal(TPMI_YES_NO *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_YES_NO orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT8_Unmarshal(target, buffer, size);  
@@ -566,6 +591,7 @@ TPMI_YES_NO_Unmarshal(TPMI_YES_NO *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -577,6 +603,7 @@ TPM_RC
 TPMI_DH_OBJECT_Unmarshal(TPMI_DH_OBJECT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_OBJECT orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -589,6 +616,7 @@ TPMI_DH_OBJECT_Unmarshal(TPMI_DH_OBJECT *target, BYTE **buffer, INT32 *size, BOO
 	    isNotPersistent &&
 	    isNotLegalNull) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -600,6 +628,7 @@ TPM_RC
 TPMI_DH_PARENT_Unmarshal(TPMI_DH_PARENT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_PARENT orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -618,6 +647,7 @@ TPMI_DH_PARENT_Unmarshal(TPMI_DH_PARENT *target, BYTE **buffer, INT32 *size, BOO
 	    isNotEndorsement && 
 	    isNotLegalNull) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -629,6 +659,7 @@ TPM_RC
 TPMI_DH_PERSISTENT_Unmarshal(TPMI_DH_PERSISTENT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_PERSISTENT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -637,6 +668,7 @@ TPMI_DH_PERSISTENT_Unmarshal(TPMI_DH_PERSISTENT *target, BYTE **buffer, INT32 *s
 	BOOL isNotPersistent = (*target < PERSISTENT_FIRST) || (*target > PERSISTENT_LAST);
 	if (isNotPersistent) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -648,6 +680,7 @@ TPM_RC
 TPMI_DH_ENTITY_Unmarshal(TPMI_DH_ENTITY *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_ENTITY orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -674,6 +707,7 @@ TPMI_DH_ENTITY_Unmarshal(TPMI_DH_ENTITY *target, BYTE **buffer, INT32 *size, BOO
 	    isNotAuth &&
 	    isNotLegalNull) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -685,6 +719,7 @@ TPM_RC
 TPMI_DH_PCR_Unmarshal(TPMI_DH_PCR *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_PCR orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -695,6 +730,7 @@ TPMI_DH_PCR_Unmarshal(TPMI_DH_PCR *target, BYTE **buffer, INT32 *size, BOOL allo
 	if (isNotPcr &&
 	    isNotLegalNull) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -706,6 +742,7 @@ TPM_RC
 TPMI_SH_AUTH_SESSION_Unmarshal(TPMI_SH_AUTH_SESSION *target, BYTE **buffer, INT32 *size, BOOL allowPwd)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SH_AUTH_SESSION orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -718,6 +755,7 @@ TPMI_SH_AUTH_SESSION_Unmarshal(TPMI_SH_AUTH_SESSION *target, BYTE **buffer, INT3
 	    isNotPolicySession &&
 	    isNotLegalPwd) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -729,6 +767,7 @@ TPM_RC
 TPMI_SH_HMAC_Unmarshal(TPMI_SH_HMAC *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SH_HMAC orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -737,6 +776,7 @@ TPMI_SH_HMAC_Unmarshal(TPMI_SH_HMAC *target, BYTE **buffer, INT32 *size)
 	BOOL isNotHmacSession = (*target < HMAC_SESSION_FIRST ) || (*target > HMAC_SESSION_LAST);
 	if (isNotHmacSession) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -748,6 +788,7 @@ TPM_RC
 TPMI_SH_POLICY_Unmarshal(TPMI_SH_POLICY *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SH_POLICY orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -756,6 +797,7 @@ TPMI_SH_POLICY_Unmarshal(TPMI_SH_POLICY *target, BYTE **buffer, INT32 *size)
 	BOOL isNotPolicySession = (*target < POLICY_SESSION_FIRST) || (*target > POLICY_SESSION_LAST);
 	if (isNotPolicySession) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -767,6 +809,7 @@ TPM_RC
 TPMI_DH_CONTEXT_Unmarshal(TPMI_DH_CONTEXT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_CONTEXT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -779,6 +822,7 @@ TPMI_DH_CONTEXT_Unmarshal(TPMI_DH_CONTEXT *target, BYTE **buffer, INT32 *size)
 	    isNotPolicySession &&
 	    isNotTransient) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -790,6 +834,7 @@ TPM_RC
 TPMI_DH_SAVED_Unmarshal(TPMI_DH_SAVED *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_DH_SAVED orig_target = *target; // libtpms added
     allowNull = allowNull;
 
     if (rc == TPM_RC_SUCCESS) {
@@ -807,6 +852,7 @@ TPMI_DH_SAVED_Unmarshal(TPMI_DH_SAVED *target, BYTE **buffer, INT32 *size, BOOL 
 	    isNotSequenceObject &&
 	    isNotTransientStClear) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -818,6 +864,7 @@ TPM_RC
 TPMI_RH_HIERARCHY_Unmarshal(TPMI_RH_HIERARCHY *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_HIERARCHY orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -834,6 +881,7 @@ TPMI_RH_HIERARCHY_Unmarshal(TPMI_RH_HIERARCHY *target, BYTE **buffer, INT32 *siz
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -845,6 +893,7 @@ TPM_RC
 TPMI_RH_ENABLES_Unmarshal(TPMI_RH_ENABLES *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_ENABLES orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -862,6 +911,7 @@ TPMI_RH_ENABLES_Unmarshal(TPMI_RH_ENABLES *target, BYTE **buffer, INT32 *size, B
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -873,6 +923,7 @@ TPM_RC
 TPMI_RH_HIERARCHY_AUTH_Unmarshal(TPMI_RH_HIERARCHY_AUTH *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_HIERARCHY_AUTH orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -886,6 +937,7 @@ TPMI_RH_HIERARCHY_AUTH_Unmarshal(TPMI_RH_HIERARCHY_AUTH *target, BYTE **buffer, 
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -897,6 +949,7 @@ TPM_RC
 TPMI_RH_PLATFORM_Unmarshal(TPMI_RH_PLATFORM *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_PLATFORM orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -907,6 +960,7 @@ TPMI_RH_PLATFORM_Unmarshal(TPMI_RH_PLATFORM *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -918,6 +972,7 @@ TPM_RC
 TPMI_RH_ENDORSEMENT_Unmarshal(TPMI_RH_ENDORSEMENT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_ENDORSEMENT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -932,6 +987,7 @@ TPMI_RH_ENDORSEMENT_Unmarshal(TPMI_RH_ENDORSEMENT *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -943,6 +999,7 @@ TPM_RC
 TPMI_RH_PROVISION_Unmarshal(TPMI_RH_PROVISION *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_PROVISION orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -954,6 +1011,7 @@ TPMI_RH_PROVISION_Unmarshal(TPMI_RH_PROVISION *target, BYTE **buffer, INT32 *siz
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -965,6 +1023,7 @@ TPM_RC
 TPMI_RH_CLEAR_Unmarshal(TPMI_RH_CLEAR *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_CLEAR orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -976,6 +1035,7 @@ TPMI_RH_CLEAR_Unmarshal(TPMI_RH_CLEAR *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -987,6 +1047,7 @@ TPM_RC
 TPMI_RH_NV_AUTH_Unmarshal(TPMI_RH_NV_AUTH *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_NV_AUTH orig_target = *target; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -1001,6 +1062,7 @@ TPMI_RH_NV_AUTH_Unmarshal(TPMI_RH_NV_AUTH *target, BYTE **buffer, INT32 *size)
 		  BOOL isNotNv = (*target < NV_INDEX_FIRST) || (*target > NV_INDEX_LAST);
 		  if (isNotNv) {
 		      rc = TPM_RC_VALUE;
+		      *target = orig_target; // libtpms added
 		  }
 	      }
 	}
@@ -1014,6 +1076,7 @@ TPM_RC
 TPMI_RH_LOCKOUT_Unmarshal(TPMI_RH_LOCKOUT *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_LOCKOUT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -1024,6 +1087,7 @@ TPMI_RH_LOCKOUT_Unmarshal(TPMI_RH_LOCKOUT *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1035,6 +1099,7 @@ TPM_RC
 TPMI_RH_NV_INDEX_Unmarshal(TPMI_RH_NV_INDEX *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RH_NV_INDEX orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_HANDLE_Unmarshal(target, buffer, size);  
@@ -1043,6 +1108,7 @@ TPMI_RH_NV_INDEX_Unmarshal(TPMI_RH_NV_INDEX *target, BYTE **buffer, INT32 *size)
 	BOOL isNotNv = (*target < NV_INDEX_FIRST) || (*target > NV_INDEX_LAST);
 	if (isNotNv) {
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1054,6 +1120,7 @@ TPM_RC
 TPMI_ALG_HASH_Unmarshal(TPMI_ALG_HASH *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_HASH orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1082,6 +1149,7 @@ TPMI_ALG_HASH_Unmarshal(TPMI_ALG_HASH *target, BYTE **buffer, INT32 *size, BOOL 
 	    }
 	  default:
 	    rc = TPM_RC_HASH;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1093,6 +1161,7 @@ TPM_RC
 TPMI_ALG_SYM_Unmarshal(TPMI_ALG_SYM *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_SYM orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1121,6 +1190,7 @@ TPMI_ALG_SYM_Unmarshal(TPMI_ALG_SYM *target, BYTE **buffer, INT32 *size, BOOL al
 	    }
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1132,6 +1202,7 @@ TPM_RC
 TPMI_ALG_SYM_OBJECT_Unmarshal(TPMI_ALG_SYM_OBJECT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_SYM_OBJECT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1157,6 +1228,7 @@ TPMI_ALG_SYM_OBJECT_Unmarshal(TPMI_ALG_SYM_OBJECT *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1168,6 +1240,7 @@ TPM_RC
 TPMI_ALG_SYM_MODE_Unmarshal(TPMI_ALG_SYM_MODE *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_SYM_MODE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1199,6 +1272,7 @@ TPMI_ALG_SYM_MODE_Unmarshal(TPMI_ALG_SYM_MODE *target, BYTE **buffer, INT32 *siz
 	    }
 	  default:
 	    rc = TPM_RC_MODE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1210,6 +1284,7 @@ TPM_RC
 TPMI_ALG_KDF_Unmarshal(TPMI_ALG_KDF *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_KDF orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1235,6 +1310,7 @@ TPMI_ALG_KDF_Unmarshal(TPMI_ALG_KDF *target, BYTE **buffer, INT32 *size, BOOL al
 	    }
 	  default:
 	    rc = TPM_RC_KDF;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1246,6 +1322,7 @@ TPM_RC
 TPMI_ALG_SIG_SCHEME_Unmarshal(TPMI_ALG_SIG_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_SIG_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1280,6 +1357,7 @@ TPMI_ALG_SIG_SCHEME_Unmarshal(TPMI_ALG_SIG_SCHEME *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_SCHEME;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1291,6 +1369,7 @@ TPM_RC
 TPMI_ECC_KEY_EXCHANGE_Unmarshal(TPMI_ECC_KEY_EXCHANGE *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ECC_KEY_EXCHANGE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1313,6 +1392,7 @@ TPMI_ECC_KEY_EXCHANGE_Unmarshal(TPMI_ECC_KEY_EXCHANGE *target, BYTE **buffer, IN
 	    }
 	  default:
 	    rc = TPM_RC_SCHEME;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1325,6 +1405,7 @@ TPM_RC
 TPMI_ST_COMMAND_TAG_Unmarshal(TPMI_ST_COMMAND_TAG *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ST_COMMAND_TAG orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(target, buffer, size);  
@@ -1336,6 +1417,7 @@ TPMI_ST_COMMAND_TAG_Unmarshal(TPMI_ST_COMMAND_TAG *target, BYTE **buffer, INT32 
 	    break;
 	  default:
 	    rc = TPM_RC_BAD_TAG;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1347,6 +1429,7 @@ TPM_RC
 TPMI_ALG_MAC_SCHEME_Unmarshal(TPMI_ALG_MAC_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_MAC_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1378,6 +1461,7 @@ TPMI_ALG_MAC_SCHEME_Unmarshal(TPMI_ALG_MAC_SCHEME *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1389,6 +1473,7 @@ TPM_RC
 TPMI_ALG_CIPHER_MODE_Unmarshal(TPMI_ALG_CIPHER_MODE*target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_CIPHER_MODE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -1417,6 +1502,7 @@ TPMI_ALG_CIPHER_MODE_Unmarshal(TPMI_ALG_CIPHER_MODE*target, BYTE **buffer, INT32
 	    }
 	  default:
 	    rc = TPM_RC_MODE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -1666,6 +1752,7 @@ TPM_RC
 TPMT_TK_CREATION_Unmarshal(TPMT_TK_CREATION *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_tag = target->tag; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(&target->tag, buffer, size);
@@ -1673,6 +1760,7 @@ TPMT_TK_CREATION_Unmarshal(TPMT_TK_CREATION *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->tag != TPM_ST_CREATION) {
 	    rc = TPM_RC_TAG;
+	    target->tag = orig_tag; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1690,6 +1778,7 @@ TPM_RC
 TPMT_TK_VERIFIED_Unmarshal(TPMT_TK_VERIFIED *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_tag = target->tag; // libtpms added
     
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(&target->tag, buffer, size);
@@ -1697,6 +1786,7 @@ TPMT_TK_VERIFIED_Unmarshal(TPMT_TK_VERIFIED *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (target->tag != TPM_ST_VERIFIED) {
 	    rc = TPM_RC_TAG;
+	    target->tag = orig_tag; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1714,6 +1804,7 @@ TPM_RC
 TPMT_TK_AUTH_Unmarshal(TPMT_TK_AUTH *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_tag = target->tag; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(&target->tag, buffer, size);
@@ -1722,6 +1813,7 @@ TPMT_TK_AUTH_Unmarshal(TPMT_TK_AUTH *target, BYTE **buffer, INT32 *size)
 	if ((target->tag != TPM_ST_AUTH_SIGNED) &&
 	    (target->tag != TPM_ST_AUTH_SECRET)) {
 	    rc = TPM_RC_TAG;
+	    target->tag = orig_tag; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -1739,6 +1831,7 @@ TPM_RC
 TPMT_TK_HASHCHECK_Unmarshal(TPMT_TK_HASHCHECK *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPM_ST orig_tag = target->tag; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(&target->tag, buffer, size);
@@ -1746,6 +1839,7 @@ TPMT_TK_HASHCHECK_Unmarshal(TPMT_TK_HASHCHECK *target, BYTE **buffer, INT32 *siz
     if (rc == TPM_RC_SUCCESS) {
 	if (target->tag != TPM_ST_HASHCHECK) {
 	    rc = TPM_RC_TAG;
+	    target->tag = orig_tag; // libtpms added
 	}
     }
     if (rc == TPM_RC_SUCCESS) {
@@ -2335,6 +2429,7 @@ TPM_RC
 TPMI_ST_ATTEST_Unmarshal(TPMI_ST_ATTEST *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ST_ATTEST orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ST_Unmarshal(target, buffer, size);
@@ -2351,6 +2446,7 @@ TPMI_ST_ATTEST_Unmarshal(TPMI_ST_ATTEST *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_SELECTOR;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2462,6 +2558,7 @@ TPM_RC
 TPMI_AES_KEY_BITS_Unmarshal(TPMI_AES_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_AES_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);  
@@ -2473,6 +2570,7 @@ TPMI_AES_KEY_BITS_Unmarshal(TPMI_AES_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2484,6 +2582,7 @@ TPM_RC
 TPMI_CAMELLIA_KEY_BITS_Unmarshal(TPMI_CAMELLIA_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_CAMELLIA_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);  
@@ -2494,6 +2593,7 @@ TPMI_CAMELLIA_KEY_BITS_Unmarshal(TPMI_CAMELLIA_KEY_BITS *target, BYTE **buffer, 
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2505,6 +2605,7 @@ TPM_RC
 TPMI_SM4_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SM4_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);  
@@ -2515,6 +2616,7 @@ TPMI_SM4_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2526,6 +2628,7 @@ TPM_RC
 TPMI_TDES_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_SM4_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);
@@ -2537,6 +2640,7 @@ TPMI_TDES_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *si
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -2822,6 +2926,7 @@ TPM_RC
 TPMI_ALG_KEYEDHASH_SCHEME_Unmarshal(TPMI_ALG_KEYEDHASH_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_KEYEDHASH_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -2841,6 +2946,7 @@ TPMI_ALG_KEYEDHASH_SCHEME_Unmarshal(TPMI_ALG_KEYEDHASH_SCHEME *target, BYTE **bu
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3225,6 +3331,7 @@ TPM_RC
 TPMI_ALG_ASYM_SCHEME_Unmarshal(TPMI_ALG_ASYM_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_ASYM_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3268,6 +3375,7 @@ TPMI_ALG_ASYM_SCHEME_Unmarshal(TPMI_ALG_ASYM_SCHEME *target, BYTE **buffer, INT3
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3364,6 +3472,7 @@ TPM_RC
 TPMI_ALG_RSA_SCHEME_Unmarshal(TPMI_ALG_RSA_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_RSA_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3389,6 +3498,7 @@ TPMI_ALG_RSA_SCHEME_Unmarshal(TPMI_ALG_RSA_SCHEME *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3416,6 +3526,7 @@ TPM_RC
 TPMI_ALG_RSA_DECRYPT_Unmarshal(TPMI_ALG_RSA_DECRYPT *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_RSA_DECRYPT orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3435,6 +3546,7 @@ TPMI_ALG_RSA_DECRYPT_Unmarshal(TPMI_ALG_RSA_DECRYPT *target, BYTE **buffer, INT3
 	    }
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3475,6 +3587,7 @@ TPM_RC
 TPMI_RSA_KEY_BITS_Unmarshal(TPMI_RSA_KEY_BITS *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_RSA_KEY_BITS orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_KEY_BITS_Unmarshal(target, buffer, size);  
@@ -3486,6 +3599,7 @@ TPMI_RSA_KEY_BITS_Unmarshal(TPMI_RSA_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3570,6 +3684,7 @@ TPM_RC
 TPMI_ALG_ECC_SCHEME_Unmarshal(TPMI_ALG_ECC_SCHEME *target, BYTE **buffer, INT32 *size, BOOL allowNull)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_ECC_SCHEME orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3601,6 +3716,7 @@ TPMI_ALG_ECC_SCHEME_Unmarshal(TPMI_ALG_ECC_SCHEME *target, BYTE **buffer, INT32 
 	    }
 	  default:
 	    rc = TPM_RC_SCHEME;
+	    *target = orig_target; //  libtpms added
 	}
     }
     return rc;
@@ -3612,6 +3728,7 @@ TPM_RC
 TPMI_ECC_CURVE_Unmarshal(TPMI_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ECC_CURVE orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ECC_CURVE_Unmarshal(target, buffer, size);  
@@ -3648,6 +3765,7 @@ TPMI_ECC_CURVE_Unmarshal(TPMI_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_CURVE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -3905,6 +4023,7 @@ TPM_RC
 TPMI_ALG_PUBLIC_Unmarshal(TPMI_ALG_PUBLIC *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMI_ALG_PUBLIC orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = TPM_ALG_ID_Unmarshal(target, buffer, size);  
@@ -3926,6 +4045,7 @@ TPMI_ALG_PUBLIC_Unmarshal(TPMI_ALG_PUBLIC *target, BYTE **buffer, INT32 *size)
 	    break;
 	  default:
 	    rc = TPM_RC_TYPE;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;
@@ -4293,6 +4413,7 @@ TPM_RC
 TPMA_NV_Unmarshal(TPMA_NV *target, BYTE **buffer, INT32 *size)
 {
     TPM_RC rc = TPM_RC_SUCCESS;
+    TPMA_NV orig_target = *target; // libtpms added
 
     if (rc == TPM_RC_SUCCESS) {
 	rc = UINT32_Unmarshal((UINT32 *)target, buffer, size);  /* libtpms changed */
@@ -4300,6 +4421,7 @@ TPMA_NV_Unmarshal(TPMA_NV *target, BYTE **buffer, INT32 *size)
     if (rc == TPM_RC_SUCCESS) {
 	if (*target & TPMA_NV_RESERVED) {
 	    rc = TPM_RC_RESERVED_BITS;
+	    *target = orig_target; // libtpms added
 	}
     }
     return rc;


### PR DESCRIPTION
This PR backports patches that resolve issues with bad input values and set TPM2B buffer size indicators to '0' if the input value was larger than the actual TPM2B type's buffer and in other cases restore the original value of a field if the unmarshalled value was found to be illegal. This prevents keeping around illegal buffer sizes and illegal values in memory that may cause issues.