### PR TITLE
tpm2: Avoid compiler warning by using memcpy instead of MemoryCopy (g…

### DIFF
--- a/src/tpm2/NVDynamic.c
+++ b/src/tpm2/NVDynamic.c
@@ -352,7 +352,7 @@ NvRamNext(
     if(currentAddr + sizeof(NV_RAM_HEADER) > RAM_ORDERLY_END)
 	return NULL;
     // read the header of the next entry
-    MemoryCopy(&header, currentAddr, sizeof(NV_RAM_HEADER));
+    memcpy(&header, currentAddr, sizeof(NV_RAM_HEADER)); // libtpms: do not use MemoryCopy to avoid gcc warning
     // if the size field is zero, then we have hit the end of the list
     if(header.size == 0)
 	// leave the *iter pointing at the end of the list


### PR DESCRIPTION
…cc 10.3)

Fix the following compiler warning from gcc 10.3.0 by using memcpy
instead of MemoryCopy (fixes issue #229).

tpm2/NVDynamic.c: In function 'NvRamGetEnd':
tpm2/NVDynamic.c:378:12: warning: function may return address of local variable [-Wreturn-local-addr]
  378 |     return iter;
      |            ^
tpm2/NVDynamic.c:339:26: note: declared here
  339 |     NV_RAM_HEADER        header;
      |                          ^
tpm2/NVDynamic.c: In function 'NvRamGetIndex':
tpm2/NVDynamic.c:411:12: warning: function may return address of local variable [-Wreturn-local-addr]
  411 |     return currentAddr;
      |            ^
tpm2/NVDynamic.c:339:26: note: declared here
  339 |     NV_RAM_HEADER        header;
      |                          ^

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>