### PR TITLE
tpm2: Avoid compiler warning by using memcpy instead of MemoryCopy (gcc 10.3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms],[0.8.4])
+AC_INIT([libtpms],[0.8.5])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.8.4
+%define version   0.8.5
 %define release   1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 8
-#define TPM_LIBRARY_VER_MICRO 4
+#define TPM_LIBRARY_VER_MICRO 5
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/NVDynamic.c
+++ b/src/tpm2/NVDynamic.c
@@ -352,7 +352,7 @@ NvRamNext(
     if(currentAddr + sizeof(NV_RAM_HEADER) > RAM_ORDERLY_END)
 	return NULL;
     // read the header of the next entry
-    MemoryCopy(&header, currentAddr, sizeof(NV_RAM_HEADER));
+    memcpy(&header, currentAddr, sizeof(NV_RAM_HEADER)); // libtpms: do not use MemoryCopy to avoid gcc warning
     // if the size field is zero, then we have hit the end of the list
     if(header.size == 0)
 	// leave the *iter pointing at the end of the list


### PR DESCRIPTION
Fix the following compiler warning from gcc 10.3.0 by using memcpy
instead of MemoryCopy (fixes issue #229).

tpm2/NVDynamic.c: In function 'NvRamGetEnd':
tpm2/NVDynamic.c:378:12: warning: function may return address of local variable [-Wreturn-local-addr]
  378 |     return iter;
      |            ^
tpm2/NVDynamic.c:339:26: note: declared here
  339 |     NV_RAM_HEADER        header;
      |                          ^
tpm2/NVDynamic.c: In function 'NvRamGetIndex':
tpm2/NVDynamic.c:411:12: warning: function may return address of local variable [-Wreturn-local-addr]
  411 |     return currentAddr;
      |            ^
tpm2/NVDynamic.c:339:26: note: declared here
  339 |     NV_RAM_HEADER        header;
      |                          ^

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>