### PR TITLE
tests: Extend the fuzzer with state suspend/resume at every step

### DIFF
--- a/tests/fuzz.cc
+++ b/tests/fuzz.cc
@@ -9,6 +9,13 @@
 #include <libtpms/tpm_error.h>
 #include <libtpms/tpm_memory.h>
 
+
+static void die(const char *msg)
+{
+    fprintf(stderr, "%s", msg);
+    assert(false);
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     unsigned char *rbuffer = NULL;
@@ -20,19 +27,20 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     };
 
     res = TPMLIB_ChooseTPMVersion(TPMLIB_TPM_VERSION_2);
-    assert(res == TPM_SUCCESS);
+    if (res != TPM_SUCCESS)
+        die("Could not choose the TPM version\n");
 
     res = TPMLIB_MainInit();
     if (res != TPM_SUCCESS)
-        fprintf(stderr, "Error: TPMLIB_MainInit() failed\n");
+        die("Error: TPMLIB_MainInit() failed\n");
 
     res = TPMLIB_Process(&rbuffer, &rlength, &rtotal, startup, sizeof(startup));
     if (res != TPM_SUCCESS)
-        fprintf(stderr, "Error: TPMLIB_Process(Startup) failed\n");
+        die("Error: TPMLIB_Process(Startup) failed\n");
 
     res = TPMLIB_Process(&rbuffer, &rlength, &rtotal, (unsigned char*)data, size);
     if (res != TPM_SUCCESS)
-        fprintf(stderr, "Error: TPMLIB_Process(fuzz-command) failed\n");
+        die("Error: TPMLIB_Process(fuzz-command) failed\n");
 
     TPMLIB_Terminate();
     TPM_Free(rbuffer);

--- a/tests/fuzz.cc
+++ b/tests/fuzz.cc
@@ -16,6 +16,43 @@ static void die(const char *msg)
     assert(false);
 }
 
+static TPM_RESULT mytpm_io_init(void)
+{
+    return TPM_SUCCESS;
+}
+
+static TPM_RESULT mytpm_io_getlocality(TPM_MODIFIER_INDICATOR *locModif,
+                                       uint32_t tpm_number)
+{
+    *locModif = 0;
+
+    return TPM_SUCCESS;
+}
+
+static TPM_RESULT mytpm_io_getphysicalpresence(TPM_BOOL *phyPres,
+                                               uint32_t tpm_number)
+{
+    *phyPres = FALSE;
+
+    return TPM_SUCCESS;
+}
+
+static TPM_RESULT mytpm_nvram_loaddata(unsigned char **data,
+                                       uint32_t *length,
+                                       uint32_t tpm_number,
+                                       const char *name)
+{
+    return TPM_RETRY;
+}
+
+static TPM_RESULT mytpm_nvram_storedata(const unsigned char *data,
+                                        uint32_t length,
+                                        uint32_t tpm_number,
+                                        const char *name)
+{
+    return TPM_SUCCESS;
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     unsigned char *rbuffer = NULL;
@@ -25,6 +62,19 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     unsigned char startup[] = {
         0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00
     };
+    struct libtpms_callbacks cbs = {
+        .sizeOfStruct               = sizeof(struct libtpms_callbacks),
+        .tpm_nvram_init             = NULL,
+        .tpm_nvram_loaddata         = mytpm_nvram_loaddata,
+        .tpm_nvram_storedata        = mytpm_nvram_storedata,
+        .tpm_nvram_deletename       = NULL,
+        .tpm_io_init                = mytpm_io_init,
+        .tpm_io_getlocality         = mytpm_io_getlocality,
+        .tpm_io_getphysicalpresence = mytpm_io_getphysicalpresence,
+    };
+    res = TPMLIB_RegisterCallbacks(&cbs);
+    if (res != TPM_SUCCESS)
+        die("Could not register callbacks\n");
 
     res = TPMLIB_ChooseTPMVersion(TPMLIB_TPM_VERSION_2);
     if (res != TPM_SUCCESS)


### PR DESCRIPTION
This PR extends the fuzzer with state suspend/resume at every step.