### PR TITLE
tpm2: Enable case statements depending on enabled key sizes of AES and Camellia

### DIFF
--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -2629,7 +2629,15 @@ TPMI_CAMELLIA_KEY_BITS_Unmarshal(TPMI_CAMELLIA_KEY_BITS *target, BYTE **buffer, 
     }
     if (rc == TPM_RC_SUCCESS) {
 	switch (*target) {
+#if CAMELLIA_128	// libtpms added
 	  case 128:
+#endif			// libtpms added begin
+#if CAMELLIA_192
+	  case 192:
+#endif
+#if CAMELLIA_256
+	  case 256:
+#endif			// libtpms added end
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -2605,8 +2605,15 @@ TPMI_AES_KEY_BITS_Unmarshal(TPMI_AES_KEY_BITS *target, BYTE **buffer, INT32 *siz
     }
     if (rc == TPM_RC_SUCCESS) {
 	switch (*target) {
+#if AES_128	// libtpms added
 	  case 128:
+#endif		// libtpms added begin
+#if AES_192
+	  case 192:
+#endif
+#if AES_256	// libtpms added end
 	  case 256:
+#endif		// libtpms added
 	    break;
 	  default:
 	    rc = TPM_RC_VALUE;


### PR DESCRIPTION
Enable case statements depending on enabled key sizes of AES and Camellia.