### PR TITLE
nvIndex: Fix null pointer dereference

### DIFF
--- a/src/tpm2/EACommands.c
+++ b/src/tpm2/EACommands.c
@@ -547,6 +547,7 @@ TPM2_PolicyNV(
 	    nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
 	    // Common read access checks. NvReadAccessChecks() may return
 	    // TPM_RC_NV_AUTHORIZATION, TPM_RC_NV_LOCKED, or TPM_RC_NV_UNINITIALIZED
+	    pAssert(nvIndex != NULL);
 	    result = NvReadAccessChecks(in->authHandle,
 					in->nvIndex,
 					nvIndex->publicArea.attributes);
@@ -1130,6 +1131,7 @@ TPM2_PolicyAuthorizeNV(
 	    // Common read access checks. NvReadAccessChecks() returns
 	    // TPM_RC_NV_AUTHORIZATION, TPM_RC_NV_LOCKED, or TPM_RC_NV_UNINITIALIZED
 	    // error may be returned at this point
+	    pAssert(nvIndex != NULL);
 	    result = NvReadAccessChecks(in->authHandle, in->nvIndex,
 					nvIndex->publicArea.attributes);
 	    if(result != TPM_RC_SUCCESS)

--- a/src/tpm2/Entity.c
+++ b/src/tpm2/Entity.c
@@ -380,7 +380,7 @@ EntityGetAuthPolicy(
 	    // authPolicy for a NV index
 	      {
 		  NV_INDEX        *nvIndex = NvGetIndexInfo(handle, NULL);
-		  pAssert(nvIndex != 0);
+		  pAssert(nvIndex != NULL);
 		  *authPolicy = nvIndex->publicArea.authPolicy;
 		  hashAlg = nvIndex->publicArea.nameAlg;
 	      }

--- a/src/tpm2/NVCommands.c
+++ b/src/tpm2/NVCommands.c
@@ -224,6 +224,7 @@ TPM2_NV_UndefineSpace(
 {
     NV_REF           locator;
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
+    pAssert(nvIndex != NULL);
     // Input Validation
     // This command can't be used to delete an index with TPMA_NV_POLICY_DELETE SET
     if(IS_ATTRIBUTE(nvIndex->publicArea.attributes, TPMA_NV, POLICY_DELETE))
@@ -250,6 +251,7 @@ TPM2_NV_UndefineSpaceSpecial(
     TPM_RC           result;
     NV_REF           locator;
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
+    pAssert(nvIndex != NULL);
     // Input Validation
     // This operation only applies when the TPMA_NV_POLICY_DELETE attribute is SET
     if(!IS_ATTRIBUTE(nvIndex->publicArea.attributes, TPMA_NV, POLICY_DELETE))
@@ -275,6 +277,7 @@ TPM2_NV_ReadPublic(
 		   )
 {
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, NULL);
+    pAssert(nvIndex != NULL);
     // Command Output
     // Copy index public data to output
     out->nvPublic.nvPublic = nvIndex->publicArea;
@@ -292,6 +295,7 @@ TPM2_NV_Write(
 	      )
 {
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, NULL);
+    pAssert(nvIndex != NULL);
     TPMA_NV          attributes = nvIndex->publicArea.attributes;
     TPM_RC           result;
     // Input Validation
@@ -341,6 +345,7 @@ TPM2_NV_Increment(
     NV_REF           locator;
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
     UINT64           countValue;
+    pAssert(nvIndex != NULL);
     // Input Validation
     // Common access checks, NvWriteAccessCheck() may return TPM_RC_NV_AUTHORIZATION
     // or TPM_RC_NV_LOCKED
@@ -394,6 +399,7 @@ TPM2_NV_Extend(
     TPM2B_DIGEST            oldDigest;
     TPM2B_DIGEST            newDigest;
     HASH_STATE              hashState;
+    pAssert(nvIndex != NULL);
     // Input Validation
     // Common access checks, NvWriteAccessCheck() may return TPM_RC_NV_AUTHORIZATION
     // or TPM_RC_NV_LOCKED
@@ -443,6 +449,7 @@ TPM2_NV_SetBits(
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
     UINT64           oldValue;
     UINT64           newValue;
+    pAssert(nvIndex != NULL);
     // Input Validation
     // Common access checks, NvWriteAccessCheck() may return TPM_RC_NV_AUTHORIZATION
     // or TPM_RC_NV_LOCKED
@@ -477,6 +484,7 @@ TPM2_NV_WriteLock(
     TPM_RC           result;
     NV_REF           locator;
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
+    pAssert(nvIndex != NULL);
     TPMA_NV          nvAttributes = nvIndex->publicArea.attributes;
     // Input Validation:
     // Common access checks, NvWriteAccessCheck() may return TPM_RC_NV_AUTHORIZATION
@@ -539,6 +547,7 @@ TPM2_NV_Read(
     NV_REF           locator;
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
     TPM_RC           result;
+    pAssert(nvIndex != NULL);
     // Input Validation
     // Common read access checks. NvReadAccessChecks() may return
     // TPM_RC_NV_AUTHORIZATION, TPM_RC_NV_LOCKED, or TPM_RC_NV_UNINITIALIZED
@@ -576,6 +585,7 @@ TPM2_NV_ReadLock(
     // The referenced index has been checked multiple times before this is called
     // so it must be present and will be loaded into cache
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
+    pAssert(nvIndex == NULL);
     TPMA_NV          nvAttributes = nvIndex->publicArea.attributes;
     // Input Validation
     // Common read access checks. NvReadAccessChecks() may return
@@ -612,6 +622,7 @@ TPM2_NV_ChangeAuth(
 {
     NV_REF           locator;
     NV_INDEX        *nvIndex = NvGetIndexInfo(in->nvIndex, &locator);
+    pAssert(nvIndex != NULL);
     // Input Validation
     // Remove trailing zeros and make sure that the result is not larger than the
     // digest of the nameAlg.
@@ -645,6 +656,7 @@ TPM2_NV_Certify(
 	return TPM_RCS_SCHEME + RC_NV_Certify_inScheme;
     // Common access checks, NvWriteAccessCheck() may return TPM_RC_NV_AUTHORIZATION
     // or TPM_RC_NV_LOCKED
+    pAssert(nvIndex != NULL);
     result = NvReadAccessChecks(in->authHandle, in->nvIndex,
 				nvIndex->publicArea.attributes);
     if(result != TPM_RC_SUCCESS)

--- a/src/tpm2/NVDynamic.c
+++ b/src/tpm2/NVDynamic.c
@@ -835,6 +835,7 @@ NvWriteIndexAttributes(
     if(IS_ATTRIBUTE(attributes, TPMA_NV, ORDERLY))
 	{
 	    NV_RAM_REF      ram = NvRamGetIndex(handle);
+	    pAssert(ram != 0);
 	    NvWriteRamIndexAttributes(ram, attributes);
 	    result = TPM_RC_SUCCESS;
 	}
@@ -1047,6 +1048,7 @@ NvGetNameByIndexHandle(
 		       )
 {
     NV_INDEX             *nvIndex = NvGetIndexInfo(handle, NULL);
+    pAssert(nvIndex != NULL);
     return NvGetIndexName(nvIndex, name);
 }
 /* 8.4.5.15 NvDefineIndex() */

--- a/src/tpm2/NV_spt.c
+++ b/src/tpm2/NV_spt.c
@@ -173,6 +173,7 @@ NvIsPinPassIndex(
     if(HandleGetType(index) == TPM_HT_NV_INDEX)
 	{
 	    NV_INDEX                *nvIndex = NvGetIndexInfo(index, NULL);
+	    pAssert(nvIndex != NULL);
 	    return IsNvPinPassIndex(nvIndex->publicArea.attributes);
 	}
     return FALSE;

--- a/src/tpm2/SessionCommands.c
+++ b/src/tpm2/SessionCommands.c
@@ -133,6 +133,7 @@ TPM2_StartAuthSession(
 	    // a PIN index can't be a bind object
 	      {
 		  NV_INDEX       *nvIndex = NvGetIndexInfo(in->bind, NULL);
+		  pAssert(nvIndex != NULL);
 		  if(IsNvPinPassIndex(nvIndex->publicArea.attributes)
 		     || IsNvPinFailIndex(nvIndex->publicArea.attributes))
 		      return TPM_RCS_HANDLE + RC_StartAuthSession_bind;

--- a/src/tpm2/SessionProcess.c
+++ b/src/tpm2/SessionProcess.c
@@ -99,6 +99,7 @@ IsDAExempted(
 	  case TPM_HT_NV_INDEX:
 	      {
 		  NV_INDEX            *nvIndex = NvGetIndexInfo(handle, NULL);
+		  pAssert(nvIndex != NULL);
 		  result = IS_ATTRIBUTE(nvIndex->publicArea.attributes, TPMA_NV, NO_DA);
 		  break;
 	      }
@@ -460,6 +461,7 @@ IsAuthPolicyAvailable(
 	    // An NV Index.
 	      {
 		  NV_INDEX         *nvIndex = NvGetIndexInfo(handle, NULL);
+		  pAssert(nvIndex != NULL);
 		  TPMA_NV           nvAttributes = nvIndex->publicArea.attributes;
 		  //
 		  // If the policy size is not zero, check if policy can be used.
@@ -986,6 +988,7 @@ CheckPolicyAuthSession(
 		return TPM_RC_POLICY_FAIL;
 	    // Get the index data
 	    nvIndex = NvGetIndexInfo(s_associatedHandles[sessionIndex], &locator);
+	    pAssert(nvIndex != NULL);
 	    // Make sure that the TPMA_WRITTEN_ATTRIBUTE has the desired state
 	    if((IS_ATTRIBUTE(nvIndex->publicArea.attributes, TPMA_NV, WRITTEN))
 	       != (session->attributes.nvWrittenState == SET))


### PR DESCRIPTION
Variable nvIndex is obtained via calling NvGetIndexInfo.
Unfortunately, the function call can return a NULL
pointer if the index was not found.

After the nvIndex is populated, potentially with NULL,
the pointer is accessed without checks. There are
places where this check happens, but they are
not exhaustive.

Ensure that all nvIndex obtained via NvGetIndexInfo
are guarded with asserts to avoid access to invalid
memory regions.

Signed-off-by: Alexandru Vasile <lexnv@amazon.com>