### PR TITLE
tpm2: Marshal event sequence objects' hash state

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -2245,7 +2245,7 @@ HMAC_STATE_Unmarshal(HMAC_STATE *data, BYTE **buffer, INT32 *size)
 }
 
 #define HASH_OBJECT_MAGIC 0xb874fe38
-#define HASH_OBJECT_VERSION 2
+#define HASH_OBJECT_VERSION 3
 
 static UINT16
 HASH_OBJECT_Marshal(HASH_OBJECT *data, BYTE **buffer, INT32 *size)
@@ -2261,7 +2261,8 @@ HASH_OBJECT_Marshal(HASH_OBJECT *data, BYTE **buffer, INT32 *size)
     written += TPMI_ALG_HASH_Marshal(&data->nameAlg, buffer, size);
     written += TPMA_OBJECT_Marshal(&data->objectAttributes, buffer, size);
     written += TPM2B_AUTH_Marshal(&data->auth, buffer, size);
-    if (data->attributes.hashSeq == SET) {
+    if (data->attributes.hashSeq == SET ||
+        data->attributes.eventSeq == SET /* since v3 */) {
         array_size = ARRAY_SIZE(data->state.hashState);
         written += UINT16_Marshal(&array_size, buffer, size);
         for (i = 0; i < array_size; i++) {
@@ -2309,7 +2310,9 @@ HASH_OBJECT_Unmarshal(HASH_OBJECT *data, BYTE **buffer, INT32 *size)
         rc = TPM2B_AUTH_Unmarshal(&data->auth, buffer, size);
     }
     if (rc == TPM_RC_SUCCESS) {
-        if (data->attributes.hashSeq == SET) {
+        /* hashSeq was always written correctly; eventSeq only appeared in v3 */
+        if (data->attributes.hashSeq == SET ||
+            (data->attributes.eventSeq == SET && hdr.version >= 3)) {
             if (rc == TPM_RC_SUCCESS) {
                 rc = UINT16_Unmarshal(&array_size, buffer, size);
             }


### PR DESCRIPTION
Event sequence objects were never properly marshalled and when their state
was saved and later restored their state may have been corrupted. Fix this
now by also marshalling the state of event sequence objects.

Bump up the version of the HASH_OBJECT's header to '3' so that previously
written state can be resumed if an event sequence object is encountered
and we only unmarshal an event sequence object when the version is at least
'3'.

Fixes issue #259.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>