### PR TITLE
Fix build and runtime for OpenSSL 3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -320,6 +320,7 @@ if test "x$enable_hardening" != "xno"; then
 fi
 
 AM_CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign -Wmissing-prototypes"
+AM_CFLAGS="$AM_CFLAGS -Wno-deprecated-declarations"
 AM_LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
 
 AC_SUBST([AM_CFLAGS])

--- a/configure.ac
+++ b/configure.ac
@@ -221,10 +221,19 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 	AC_CHECK_LIB([crypto], [EVP_PKEY_verify_init],, not_found=1)
 	AC_CHECK_LIB([crypto], [EVP_PKEY_verify],, not_found=1)
 	AC_CHECK_LIB([crypto], [EVP_get_digestbyname],, not_found=1)
-	AX_CHECK_DEFINE([<openssl/rsa.h>], [EVP_PKEY_CTX_set0_rsa_oaep_label],, not_found=1)
-	AX_CHECK_DEFINE([<openssl/rsa.h>], [EVP_PKEY_CTX_set_rsa_padding],, not_found=1)
-	AX_CHECK_DEFINE([<openssl/rsa.h>], [EVP_PKEY_CTX_set_rsa_oaep_md],, not_found=1)
-	AX_CHECK_DEFINE([<openssl/evp.h>], [EVP_PKEY_CTX_set_signature_md],, not_found=1)
+	# OpenSSL 3.0 turned some #defines into functions
+	AX_CHECK_DEFINE([<openssl/rsa.h>], [EVP_PKEY_CTX_set0_rsa_oaep_label],,
+	    AC_CHECK_LIB([crypto], [EVP_PKEY_CTX_set0_rsa_oaep_label],, not_found=1)
+	)
+	AX_CHECK_DEFINE([<openssl/rsa.h>], [EVP_PKEY_CTX_set_rsa_padding],,
+	    AC_CHECK_LIB([crypto], [EVP_PKEY_CTX_set_rsa_padding],, not_found=1)
+	)
+	AX_CHECK_DEFINE([<openssl/rsa.h>], [EVP_PKEY_CTX_set_rsa_oaep_md],,
+	    AC_CHECK_LIB([crypto], [EVP_PKEY_CTX_set_rsa_oaep_md],, not_found=1)
+	)
+	AX_CHECK_DEFINE([<openssl/evp.h>], [EVP_PKEY_CTX_set_signature_md],,
+	    AC_CHECK_LIB([crypto], [EVP_PKEY_CTX_set_signature_md],, not_found=1)
+	)
 	if test "x$not_found" = "x0"; then
 		use_openssl_functions_rsa=1
 		use_openssl_functions_for="${use_openssl_functions_for}RSA "

--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -1443,11 +1443,11 @@ CryptRsaDecrypt(
                 if (tmp == NULL)
                     ERROR_RETURN(TPM_RC_FAILURE);
                 memcpy(tmp, label->buffer, label->size);
-            }
 
-            if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, tmp, label->size) <= 0)
-                ERROR_RETURN(TPM_RC_FAILURE);
-            tmp = NULL;
+                if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, tmp, label->size) <= 0)
+                    ERROR_RETURN(TPM_RC_FAILURE);
+                tmp = NULL;
+            }
             break;
 	  default:
             ERROR_RETURN(TPM_RC_SCHEME);

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -492,7 +492,7 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
     BIGNUM       *dQ = BN_new();
     BIGNUM       *qInv = BN_new();
 #endif
-    RSA          *key;
+    RSA          *key = NULL;
     BN_CTX       *ctx = NULL;
     TPM_RC        retVal = InitOpenSSLRSAPublicKey(rsaKey, pkey);
 
@@ -507,7 +507,7 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
     if (P == NULL)
         ERROR_RETURN(TPM_RC_FAILURE)
 
-    key = EVP_PKEY_get0_RSA(*pkey);
+    key = EVP_PKEY_get1_RSA(*pkey);
     if (key == NULL)
         ERROR_RETURN(TPM_RC_FAILURE);
     RSA_get0_key(key, &N, &E, NULL);
@@ -554,6 +554,7 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
     BN_clear_free(P);
     BN_clear_free(Q);
     BN_free(Qr);
+    RSA_free(key); // undo reference from EVP_PKEY_get1_RSA()
 
     if (retVal != TPM_RC_SUCCESS) {
         BN_clear_free(D);


### PR DESCRIPTION
This PR fixes various aspects of the build of libtpms for OpenSSL 3.0 and also some runtime aspects of it.