### PR TITLE
build-sys: Use -DOPENSSL_SUPPRESS_DEPRECATED to suppress warning (OSS…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,8 @@ openssl)
         AC_DEFINE([USE_OPENSSL_CRYPTO_LIBRARY],
                   [1],
                   [use openssl crypto library])
+	LIBCRYPTO_EXTRA_CFLAGS="-DOPENSSL_SUPPRESS_DEPRECATED"
+	AC_SUBST([LIBCRYPTO_EXTRA_CFLAGS])
 	;;
 esac
 
@@ -320,7 +322,7 @@ if test "x$enable_hardening" != "xno"; then
 fi
 
 AM_CFLAGS="$CFLAGS $COVERAGE_CFLAGS -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign -Wmissing-prototypes"
-AM_CFLAGS="$AM_CFLAGS -Wno-deprecated-declarations"
+AM_CFLAGS="$AM_CFLAGS"
 AM_LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
 
 AC_SUBST([AM_CFLAGS])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,8 @@ common_CFLAGS = -include tpm_library_conf.h \
 		$(AM_CFLAGS) \
                 $(HARDENING_CFLAGS) \
                $(SANITIZERS) \
-               $(FUZZER)
+               $(FUZZER) \
+               $(LIBCRYPTO_EXTRA_CFLAGS)
 
 # build with libtpms callback support
 common_CFLAGS += -DTPM_LIBTPMS_CALLBACKS


### PR DESCRIPTION
…L 3)

Instead of using -Wno-deprecated-declarations use
-DOPENSSL_SUPPRESS_DEPRECATED to only suppress OpenSSL deprecated
declarations warnings.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>