### PR TITLE
tpm2: Do not write permanent state if only clock changed

### DIFF
--- a/src/tpm2/Time.c
+++ b/src/tpm2/Time.c
@@ -136,7 +136,16 @@ TimeClockUpdate(
 	    go.clockSafe = YES;
 	    // update the time
 	    go.clock = newTime;
+
+	    /* libtpms: Changing the clock alone does not cause the permanent
+	     *          state to be written to storage, there must be other
+	     *          reasons as well.
+	     */
+	    UPDATE_TYPE old_g_updateNV = g_updateNV;	// libtpms added
+
 	    NvWrite(NV_ORDERLY_DATA, sizeof(go), &go);
+
+	    g_updateNV = old_g_updateNV;		// libtpms added
 	}
     else
 	// No NV update needed so just update


### PR DESCRIPTION
To avoid timeouts on short-running commands, such as TPM2_PCR_Extend,
avoid triggering the writing of the permanent state of the TPM 2
if only the clock was updated. So the clock by itself will not cause
the permanent state to be written out anymore but there have to be
other reasons as well.

The state will still be written out upon a TPM2_Shutdown, which is
supposed to be the last command to be sent to the TPM when shutting
down the VM/vTPM. Also, the permanent state will still carry the
latest clock value if it is retrieved via control channel for
VM/VTPM suspend.

The case that may be affected, but is of lesser importance, is the one
where swtpm's volatile state is written to storage using 'swtpm_ioctl -v'
and then swtpm is terminated and restarted (similar to suspend/resume)
and the permanent state file is read from storage but does not contain
the latest clock value. In this case the go.clock will be updated when
the first command after resume is executed.

This fixes the swtpm issue https://github.com/stefanberger/swtpm/issues/597.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>