### PR TITLE
Fix "maybe-uninitialized" warning

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -3880,7 +3880,7 @@ PACompileConstants_Unmarshal(BYTE **buffer, INT32 *size)
     unsigned i;
     NV_HEADER hdr;
     UINT32 array_size;
-    UINT32 exp_array_size;
+    UINT32 exp_array_size = 0;
 
     if (rc == TPM_RC_SUCCESS) {
         rc = NV_HEADER_Unmarshal(&hdr, buffer, size,


### PR DESCRIPTION
exp_array_size is always initialized if `rc == TPM_RC_SUCCESS` and never used if `rc != TPM_RC_SUCCESS` but some compilers have trouble noticing this:

![image](https://user-images.githubusercontent.com/7763184/139433326-20368bc7-cc16-44e2-83ba-f8fe3c42ad5c.png)

```
  CC       tpm12/libtpms_tpm12_la-tpm_identity.lo
  CC       tpm12/libtpms_tpm12_la-tpm_init.lo
  CC       tpm12/libtpms_tpm12_la-tpm_libtpms_io.lo
  CC       tpm12/libtpms_tpm12_la-tpm_key.lo
  CC       tpm12/libtpms_tpm12_la-tpm_load.lo
  CC       tpm12/libtpms_tpm12_la-tpm_maint.lo
  CC       tpm12/libtpms_tpm12_la-tpm_migration.lo
  CC       tpm12/libtpms_tpm12_la-tpm_nonce.lo
tpm2/NVMarshal.c: In function 'PERSISTENT_ALL_Unmarshal':
tpm2/NVMarshal.c:3921:38: error: 'exp_array_size' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 3921 |     for (i = 0; rc == TPM_RC_SUCCESS && i < exp_array_size; i++)
      |                 ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
tpm2/NVMarshal.c:3883:12: note: 'exp_array_size' was declared here
 3883 |     UINT32 exp_array_size;
      |            ^~~~~~~~~~~~~~
tpm2/NVMarshal.c: At top level:
cc1: note: unrecognized command-line option '-Wno-self-assign' may have been intended to silence earlier diagnostics
cc1: all warnings being treated as errors
  CC       tpm12/libtpms_tpm12_la-tpm_nvram.lo
make[2]: *** [Makefile:2977: tpm2/libtpms_tpm2_la-NVMarshal.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/builds/kpcyrd/aports/testing/libtpms/src/libtpms-0.9.0/src'
make[1]: *** [Makefile:521: all-recursive] Error 1
make[1]: Leaving directory '/builds/kpcyrd/aports/testing/libtpms/src/libtpms-0.9.0'
make: *** [Makefile:428: all] Error 2
>>> ERROR: libtpms: build failed
```

Related to https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/26913