### PR TITLE
Fix "maybe-uninitialized" warning

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -3880,7 +3880,7 @@ PACompileConstants_Unmarshal(BYTE **buffer, INT32 *size)
     unsigned i;
     NV_HEADER hdr;
     UINT32 array_size;
-    UINT32 exp_array_size;
+    UINT32 exp_array_size = 0;
 
     if (rc == TPM_RC_SUCCESS) {
         rc = NV_HEADER_Unmarshal(&hdr, buffer, size,


### PR DESCRIPTION
exp_array_size is always initialized if `rc == TPM_RC_SUCCESS` and never used
if `rc != TPM_RC_SUCCESS` but some compilers have trouble noticing this.

Signed-off-by: kpcyrd <git@rxv.cc>