### PR TITLE
Backport s_ContextSlotMask initialization fix to 0.9.x

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 CHANGES - changes for libtpms
 
+version 0.9.1:
+  - tpm2: Do not write permanent state if only clock changed
+  - tpm2: Fix "maybe-uninitialized" warning
+
 version 0.9.0:
   - NOTE: Downgrade to previous versions is not possible. See below.
   - The size of the context gap has been adjusted to 0xffff from 0xff.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 CHANGES - changes for libtpms
 
+version 0.9.2:
+  - tpm2: When writing state initialize s_ContextSlotMask if not set
+
 version 0.9.1:
   - tpm2: Do not write permanent state if only clock changed
   - tpm2: Fix "maybe-uninitialized" warning

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms],[0.9.1])
+AC_INIT([libtpms],[0.9.2])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms],[0.9.0])
+AC_INIT([libtpms],[0.9.1])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtpms (0.9.1) RELEASED; urgency=medium
+
+  * tpm2: Do not write permanent state if only clock changed
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Wed, 24 Nov 2021 09:00:00 -0500
+
 libtpms (0.9.0) RELEASED; urgency=medium
 
   * Stable release

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.9.0
+%define version   0.9.1
 %define release   0~dev1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Wed Nov 24 2021 Stefan Berger - 0.9.1-1
+- Release of version 0.9.1
+
 * Wed Sep 29 2021 Stefan Berger - 0.9.0-1
 - Release of version 0.9.0 (rev. 164)
 

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.9.1
+%define version   0.9.2
 %define release   0~dev1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/dist/libtpms.spec.in
+++ b/dist/libtpms.spec.in
@@ -112,6 +112,9 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/libtpms.la
 %postun -p /sbin/ldconfig
 
 %changelog
+* Wed Nov 24 2021 Stefan Berger - 0.9.1-1
+- Release of version 0.9.1
+
 * Wed Sep 29 2021 Stefan Berger - 0.9.0-1
 - Release of version 0.9.0 (rev. 164)
 

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 9
-#define TPM_LIBRARY_VER_MICRO 0
+#define TPM_LIBRARY_VER_MICRO 1
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 9
-#define TPM_LIBRARY_VER_MICRO 1
+#define TPM_LIBRARY_VER_MICRO 2
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -3880,7 +3880,7 @@ PACompileConstants_Unmarshal(BYTE **buffer, INT32 *size)
     unsigned i;
     NV_HEADER hdr;
     UINT32 array_size;
-    UINT32 exp_array_size;
+    UINT32 exp_array_size = 0;
 
     if (rc == TPM_RC_SUCCESS) {
         rc = NV_HEADER_Unmarshal(&hdr, buffer, size,

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -1422,6 +1422,11 @@ STATE_RESET_DATA_Marshal(STATE_RESET_DATA *data, BYTE **buffer, INT32 *size)
     written += UINT16_Marshal(&array_size, buffer, size);
     for (i = 0; i < array_size; i++)
         written += UINT16_Marshal(&data->contextArray[i], buffer, size);
+
+    if (s_ContextSlotMask != 0x00ff && s_ContextSlotMask != 0xffff) {
+        /* TPM wasn't initialized, so s_ContextSlotMask wasn't set */
+        s_ContextSlotMask = 0xffff;
+    }
     written += UINT16_Marshal(&s_ContextSlotMask, buffer, size);
 
     written += UINT64_Marshal(&data->contextCounter, buffer, size);

--- a/src/tpm2/Time.c
+++ b/src/tpm2/Time.c
@@ -136,7 +136,16 @@ TimeClockUpdate(
 	    go.clockSafe = YES;
 	    // update the time
 	    go.clock = newTime;
+
+	    /* libtpms: Changing the clock alone does not cause the permanent
+	     *          state to be written to storage, there must be other
+	     *          reasons as well.
+	     */
+	    UPDATE_TYPE old_g_updateNV = g_updateNV;	// libtpms added
+
 	    NvWrite(NV_ORDERLY_DATA, sizeof(go), &go);
+
+	    g_updateNV = old_g_updateNV;		// libtpms added
 	}
     else
 	// No NV update needed so just update


### PR DESCRIPTION
This series prepares libtpms for v0.9.2 and backports a s_ContextSlotMask initialization fix.