### PR TITLE
tpm2: Fix typo in __GNUC_MINOR__ preprocessor symbol

### DIFF
--- a/src/tpm2/CompilerDependencies.h
+++ b/src/tpm2/CompilerDependencies.h
@@ -128,7 +128,7 @@
 #endif
 #   define __pragma(x)
     /* libtpms added begin */
-#   if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR >= 2)
+#   if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
 #     define REVERSE_ENDIAN_16(_Number) __builtin_bswap16(_Number)
 #     define REVERSE_ENDIAN_32(_Number) __builtin_bswap32(_Number)
 #     define REVERSE_ENDIAN_64(_Number) __builtin_bswap64(_Number)


### PR DESCRIPTION
Fix typo in the __GNUC_MINOR__ preprocessor symbol.

This change is unlikely to have any impact since it was used for
comparions for gcc version 4.2, which is not in use anymore by now.

Resolves: https://github.com/stefanberger/libtpms/issues/289
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>