### PR TITLE
 tpm2: Do not call EVP_PKEY_CTX_set0_rsa_oaep_label() for label of siz…  …e 0 (OSSL 3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms],[0.9.2])
+AC_INIT([libtpms],[0.9.3])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.9.2
+%define version   0.9.3
 %define release   0~dev1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 9
-#define TPM_LIBRARY_VER_MICRO 2
+#define TPM_LIBRARY_VER_MICRO 3
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -1356,10 +1356,9 @@ CryptRsaEncrypt(
                 if (tmp == NULL)
                     ERROR_RETURN(TPM_RC_FAILURE);
                 memcpy(tmp, label->buffer, label->size);
+                if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, tmp, label->size) <= 0)
+                    ERROR_RETURN(TPM_RC_FAILURE);
             }
-            // label->size == 0 is supported
-            if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, tmp, label->size) <= 0)
-                ERROR_RETURN(TPM_RC_FAILURE);
             tmp = NULL;
             break;
           default:


### PR DESCRIPTION
Openssl 3.0 did return an error if EVP_PKEY_CTX_set0_rsa_oaep_label was called
with label size 0. The function should only be called if the size of the label
is greater 0.
With this fix TPM2_RSA_Encrypt/Decrypt did work with OpenSSL 1.1 and 3.0
for encryption without label.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>