### PR TITLE
build-sys: Add probing for -fstack-protector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,10 +284,12 @@ AC_ARG_ENABLE([hardening],
   AS_HELP_STRING([--disable-hardening], [Disable hardening flags]))
 
 if test "x$enable_hardening" != "xno"; then
-	# Some versions of gcc fail with -Wstack-protector enabled
-	TMP="$($CC -fstack-protector-strong $srcdir/include/libtpms/tpm_error.h 2>&1)"
-	if echo $TMP | $GREP 'unrecognized command line option' >/dev/null; then
-		HARDENING_CFLAGS="-fstack-protector "
+	# Some versions of gcc fail with -Wstack-protector,
+	# some with -Wstack-protector-strong enabled
+	if ! $CC -fstack-protector-strong $srcdir/include/libtpms/tpm_error.h 2>/dev/null; then
+		if $CC -fstack-protector $srcdir/include/libtpms/tpm_error.h 2>/dev/null; then
+			HARDENING_CFLAGS="-fstack-protector "
+		fi
 	else
 		HARDENING_CFLAGS="-fstack-protector-strong "
 	fi


### PR DESCRIPTION
Add probing for -fstack-protector to the existing
-fstack-protector-strong since not all platforms support either one
of them.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>