### PR TITLE
tpm2: Check return code of BN_div()

### DIFF
--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -516,8 +516,7 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
 
     /* Q = N/P; no remainder */
     BN_set_flags(P, BN_FLG_CONSTTIME); // P is secret
-    BN_div(Q, Qr, N, P, ctx);
-    if(!BN_is_zero(Qr))
+    if (!BN_div(Q, Qr, N, P, ctx) || !BN_is_zero(Qr))
         ERROR_RETURN(TPM_RC_BINDING);
     BN_set_flags(Q, BN_FLG_CONSTTIME); // Q is secret
 


### PR DESCRIPTION
Backport of 8590849b65.

Check the return code of BN_div() when calculating Q and Qr of
a private key.

Resolves: https://github.com/stefanberger/libtpms/issues/304
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>