### PR TITLE
tpm2: Check return code of BN_div()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms],[0.9.3])
+AC_INIT([libtpms],[0.9.4])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.9.3
+%define version   0.9.4
 %define release   0~dev1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 9
-#define TPM_LIBRARY_VER_MICRO 3
+#define TPM_LIBRARY_VER_MICRO 4
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -521,8 +521,7 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
             ERROR_RETURN(TPM_RC_FAILURE);
         /* Q = N/P; no remainder */
         BN_set_flags(P, BN_FLG_CONSTTIME); // P is secret
-        BN_div(Q, Qr, N, P, ctx);
-        if(!BN_is_zero(Qr))
+        if (!BN_div(Q, Qr, N, P, ctx) || !BN_is_zero(Qr))
             ERROR_RETURN(TPM_RC_BINDING);
         BN_set_flags(Q, BN_FLG_CONSTTIME); // Q is secret
 


### PR DESCRIPTION
Check the return code of BN_div() when calculating Q and Qr of
a private key.

Resolves: https://github.com/stefanberger/libtpms/issues/304
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>