### PR TITLE
tpm2: Initialize variable reported by Coverity (false positive)

### DIFF
--- a/src/tpm2/ExecCommand.c
+++ b/src/tpm2/ExecCommand.c
@@ -148,6 +148,7 @@ ExecuteCommand(
     if(g_DRTMHandle != TPM_RH_UNASSIGNED)
 	ObjectTerminateEvent();
     // Get command buffer size and command buffer.
+    command.tag = 0;				// libtpms added: Coverity
     command.parameterBuffer = request;
     command.parameterSize = requestSize;
     // Parse command header: tag, commandSize and command.code.


### PR DESCRIPTION
Initialize a variable in ExecuteCommand following Coverity report
CID 1461252.

Down the callpath as reported in CID 1461252 in
TPMI_ST_COMMAND_TAG_Unmarshal() the passed-in value of
TPMI_ST_COMMAND_TAG *target is stored and possibly restored later on in
case of failure. Coverity complains that the variable is uninitialized.
While this is correct, there's no harm reading the uninitialized value
from the structure and possibly restoring it later on while not doing
anything else with it otherwise. Therefore, it's a false positive.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>