### PR TITLE
Fix configure script to support _FORTIFY_SOURCE=3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,11 +294,10 @@ if test "x$enable_hardening" != "xno"; then
 		HARDENING_CFLAGS="-fstack-protector-strong "
 	fi
 
-	dnl Must not have -O0 but must have a -O for -D_FORTIFY_SOURCE=2
-	TMP1="$(echo $CFLAGS | sed -n 's/.*\(-O0\).*/\1/p')"
-	TMP2="$(echo $CFLAGS | sed -n 's/.*\(-O\).*/\1/p')"
-	if test -z "$TMP1" && test -n "$TPM2"; then
-		HARDENING_CFLAGS="$HARDENING_CFLAGS -D_FORTIFY_SOURCE=2 "
+	dnl Only support -D_FORTIFY_SOURCE=2 and have higher levels passed in by user
+	dnl since they may create more overhead
+	if $CC $CFLAGS -Werror -D_FORTIFY_SOURCE=2 $srcdir/include/libtpms/tpm_library.h 2>/dev/null; then
+		HARDENING_CFLAGS="$HARDENING_CFLAGS -D_FORTIFY_SOURCE=2"
 	fi
 	dnl Check linker for 'relro' and 'now'
 	save_CFLAGS="$CFLAGS"


### PR DESCRIPTION
gcc 12.1 supports _FORTIFY_SOURCE=3. Modify the existing check for whether
_FORTIFY_SOURCE=2 can be used to test compile with the user provided
CFLAGS and only add _D_FORTIFY_SOURCE=2 to the HARDENING_CFLAGS if the
user doesn't provide anything that's not compatible.

Following an online article _FORTIFY_SOURCE=3 may add more overhead, so
we only go up to level 2 for now and let build servers or user provide
the higher level via the CFLAGS.

https://developers.redhat.com/blog/2021/04/16/broadening-compiler-checks-for-buffer-overflows-in-_fortify_source#what_s_next_for__fortify_source

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>