### PR TITLE
tpm: #undef printf in case it is #define'd (OSS-Fuzz)

### DIFF
--- a/src/tpm_debug.h
+++ b/src/tpm_debug.h
@@ -66,6 +66,9 @@ extern int swallow_rc;
 #endif  /* TPM_DEBUG */
 #endif
 
+#ifdef printf
+# undef  printf
+#endif
 #define printf(...) TPMLIB_LogPrintf(__VA_ARGS__);
 
 #endif


### PR DESCRIPTION
The build environment used by OSS-Fuzz reports this error.

```
 In file included from /src/libtpms/src/tpm_debug.c:42:
 /src/libtpms/src/tpm_debug.h:69:9: error: 'printf' macro redefined [-Werror,-Wmacro-redefined]
 #define printf(...) TPMLIB_LogPrintf(__VA_ARGS__);
 :         ^
 /usr/include/x86_64-linux-gnu/bits/stdio2.h:110:11: note: previous definition is here
 # define printf(...) \
           ^
 1 error generated.
```

The simple fix is to #undef printf in case it is #define'd.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>