### PR TITLE
nvfile: Free allocated memory on failure

### DIFF
--- a/src/tpm_nvfile.c
+++ b/src/tpm_nvfile.c
@@ -267,6 +267,11 @@ TPM_RESULT TPM_NVRAM_LoadData(unsigned char **data,     /* freed by caller */
             printf(" TPM_NVRAM_LoadData: Closed file %s\n", filename);
         }
     }
+
+    if (rc) {
+        free(*data);
+        *data = NULL;
+    }
     return rc;
 }
 


### PR DESCRIPTION
In TPM_NVRAM_LoadData(), there is an unlikely path where the function
will return an error code but still expect the caller to free the
allocated data. At least some of the callers don't handle this correctly
so ensure that the caller only needs to free data if the function
returns success.

Reported by Coverity.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>