### PR TITLE
tpm2: Fix size check in CryptSecretDecrypt

### DIFF
--- a/src/tpm2/CryptUtil.c
+++ b/src/tpm2/CryptUtil.c
@@ -730,7 +730,7 @@ CryptSecretDecrypt(
 					     nonceCaller->t.size);
 			      }
 			  // make sure secret will fit
-			  if(secret->t.size > data->t.size)
+			  if(secret->t.size > sizeof(data->t.buffer))
 			      return TPM_RC_FAILURE;
 			  data->t.size = secret->t.size;
 			  // CFB decrypt, using nonceCaller as iv


### PR DESCRIPTION
Check the secret size against the size of the buffer, not the size
member that has not been set yet.

Reported by Coverity.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>