### PR TITLE
tpm2: Fix size check in CryptSecretDecrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #
 # See the LICENSE file for the license associated with this file.
 
-AC_INIT([libtpms],[0.9.4])
+AC_INIT([libtpms],[0.9.5])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_AUX_DIR([.])

--- a/dist/libtpms.spec
+++ b/dist/libtpms.spec
@@ -1,7 +1,7 @@
 # --- libtpm rpm-spec ---
 
 %define name      libtpms
-%define version   0.9.4
+%define version   0.9.5
 %define release   0~dev1
 
 # Valid crypto subsystems are 'freebl' and 'openssl'

--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define TPM_LIBRARY_VER_MAJOR 0
 #define TPM_LIBRARY_VER_MINOR 9
-#define TPM_LIBRARY_VER_MICRO 4
+#define TPM_LIBRARY_VER_MICRO 5
 
 #define TPM_LIBRARY_VERSION_GEN(MAJ, MIN, MICRO) \
     (( MAJ << 16 ) | ( MIN << 8 ) | ( MICRO ))

--- a/src/tpm2/CryptUtil.c
+++ b/src/tpm2/CryptUtil.c
@@ -732,7 +732,7 @@ CryptSecretDecrypt(
 					     nonceCaller->t.size);
 			      }
 			  // make sure secret will fit
-			  if(secret->t.size > data->t.size)
+			  if(secret->t.size > sizeof(data->t.buffer))
 			      return TPM_RC_FAILURE;
 			  data->t.size = secret->t.size;
 			  // CFB decrypt, using nonceCaller as iv


### PR DESCRIPTION
Check the secret size against the size of the buffer, not the size
member that has not been set yet.

Reported by Coverity.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>