### PR TITLE
tpm2: Never increase TPM_PT_LOCKOUT_COUNTER on TPM2_Startup()

### DIFF
--- a/src/tpm2/DA.c
+++ b/src/tpm2/DA.c
@@ -140,6 +140,13 @@ DAStartup(
        && !IS_ORDERLY(g_prevOrderlyState))
 	{
 #if USE_DA_USED
+	    // libtpms added: begin
+	    // To avoid the TPM_PT_LOCKOUT_COUNTER to increase and ultimately cause
+	    // DA lockouts due to abrupt termination of a VM that couldn't send
+	    // TPM2_Shutdown(), we *never* increase the failedTries upon TPM2_Startup().
+	    // https://bugzilla.redhat.com/show_bug.cgi?id=2087538
+	    g_daUsed = FALSE;
+	    // libtpms added: end
 	    gp.failedTries += g_daUsed;
 	    g_daUsed = FALSE;
 #else


### PR DESCRIPTION
To avoid the TPM_PT_LOCKOUT_COUNTER from increasing upon TPM2_Startup()
following an abrupt shutdown or abrupt re-initialization of the TPM 2,
set g_daUsed to FALSE before it can be used to increase the failedTries
counter.

Buglink: https://bugzilla.redhat.com/show_bug.cgi?id=2087538
Signed-off-by: Stefan Berger <stefanb@linx.ibm.com><