### PR TITLE
tpm2: Do not set RSA_FLAG_NO_BLINDING on RSA keys anymore

### DIFF
--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -371,8 +371,6 @@ InitOpenSSLRSAPublicKey(OBJECT      *key,     // IN
         EVP_PKEY_assign_RSA(*pkey, rsakey) == 0)
         ERROR_RETURN(TPM_RC_FAILURE)
 
-    RSA_set_flags(rsakey, RSA_FLAG_NO_BLINDING);
-
     retVal = TPM_RC_SUCCESS;
 
  Exit:


### PR DESCRIPTION
Do not set the RSA_FLAG_NO_BLINDING on RSA keys anymore. The BoringSSL
documentation states the following:

"RSA_FLAG_NO_BLINDING disables blinding of private operations, which is
a dangerous thing to do. It is deprecated and should not be used. It will
be ignored whenever possible."

So, follow this documentation. OpenSSL does not seem to say much about it.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>