### PR TITLE
tpm2: Fix a typo in PERSISTENT_ALL_Unmarshal

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -4891,7 +4891,7 @@ PERSISTENT_ALL_Unmarshal(BYTE **buffer, INT32 *size)
        this allows us to downgrade state */
     if (rc == TPM_RC_SUCCESS && hdr.version >= 2) {
         BLOCK_SKIP_READ(skip_future_versions, FALSE, buffer, size,
-                        "USER NVRAM", "version 3 or later");
+                        "PERSISTENT_ALL", "version 3 or later");
         /* future versions nest-append here */
     }
 


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>