### PR TITLE
libressl: add support

### DIFF
--- a/src/tpm12/tpm_crypto.c
+++ b/src/tpm12/tpm_crypto.c
@@ -133,7 +133,7 @@ static TPM_RESULT TPM_SymmetricKeyData_Crypt(unsigned char *data_out,
 
 #include <openssl/aes.h>
 
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(LIBRESSL_VERSION_NUMBER)
  # define OPENSSL_OLD_API
 #elif OPENSSL_VERSION_NUMBER < 0x10100000
  #define OPENSSL_OLD_API

--- a/src/tpm12/tpm_crypto.c
+++ b/src/tpm12/tpm_crypto.c
@@ -135,10 +135,8 @@ static TPM_RESULT TPM_SymmetricKeyData_Crypt(unsigned char *data_out,
 
 #if defined(__OpenBSD__)
  # define OPENSSL_OLD_API
-#else
- #if OPENSSL_VERSION_NUMBER < 0x10100000
-  #define OPENSSL_OLD_API
- #endif
+#elif OPENSSL_VERSION_NUMBER < 0x10100000
+ #define OPENSSL_OLD_API
 #endif
 
 /* AES requires data lengths that are a multiple of the block size */


### PR DESCRIPTION
Add support for building with libressl on non-bsd systems.