### PR TITLE
Set license identifier in test cases and fix output in case of file size error

### DIFF
--- a/tests/base64decode.c
+++ b/tests/base64decode.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/common
+++ b/tests/common
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Get the size of a file in bytes
 #

--- a/tests/freebl_sha1flattensize.c
+++ b/tests/freebl_sha1flattensize.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdint.h>
 #include <stdio.h>
 

--- a/tests/tpm2_createprimary.c
+++ b/tests/tpm2_createprimary.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>

--- a/tests/tpm2_createprimary.sh
+++ b/tests/tpm2_createprimary.sh
@@ -24,9 +24,10 @@ rc=$?
 
 fs=$(get_filesize NVChip)
 [ $? -ne 0 ] && exit 1
-if [ $fs -ne 176832 ]; then
+exp=176832
+if [ $fs -ne $exp ]; then
 	echo "Error: Unexpected size of NVChip file."
-	echo "Expected: 131072"
+	echo "Expected: $exp"
 	echo "Got     : $fs"
 	rc=1
 fi

--- a/tests/tpm2_pcr_read.c
+++ b/tests/tpm2_pcr_read.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>

--- a/tests/tpm2_pcr_read.sh
+++ b/tests/tpm2_pcr_read.sh
@@ -24,9 +24,10 @@ rc=$?
 
 fs=$(get_filesize NVChip)
 [ $? -ne 0 ] && exit 1
-if [ $fs -ne 176832 ]; then
+exp=176832
+if [ $fs -ne $exp ]; then
 	echo "Error: Unexpected size of NVChip file."
-	echo "Expected: 131072"
+	echo "Expected: $exp"
 	echo "Got     : $fs"
 	rc=1
 fi

--- a/tests/tpm2_selftest.c
+++ b/tests/tpm2_selftest.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>

--- a/tests/tpm2_selftest.sh
+++ b/tests/tpm2_selftest.sh
@@ -24,9 +24,10 @@ rc=$?
 
 fs=$(get_filesize NVChip)
 [ $? -ne 0 ] && exit 1
-if [ $fs -ne 176832 ]; then
+exp=176832
+if [ $fs -ne $exp ]; then
 	echo "Error: Unexpected size of NVChip file."
-	echo "Expected: 131072"
+	echo "Expected: $exp"
 	echo "Got     : $fs"
 	rc=1
 fi


### PR DESCRIPTION
Set license identifier in test cases and fix output in case of file size error