### PR TITLE
Implement usage of OpenSSL 3 API for replacement of deprecated EVP_CIPHER_CTX_iv()

### DIFF
--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -621,7 +621,8 @@ CryptSymmetricEncrypt(
             ERROR_RETURN(TPM_RC_FAILURE);
 
         ivInOut->t.size = ivLen;
-        memcpy(ivInOut->t.buffer, EVP_CIPHER_CTX_iv(ctx), ivInOut->t.size);
+        if (DoEVPGetIV(ctx, ivInOut->t.buffer, ivInOut->t.size))
+            ERROR_RETURN(TPM_RC_FAILURE);
     }
  Exit:
     if (retVal == TPM_RC_SUCCESS && pOut != dOut)
@@ -743,7 +744,8 @@ CryptSymmetricDecrypt(
             ERROR_RETURN(TPM_RC_FAILURE);
 
         ivInOut->t.size = ivLen;
-        memcpy(ivInOut->t.buffer, EVP_CIPHER_CTX_iv(ctx), ivInOut->t.size);
+        if (DoEVPGetIV(ctx, ivInOut->t.buffer, ivInOut->t.size))
+            ERROR_RETURN(TPM_RC_FAILURE);
     }
 
  Exit:

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -621,7 +621,7 @@ CryptSymmetricEncrypt(
             ERROR_RETURN(TPM_RC_FAILURE);
 
         ivInOut->t.size = ivLen;
-        if (DoEVPGetIV(ctx, ivInOut->t.buffer, ivInOut->t.size))
+        if (ivLen > 0 && DoEVPGetIV(ctx, ivInOut->t.buffer, ivInOut->t.size))
             ERROR_RETURN(TPM_RC_FAILURE);
     }
  Exit:
@@ -744,7 +744,7 @@ CryptSymmetricDecrypt(
             ERROR_RETURN(TPM_RC_FAILURE);
 
         ivInOut->t.size = ivLen;
-        if (DoEVPGetIV(ctx, ivInOut->t.buffer, ivInOut->t.size))
+        if (ivLen > 0 && DoEVPGetIV(ctx, ivInOut->t.buffer, ivInOut->t.size))
             ERROR_RETURN(TPM_RC_FAILURE);
     }
 

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -286,6 +286,22 @@ evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
     return evpfn;
 }
 
+TPM_RC DoEVPGetIV(
+                  EVP_CIPHER_CTX    *ctx,    // IN: required context
+                  unsigned char     *iv,     // IN: pointer to buffer for IV
+                  size_t             iv_len  // IN: size of the buffer
+                  )
+{
+    const unsigned char *c_iv;
+
+    c_iv = EVP_CIPHER_CTX_iv(ctx);
+    if (!c_iv)
+        return TPM_RC_FAILURE;
+    memcpy(iv, c_iv, iv_len);
+
+    return 0;
+}
+
 #endif // USE_OPENSSL_FUNCTIONS_SYMMETRIC
 
 #if USE_OPENSSL_FUNCTIONS_EC

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -292,12 +292,21 @@ TPM_RC DoEVPGetIV(
                   size_t             iv_len  // IN: size of the buffer
                   )
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_PARAM params[] = {
+        OSSL_PARAM_octet_ptr(OSSL_CIPHER_PARAM_UPDATED_IV, &iv, iv_len),
+        OSSL_PARAM_END
+    };
+    if (EVP_CIPHER_CTX_get_params(ctx, params) != 1)
+        return TPM_RC_FAILURE;
+#else
     const unsigned char *c_iv;
 
     c_iv = EVP_CIPHER_CTX_iv(ctx);
     if (!c_iv)
         return TPM_RC_FAILURE;
     memcpy(iv, c_iv, iv_len);
+#endif // OPENSSL_VERSION_NUMBER
 
     return 0;
 }

--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -80,6 +80,13 @@ evpfunc GetEVPCipher(TPM_ALG_ID    algorithm,       // IN
                      BYTE         *keyToUse,        // OUT same as key or stretched key
                      UINT16       *keyToUseLen      // IN/OUT
                      );
+
+TPM_RC DoEVPGetIV(
+                  EVP_CIPHER_CTX    *ctx,    // IN: required context
+                  unsigned char     *iv,     // IN: pointer to buffer for IV
+                  size_t             iv_len  // IN: size of the buffer
+                  );
+
 #endif
 
 #if USE_OPENSSL_FUNCTIONS_EC


### PR DESCRIPTION
Implement usage of OpenSSL 3 API for replacement of deprecated EVP_CIPHER_CTX_iv()