### PR TITLE
DO-NOT-MERGE: tpm2: Replace deprecated EC functions with EVP functions (OSSL 3)

### DIFF
--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -100,6 +100,12 @@ TPM_RC BuildEcPrivateKey(
                          const EC_GROUP    *G,     // IN: group of the key
                          const BIGNUM      *D      // IN: private key
                         );
+
+TPM_RC BuildEcPublicKey(
+                        EVP_PKEY         **ppkey, // OUT
+                        const EC_GROUP    *G,     // IN: group of the key
+                        const EC_POINT    *Q      // IN: public point
+                       );
 #endif
 #endif
 

--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -93,6 +93,14 @@ BOOL OpenSSLEccGetPrivate(
                           const EC_GROUP    *G,      // IN:  the EC_GROUP to use
                           const UINT32       requestedBits // IN: if not 0, then dOut must have that many bits
                          );
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+TPM_RC BuildEcPrivateKey(
+                         EVP_PKEY         **ppkey, // OUT
+                         const EC_GROUP    *G,     // IN: group of the key
+                         const BIGNUM      *D      // IN: private key
+                        );
+#endif
 #endif
 
 #if USE_OPENSSL_FUNCTIONS_RSA


### PR DESCRIPTION
This PR replaces deprecated EC functions with EVP functions when compiled for OpenSSL 3.