### PR TITLE
tpm2: Check size of TPM2B_NAME buffer before reading 2 bytes from it

### DIFF
--- a/src/tpm2/EACommands.c
+++ b/src/tpm2/EACommands.c
@@ -892,6 +892,8 @@ TPM2_PolicyAuthorize(
     // Get pointer to the session structure
     session = SessionGet(in->policySession);
     // Extract from the Name of the key, the algorithm used to compute it's Name
+    if (in->keySign.t.size < 2)		// libtpms added: TPM 2 Errata v1.4
+        return TPM_RC_INSUFFICIENT;	// libtpms added
     hashAlg = BYTE_ARRAY_TO_UINT16(in->keySign.t.name);
     // 'keySign' parameter needs to use a supported hash algorithm, otherwise
     // can't tell how large the digest should be


### PR DESCRIPTION
Fix the missing buffer size check that the TPM 2 errata v1.4 mentions in 2.6.2 by adding a buffer size check before reading 2 bytes from a TPM2B_NAME buffer. There's no known CVE for this.