### PR TITLE
tpm2: fix SignedCompareB

### DIFF
--- a/src/tpm2/MathOnByteBuffers.c
+++ b/src/tpm2/MathOnByteBuffers.c
@@ -109,13 +109,23 @@ SignedCompareB(
 	       const BYTE      *b              // IN: b buffer
 	       )
 {
-    // are the signs different ?
-    if(((a[0] ^ b[0]) & 0x80) > 0)
-	// if the signs are different, then a is less than b if a is negative.
-	return a[0] & 0x80 ? -1 : 1;
+    int      signA, signB;       /*  sign of a and b */
+    /*  For positive or 0, sign_a is 1 */
+    /*  for negative, sign_a is 0 */
+    signA = ((a[0] & 0x80) == 0) ? 1 : 0;
+    /*  For positive or 0, sign_b is 1 */
+    /*  for negative, sign_b is 0 */
+    signB = ((b[0] & 0x80) == 0) ? 1 : 0;
+    if(signA != signB)
+    {
+        return signA - signB;
+    }
+    if(signA == 1)
+        /*  do unsigned compare function */
+        return UnsignedCompareB(aSize, a, bSize, b);
     else
-	// do unsigned compare function
-	return UnsignedCompareB(aSize, a, bSize, b);
+        /*  do unsigned compare the other way */
+        return 0 - UnsignedCompareB(aSize, a, bSize, b);
 }
 /* 9.11.3.3 ModExpB */
 /* This function is used to do modular exponentiation in support of RSA. The most typical uses are:


### PR DESCRIPTION
SigedCompare returns -1 for the following call:

BYTE a = 0x81;
BYTE b = 0x82;
SignedCompareB(1, &a, 1, &b);

But should return 1, because signed 0x81 > 0x82

Signed-off-by: Juergen Repp <juergen_repp@web.de>