### PR TITLE
tpm2: configure vendor/manufacturer values

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,6 +342,88 @@ AC_CONFIG_FILES(Makefile                   \
 PKG_INSTALLDIR()
 AC_OUTPUT
 
+AC_ARG_WITH([manufacturer],
+            AS_HELP_STRING([--with-manufacturer=MANUFACTURER],[The manufacturer name]),
+            [use_manufacturer="$withval"],
+            [use_manufacturer=""]
+)
+
+if ! test "x$use_manufacturer" = "x"; then
+	CFLAGS="$CFLAGS -DCONFIG_MANUFACTURER=$use_manufacturer"
+fi
+
+AC_ARG_WITH([tpm-vendor-id],
+            AS_HELP_STRING([--with-tpm-vendor-id=VENDOR_ID],[The TPM vendor id in hex, with leading '0x']),
+            [use_vendor_id="$withval"],
+            [use_vendor_id=""]
+)
+
+if ! test "x$use_vendor_id" = "x"; then
+	CFLAGS="$CFLAGS -DMANUFACTURER_ID=$use_vendor_id"
+fi
+
+AC_ARG_WITH([vendor-string-1],
+            AS_HELP_STRING([--with-vendor-string-1=VENDOR_STRING_1],[The first 4-byte vendor string]),
+            [use_vendor_string_1="$withval"],
+            [use_vendor_string_1=""]
+)
+
+if ! test "x$use_vendor_string_1" = "x"; then
+	CFLAGS="$CFLAGS -DCONFIG_VENDOR_STRING_1=$use_vendor_string_1"
+fi
+
+AC_ARG_WITH([vendor-string-2],
+            AS_HELP_STRING([--with-vendor-string-2=VENDOR_STRING_2],[The second 4-byte vendor string]),
+            [use_vendor_string_2="$withval"],
+            [use_vendor_string_2=""]
+)
+
+if ! test "x$use_vendor_string_2" = "x"; then
+	CFLAGS="$CFLAGS -DCONFIG_VENDOR_STRING_2=$use_vendor_string_2"
+fi
+
+AC_ARG_WITH([vendor-string-3],
+            AS_HELP_STRING([--with-vendor-string-3=VENDOR_STRING_3],[The third 4-byte vendor string]),
+            [use_vendor_string_3="$withval"],
+            [use_vendor_string_3=""]
+)
+
+if ! test "x$use_vendor_string_3" = "x"; then
+	CFLAGS="$CFLAGS -DCONFIG_VENDOR_STRING_3=$use_vendor_string_3"
+fi
+
+AC_ARG_WITH([vendor-string-4],
+            AS_HELP_STRING([--with-vendor-string-4=VENDOR_STRING_4],[The fourth 4-byte vendor string]),
+            [use_vendor_string_4="$withval"],
+            [use_vendor_string_4=""]
+)
+
+if ! test "x$use_vendor_string_4" = "x"; then
+	CFLAGS="$CFLAGS -DCONFIG_VENDOR_STRING_4=$use_vendor_string_4"
+fi
+
+AC_ARG_WITH([firmware-v1],
+            AS_HELP_STRING([--with-firmware-v1=FIRMWARE_V1],[The more significant 32-bits of a vendor-specific value indicating the
+        		version of the firmware in hex, without leading '0x']),
+            [use_firmware_v1="$withval"],
+            [use_firmware_v1=""]
+)
+
+if ! test "x$use_firmware_v1" = "x"; then
+	CFLAGS="$CFLAGS -DFIRMWARE_V1=0x$use_firmware_v1"
+fi
+
+AC_ARG_WITH([firmware-v2],
+            AS_HELP_STRING([--with-firmware-v2=FIRMWARE_V2],[The least significant 32-bits of a vendor-specific value indicating the
+        		version of the firmware in hex, without leading '0x']),
+            [use_firmware_v2="$withval"],
+            [use_firmware_v2=""]
+)
+
+if ! test "x$use_firmware_v2" = "x"; then
+	CFLAGS="$CFLAGS -DFIRMWARE_V2=0x$use_firmware_v2"
+fi
+
 if test -z "$enable_debug" ; then
     enable_debug="no"
 fi

--- a/src/tpm2/VendorString.h
+++ b/src/tpm2/VendorString.h
@@ -62,47 +62,67 @@
 #ifndef VENDORSTRING_H
 #define VENDORSTRING_H
 
-/* Define up to 4-byte values for MANUFACTURER.  This value defines the response for
-   TPM_PT_MANUFACTURER in TPM2_GetCapability(). The following line should be un-commented and a
-   vendor specific string should be provided here. */
-#define    MANUFACTURER    "IBM"
-
-/*     The following #if macro may be deleted after a proper MANUFACTURER is provided. */
-#ifndef MANUFACTURER
-#error MANUFACTURER is not provided.				 \
-    Please modify VendorString.h to provide a specific	  	 \
-    manufacturer name.
+#ifndef _STRINGIFY
+#define _STRINGIFY(x) #x
+#endif
+#ifndef STRINGIFY
+#define STRINGIFY(x) _STRINGIFY(x)
 #endif
 
-/*     Define up to 4, 4-byte, vendor-specific values. The values must each be 4 bytes long and the
-       last value used may contain trailing zeros. These values define the response for
-       TPM_PT_VENDOR_STRING_(1-4) in TPM2_GetCapability(). The following line should be un-commented
-       and a vendor specific string.  The vendor strings 2-4 may also be defined as appropriate. */
+/*      To customize the MANUFACTURER macro, use the configure option "--with-manufacturer=XXXX"
+        Define up to a 4-byte string for MANUFACTURER.  This string defines the response for
+        TPM_PT_MANUFACTURER in TPM2_GetCapability().
+        Must be in the TPM Vendor ID Registry: https://trustedcomputinggroup.org/resource/vendor-id-registry/ */
+#ifndef CONFIG_MANUFACTURER
+#define MANUFACTURER    "SIM0"
+#else
+#define MANUFACTURER STRINGIFY(CONFIG_MANUFACTURER)
+#endif
+_Static_assert(sizeof(MANUFACTURER) - 1U <= 4U, "MANUFACTURER string can be up to 4-bytes");
 
-#define       VENDOR_STRING_1       "SW  "
-#define       VENDOR_STRING_2       " TPM"
-//#define       VENDOR_STRING_3
-//#define       VENDOR_STRING_4
+/*      To customize the MANUFACTURER_ID macro, use the configure option "--with-manufacturer-id=XXXX"
+        Define up to a 4-byte hex value for MANUFACTURER_ID.  This value defines the response for
+        manufacturer in TPMAttributes for TPM2_GetInfo().
+        Must be in the TPM Vendor ID Registry: https://trustedcomputinggroup.org/resource/vendor-id-registry/ */
+#ifndef MANUFACTURER_ID
+#define MANUFACTURER_ID    0x53494d30
+#endif
+_Static_assert((sizeof(MANUFACTURER_ID) <= 4U), "MANUFACTURER_ID can be up to 4-bytes");
 
-/*     The following #if macro may be deleted after a proper VENDOR_STRING_1 is provided. */
-#ifndef VENDOR_STRING_1
-#error VENDOR_STRING_1 is not provided.					\
-    Please modify VendorString.h to provide a vendor specific string.
+/*      To customize the VENDOR_STRING_[1-4] macros, use the configure options "--with-vendor-string-[1-4]=XXXX"
+        Define up to 4, 4-byte, vendor-specific strings. The strings must each be 4 bytes long.
+        These values define the response for TPM_PT_VENDOR_STRING_(1-4) in TPM2_GetCapability(). */
+#ifndef CONFIG_VENDOR_STRING_1
+#define VENDOR_STRING_1       "fTPM"
+#else
+#define VENDOR_STRING_1 STRINGIFY(CONFIG_VENDOR_STRING_1)
+#endif
+_Static_assert(sizeof(VENDOR_STRING_1) - 1U == 4U, "VENDOR_STRING_1 must be 4-bytes");
+
+#ifdef CONFIG_VENDOR_STRING_2
+#define VENDOR_STRING_2 STRINGIFY(CONFIG_VENDOR_STRING_2)
+_Static_assert(sizeof(VENDOR_STRING_2) - 1U == 4U, "VENDOR_STRING_2 must be 4-bytes");
+#endif
+#ifdef CONFIG_VENDOR_STRING_3
+#define VENDOR_STRING_3 STRINGIFY(CONFIG_VENDOR_STRING_3)
+_Static_assert(sizeof(VENDOR_STRING_3) - 1U == 4U, "VENDOR_STRING_3 must be 4-bytes");
+#endif
+#ifdef CONFIG_VENDOR_STRING_4
+#define VENDOR_STRING_4 STRINGIFY(CONFIG_VENDOR_STRING_4)
+_Static_assert(sizeof(VENDOR_STRING_4) - 1U == 4U, "VENDOR_STRING_4 must be 4-bytes");
 #endif
 
-/* the more significant 32-bits of a vendor-specific value indicating the version of the firmware
-   The following line should be un-commented and a vendor specific firmware V1 should be provided
-   here. The FIRMWARE_V2 may also be defined as appropriate. */
-#define   FIRMWARE_V1         (0x20191023)
-
-// the less significant 32-bits of a vendor-specific value indicating the version of the firmware
-#define   FIRMWARE_V2         (0x00163636)
-
-// The following #if macro may be deleted after a proper FIRMWARE_V1 is provided.
+/*      To customize the FIRMWARE_V[1-2] macros, use the configure options "--with-firmware-v[1-2]=XXXX"
+        Define the more significant 32-bits of a vendor-specific value indicating the
+        version of the firmware in FIRMWARE_V1. The less significant 32-bits of a vendor-specific
+        value indicating the version of the firmware can use the FIRMWARE_V2 macro. */
 #ifndef FIRMWARE_V1
-#error  FIRMWARE_V1 is not provided.					\
-    Please modify VendorString.h to provide a vendor specific firmware \
-    version
+#define FIRMWARE_V1     0x00000000
+#endif
+_Static_assert(sizeof(FIRMWARE_V1) == 4U, "FIRMWARE_V1 must be 4-bytes");
+
+#ifdef FIRMWARE_V2
+_Static_assert(sizeof(FIRMWARE_V2) == 4U, "FIRMWARE_V2 must be 4-bytes");
 #endif
 
 #endif

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -363,7 +363,7 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
     "}";
     const char *tpmattrs_temp =
     "\"TPMAttributes\":{"
-        "\"manufacturer\":\"id:00001014\","
+        "\"manufacturer\":\"id:%08X\","
         "\"version\":\"id:%08X\","
         "\"model\":\"swtpm\""
     "}";
@@ -398,7 +398,7 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
     if ((flags & TPMLIB_INFO_TPMATTRIBUTES)) {
         fmt = buffer;
         buffer = NULL;
-        if (asprintf(&tpmattrs, tpmattrs_temp, FIRMWARE_V1) < 0)
+        if (asprintf(&tpmattrs, tpmattrs_temp, MANUFACTURER_ID, FIRMWARE_V1) < 0)
             goto error;
         if (asprintf(&buffer, fmt,  printed ? "," : "",
                      tpmattrs, "%s%s%s") < 0)


### PR DESCRIPTION
Provide a way to configure Vendor/Manufacturer values.
This also changes default vendor/manufacturer strings to be more generic (remove IBM specifics; makes IBM less liable? 😄)
Cleaned up comments that were a little confusing in VendorString.h, most likely from the Microsoft Reference code port.

I know a major concern is swtpm state and downgrading versions, and these values (at least Manufacturer, Vendor Strings, and Firmware Version) show up in the properties-fixed get capability command. What I'm not sure of is how tightly this is coupled with 
 the swtpm state and how it would affect earlier libtpms versions.