### PR TITLE
Insert assert ensuring *buflen != BUFLEN_EMPTY_BUFFER (Coverity)

### DIFF
--- a/src/tpm_library.c
+++ b/src/tpm_library.c
@@ -636,6 +636,8 @@ TPM_RESULT CopyCachedState(enum TPMLIB_StateType st,
     *is_empty_buffer = (*buflen == BUFLEN_EMPTY_BUFFER);
 
     if (cached_blobs[st].buffer) {
+        assert(*buflen != BUFLEN_EMPTY_BUFFER);
+
         *buffer = malloc(*buflen);
         if (!*buffer) {
             TPMLIB_LogError("Could not allocate %u bytes.\n", *buflen);


### PR DESCRIPTION
Address a false positive issue detect by Coverity (CID 1517797) about *buflen.

Per this assignment of buflen

cached_blobs[st].buflen = buffer ? buflen : BUFLEN_EMPTY_BUFFER;

the following is true:

If cached_blobs[].buffer is     NULL then *buflen  = BUFLEN_EMPTY_BUFFER
If cached_blobs[].buffer is not NULL then *buflen != BUFLEN_EMPTY_BUFFER