### PR TITLE
Revert "Object: clear out sensitive area if on load if not provided"

### DIFF
--- a/src/tpm2/Object.c
+++ b/src/tpm2/Object.c
@@ -460,10 +460,7 @@ ObjectLoad(
     object->publicArea = *publicArea;
     // If there is a sensitive area, load it
     if(sensitive == NULL)
-	{		// libtpms changed begin
-	    object->attributes.publicOnly = SET;
-	    MemorySet(&object->sensitive, 0, sizeof(object->sensitive)); // needed for libtpms.
-	}		// libtpms changed end
+	object->attributes.publicOnly = SET;
     else
 	{
 	    object->sensitive = *sensitive;


### PR DESCRIPTION
This reverts commit e82727e546163817569aecb906f71ac955656e3f.

The issue has previously been resolved in commit 17255da54c.