### PR TITLE
Sync with RSA changes from upstream

### DIFF
--- a/src/tpm2/Object.c
+++ b/src/tpm2/Object.c
@@ -457,7 +457,7 @@ ObjectLoad(
 	    // If this is an RSA key that is not a parent, complete the load by
 	    // computing the private exponent.
 	    if(publicArea->type == ALG_RSA_VALUE)
-		result = CryptRsaLoadPrivateExponent(object);
+		result = CryptRsaLoadPrivateExponent(publicArea, sensitive, object);
 #endif
 	}
     return result;

--- a/src/tpm2/crypto/CryptRsa.h
+++ b/src/tpm2/crypto/CryptRsa.h
@@ -83,9 +83,9 @@ typedef struct privateExponent
 {
     bigNum              P;
     bigNum              Q;
-    bigNum              dP_unused;
-    bigNum              dQ_unused;
-    bigNum              qInv_unused;
+    bigNum              dP;
+    bigNum              dQ;
+    bigNum              qInv;
     bn_prime_t          entries[5];
 } privateExponent;
 
@@ -119,5 +119,30 @@ RsaInitializeExponentOld(
     BN_INIT(pExp->qInv);
 }					// libtpms added end
 
-#endif      // _CRYPT_RSA_H
+#include "BnMemory_fp.h"
 
+static inline void
+RsaSetExponentOld(
+		  privateExponent_t *pExp,  // OUT
+		  privateExponent   *Z      // IN
+		 )
+{
+    // pExp->Q must be set elsewhere
+    BnCopy((bigNum)&pExp->dP, Z->dP);
+    BnCopy((bigNum)&pExp->dQ, Z->dQ);
+    BnCopy((bigNum)&pExp->qInv, Z->qInv);
+}
+
+static inline void
+RsaSetExponentFromOld(
+		      privateExponent   *Z,     // OUT
+		      privateExponent_t *pExp   // IN
+                     )
+{
+    BnCopy(Z->Q, (bigNum)&pExp->Q);
+    BnCopy(Z->dP, (bigNum)&pExp->dP);
+    BnCopy(Z->dQ, (bigNum)&pExp->dQ);
+    BnCopy(Z->qInv, (bigNum)&pExp->qInv);
+}
+
+#endif      // _CRYPT_RSA_H

--- a/src/tpm2/crypto/CryptRsa.h
+++ b/src/tpm2/crypto/CryptRsa.h
@@ -79,13 +79,31 @@ BN_TYPE(prime, (MAX_RSA_KEY_BITS / 2));
 #   error   This verson only works with CRT formatted data
 #endif // !CRT_FORMAT_RSA
 
-typedef struct privateExponent
+					// libtpms added begin: keep old privateExponent
+/* The privateExponentOld is part of the OBJECT and we keep it there even though
+ * upstream got rid of it and stores Q, dP, dQ, and qInv by appending them to
+ * P stored in TPMT_SENSITIVE.TPMU_SENSITIVE_COMPOSITE.TPM2B_PRIVATE_KEY_RSA
+ */
+typedef struct privateExponentOld
 {
     bn_prime_t          Q;
     bn_prime_t          dP;
     bn_prime_t          dQ;
     bn_prime_t          qInv;
 } privateExponent_t;
+
+#include "BnMemory_fp.h"
+
+static inline void
+RsaInitializeExponentOld(
+			 privateExponent_t      *pExp
+			)
+{
+    BN_INIT(pExp->Q);
+    BN_INIT(pExp->dP);
+    BN_INIT(pExp->dQ);
+    BN_INIT(pExp->qInv);
+}					// libtpms added end
 
 #endif      // _CRYPT_RSA_H
 

--- a/src/tpm2/crypto/CryptRsa.h
+++ b/src/tpm2/crypto/CryptRsa.h
@@ -83,9 +83,9 @@ typedef struct privateExponent
 {
     bigNum              P;
     bigNum              Q;
-    bigNum              dP;
-    bigNum              dQ;
-    bigNum              qInv;
+    bigNum              dP_unused;
+    bigNum              dQ_unused;
+    bigNum              qInv_unused;
     bn_prime_t          entries[5];
 } privateExponent;
 

--- a/src/tpm2/crypto/CryptRsa.h
+++ b/src/tpm2/crypto/CryptRsa.h
@@ -79,6 +79,20 @@ BN_TYPE(prime, (MAX_RSA_KEY_BITS / 2));
 #   error   This verson only works with CRT formatted data
 #endif // !CRT_FORMAT_RSA
 
+typedef struct privateExponent
+{
+    bigNum              P;
+    bigNum              Q;
+    bigNum              dP;
+    bigNum              dQ;
+    bigNum              qInv;
+    bn_prime_t          entries[5];
+} privateExponent;
+
+#define     NEW_PRIVATE_EXPONENT(X)					\
+    privateExponent         _##X;					\
+    privateExponent         *X = RsaInitializeExponent(&(_##X))
+
 					// libtpms added begin: keep old privateExponent
 /* The privateExponentOld is part of the OBJECT and we keep it there even though
  * upstream got rid of it and stores Q, dP, dQ, and qInv by appending them to

--- a/src/tpm2/crypto/CryptRsa_fp.h
+++ b/src/tpm2/crypto/CryptRsa_fp.h
@@ -69,10 +69,6 @@ BOOL
 CryptRsaStartup(
 		void
 		);
-void
-RsaInitializeExponent(
-		      privateExponent_t      *pExp
-		      );
 INT16
 CryptRsaPssSaltSize(
 		    INT16              hashSize,

--- a/src/tpm2/crypto/CryptRsa_fp.h
+++ b/src/tpm2/crypto/CryptRsa_fp.h
@@ -80,8 +80,9 @@ CryptRsaSelectScheme(
 		     TPMT_RSA_DECRYPT    *scheme         // IN: a sign or decrypt scheme
 		     );
 TPM_RC
-CryptRsaLoadPrivateExponent(
-			    OBJECT          *rsaKey        // IN: the RSA key object
+CryptRsaLoadPrivateExponent(TPMT_PUBLIC             *publicArea,
+			    TPMT_SENSITIVE          *sensitive,
+			    OBJECT                  *rsaKey        // libtpms added
 			    );
 LIB_EXPORT TPM_RC
 CryptRsaEncrypt(

--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -97,17 +97,6 @@ CryptRsaStartup(
    function returns the pointer to the private exponent value so that it can be used in an
    initializer for a data declaration */
 
-void
-RsaInitializeExponent(
-		      privateExponent_t      *pExp
-		      )
-{
-    BN_INIT(pExp->Q);
-    BN_INIT(pExp->dP);
-    BN_INIT(pExp->dQ);
-    BN_INIT(pExp->qInv);
-}
-
 #if 0					// 	libtpms added
 /* 10.2.17.4.2	MakePgreaterThanQ() */
 /* This function swaps the pointers for P and Q if Q happens to be larger than Q. */
@@ -200,7 +189,7 @@ ComputePrivateExponent(
     BOOL                qOK;
     BN_PRIME(pT);
     //
-    RsaInitializeExponent(pExp);
+    RsaInitializeExponentOld(pExp);
     BnCopy((bigNum)&pExp->Q, Q);
     // make p the larger value so that m2 is always less than p
     if(BnUnsignedCmp(P, Q) < 0)
@@ -1007,7 +996,7 @@ CryptRsaLoadPrivateExponent(
 	{
 	    TEST(TPM_ALG_NULL);
 	    // Make sure that the bigNum used for the exponent is properly initialized
-	    RsaInitializeExponent(&rsaKey->privateExponent);
+	    RsaInitializeExponentOld(&rsaKey->privateExponent);
 	    // Find the second prime by division
 	    BnDiv(bnQ, bnQr, bnN, bnP);
 	    if(!BnEqualZero(bnQr))
@@ -1322,7 +1311,7 @@ CryptRsaGenerateKey(
         return OpenSSLCryptRsaGenerateKey(rsaKey, e, keySizeInBits);
 #endif                                 // libtpms added end
     // Need to initialize the privateExponent structure
-    RsaInitializeExponent(&rsaKey->privateExponent);
+    RsaInitializeExponentOld(&rsaKey->privateExponent);
 
     // The prime is computed in P. When a new prime is found, Q is checked to
     // see if it is zero.  If so, P is copied to Q and a new P is found.

--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -319,7 +319,7 @@ RSADP(
       )
 {
     BN_RSA_INITIALIZED(bnM, inOut);
-    BN_RSA_INITIALIZED(bnP, &key->sensitive.sensitive.rsa);
+    NEW_PRIVATE_EXPONENT(Z);
     if(UnsignedCompareB(inOut->size, inOut->buffer,
 			key->publicArea.unique.rsa.t.size,
 			key->publicArea.unique.rsa.t.buffer) >= 0)
@@ -334,7 +334,8 @@ RSADP(
 	       != TPM_RC_SUCCESS)
 		return TPM_RC_BINDING;
 	}
-    VERIFY(RsaPrivateKeyOp(bnM, bnP, &key->privateExponent));
+    VERIFY(BnFrom2B(Z->P, &key->sensitive.sensitive.rsa.b) != NULL);
+    VERIFY(RsaPrivateKeyOp(bnM, Z->P, &key->privateExponent));
     VERIFY(BnTo2B(bnM, inOut, inOut->size));
     return TPM_RC_SUCCESS;
  Error:

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -877,7 +877,7 @@ OpenSSLCryptRsaGenerateKey(
         ERROR_RETURN(TPM_RC_FAILURE);
 
     // Need to initialize the privateExponent structure
-    RsaInitializeExponent(&rsaKey->privateExponent);
+    RsaInitializeExponentOld(&rsaKey->privateExponent);
 
     if ((ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL)) == NULL ||
         EVP_PKEY_keygen_init(ctx) != 1 ||
@@ -943,7 +943,7 @@ OpenSSLCryptRsaGenerateKey(
         ERROR_RETURN(TPM_RC_FAILURE);
 
     // Need to initialize the privateExponent structure
-    RsaInitializeExponent(&rsaKey->privateExponent);
+    RsaInitializeExponentOld(&rsaKey->privateExponent);
 
     rsa = RSA_new();
     if (rsa == NULL)

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -792,7 +792,8 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
         return TPM_RC_FAILURE;
 
     if(!rsaKey->attributes.privateExp)
-        CryptRsaLoadPrivateExponent(rsaKey);
+        CryptRsaLoadPrivateExponent(&rsaKey->publicArea, &rsaKey->sensitive,
+                                    rsaKey);
 
     P = BN_bin2bn(rsaKey->sensitive.sensitive.rsa.t.buffer,
                   rsaKey->sensitive.sensitive.rsa.t.size, NULL);
@@ -905,7 +906,8 @@ OpenSSLCryptRsaGenerateKey(
 
     // CryptRsaGenerateKey calls ComputePrivateExponent; we have to call
     // it via CryptRsaLoadPrivateExponent
-    retVal = CryptRsaLoadPrivateExponent(rsaKey);
+    retVal = CryptRsaLoadPrivateExponent(&rsaKey->publicArea, &rsaKey->sensitive,
+                                         rsaKey);
 
  Exit:
     OSSL_PARAM_BLD_free(bld);
@@ -964,7 +966,8 @@ OpenSSLCryptRsaGenerateKey(
 
     // CryptRsaGenerateKey calls ComputePrivateExponent; we have to call
     // it via CryptRsaLoadPrivateExponent
-    retVal = CryptRsaLoadPrivateExponent(rsaKey);
+    retVal = CryptRsaLoadPrivateExponent(&rsaKey->publicArea, &rsaKey->sensitive,
+                                         rsaKey);
 
  Exit:
     BN_free(bnE);

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -877,9 +877,6 @@ OpenSSLCryptRsaGenerateKey(
     if (bnE == NULL || BN_set_word(bnE, e) != 1)
         ERROR_RETURN(TPM_RC_FAILURE);
 
-    // Need to initialize the privateExponent structure
-    RsaInitializeExponentOld(&rsaKey->privateExponent);
-
     if ((ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL)) == NULL ||
         EVP_PKEY_keygen_init(ctx) != 1 ||
         (bld = OSSL_PARAM_BLD_new()) == NULL ||
@@ -943,9 +940,6 @@ OpenSSLCryptRsaGenerateKey(
 
     if (bnE == NULL || BN_set_word(bnE, e) != 1)
         ERROR_RETURN(TPM_RC_FAILURE);
-
-    // Need to initialize the privateExponent structure
-    RsaInitializeExponentOld(&rsaKey->privateExponent);
 
     rsa = RSA_new();
     if (rsa == NULL)


### PR DESCRIPTION
Upstream got rid of OBJECT's privateExponent and instead stores P,Q,dP,dQ, and qInv concatenated in a TPM2B in sensitive->sensitive.rsa.t. I don't want to get rid of OBJECT's privateExponent or pack the parameters like this, so therefore this series of patches sync's up the code with upstream as cautiously as possible while maintaining the OBJECT as it is.