### PR TITLE
Sync the RSA prime number generation algorithm with rev180

### DIFF
--- a/man/man3/TPMLIB_SetProfile.pod
+++ b/man/man3/TPMLIB_SetProfile.pod
@@ -164,6 +164,11 @@ unmarshalling code of an OBJECT. Only RSA key OBJECTS have the private
 exponent field marshalled and the hierarchy field is also always marshalled
 now. RSA key OBJECTs may be 4 bytes bigger while others are smaller now.
 
+=item 7: (since v0.10)
+
+This I<StateFormatLevel> enabled a new RSA prime number generation
+algorithm for keys derived from seeds.
+
 =back
 
 A user may specify the I<StateFormatLevel> when using the I<custom> profile.

--- a/src/tpm2/BackwardsCompatibility.h
+++ b/src/tpm2/BackwardsCompatibility.h
@@ -44,7 +44,9 @@ enum {
     SEED_COMPAT_LEVEL_ORIGINAL = 0,   /* original TPM 2 code up to rev155 */
     SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169 = 1, /* RsaAdjustPrimeCandidate was fixed
                                                          before again changed in rev169 */
-    SEED_COMPAT_LEVEL_LAST = SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169
+    SEED_COMPAT_LEVEL_RSA_PRIME_GENERATION_REV169 = 2,/* new algo was introduced at around
+                                                         rev169 */
+    SEED_COMPAT_LEVEL_LAST = SEED_COMPAT_LEVEL_RSA_PRIME_GENERATION_REV169
 };
 
 #endif /* BACKWARDS_COMPATIBILITY_H */

--- a/src/tpm2/BackwardsCompatibility.h
+++ b/src/tpm2/BackwardsCompatibility.h
@@ -42,8 +42,9 @@
 typedef UINT8 SEED_COMPAT_LEVEL;
 enum {
     SEED_COMPAT_LEVEL_ORIGINAL = 0,   /* original TPM 2 code up to rev155 */
-    SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX = 1, /* RsaAdjustPrimeCandidate was fixed */
-    SEED_COMPAT_LEVEL_LAST = SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX
+    SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169 = 1, /* RsaAdjustPrimeCandidate was fixed
+                                                         before again changed in rev169 */
+    SEED_COMPAT_LEVEL_LAST = SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169
 };
 
 #endif /* BACKWARDS_COMPATIBILITY_H */

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -73,7 +73,7 @@ static const struct RuntimeProfileDesc {
      * This basically locks the name of the profile to the stateFormatLevel.
      */
     unsigned int stateFormatLevel;
-#define STATE_FORMAT_LEVEL_CURRENT 6
+#define STATE_FORMAT_LEVEL_CURRENT 7
 #define STATE_FORMAT_LEVEL_UNKNOWN 0 /* JSON didn't provide StateFormatLevel; this is only
 					allowed for the 'default' profile or when user
 					passed JSON via SetProfile() */
@@ -89,6 +89,7 @@ static const struct RuntimeProfileDesc {
  *  5 : Enabled TPM2_PolicyCapability (0x19b) & TPM2_PolicyParameters (0x19c)
  *  6 : Only OBJECTs for RSA keys marshal the private exponent; hierachy field is also
  *      marshalled now
+ *  7 : New RSA prime number generation algorithm for keys derived from seeds
  */
     const char *description;
 #define DESCRIPTION_MAX_SIZE        250
@@ -770,15 +771,18 @@ RuntimeProfileGetByIndex(size_t  idx,
 LIB_EXPORT SEED_COMPAT_LEVEL
 RuntimeProfileGetSeedCompatLevel(void)
 {
-    MUST_BE(SEED_COMPAT_LEVEL_LAST == 1); // force update when this changes
+    MUST_BE(SEED_COMPAT_LEVEL_LAST == 2); // force update when this changes
 
     switch (g_RuntimeProfile.stateFormatLevel) {
     case 1: /* profile runs on v0.9 */
 	return SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169;
 
-    case 2 ... 6: /* profile runs on v0.10 */ {
-	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 6); // force update when this changes
+    case 2 ... 6: /* profile runs on v0.10 */
 	return SEED_COMPAT_LEVEL_LAST;
+
+    case 7: /* profile runs on v0.10 */ {
+	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 7); // force update when this changes
+	return SEED_COMPAT_LEVEL_RSA_PRIME_GENERATION_REV169;
     }
 
     default:

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -763,7 +763,7 @@ RuntimeProfileGetByIndex(size_t  idx,
  * SEED_COMPAT_LEVEL must be available on the earliest version of libtpms
  * where the profile can run. If a profile for example can run on libtpms v0.9
  * then this function must return only this SEED_COMPAT_LEVEL that was
- * available in v0.9, which was SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX.
+ * available in v0.9, which was SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169.
  * The SEED_COMPAT_LEVEL depends on the stateFormatLevel that in turn depends
  * on the libtpms version.
  */
@@ -774,7 +774,7 @@ RuntimeProfileGetSeedCompatLevel(void)
 
     switch (g_RuntimeProfile.stateFormatLevel) {
     case 1: /* profile runs on v0.9 */
-	return SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX;
+	return SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169;
 
     case 2 ... 6: /* profile runs on v0.10 */ {
 	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 6); // force update when this changes

--- a/src/tpm2/TpmMath_Util.c
+++ b/src/tpm2/TpmMath_Util.c
@@ -99,6 +99,77 @@ LIB_EXPORT BOOL TpmMath_IntTo2B(
     return FALSE;
 }
 
+//*** TpmMath_GetRandomBits()
+// This function gets random bits for use in various places.
+//
+// One consequence of the generation scheme is that, if the number of bits requested
+// is not a multiple of 8, then the high-order bits are set to zero. This would come
+// into play when generating a 521-bit ECC key. A 66-byte (528-bit) value is
+// generated and the high order 7 bits are masked off (CLEAR).
+// In this situation, the highest order byte is the first byte (big-endian/TPM2B format)
+//  Return Type: BOOL
+//      TRUE(1)         success
+//      FALSE(0)        failure
+LIB_EXPORT BOOL TpmMath_GetRandomBits(BYTE* pBuffer, size_t bits, RAND_STATE* rand)
+{
+    // buffer is assumed to be large enough for the number of bits rounded up to
+    // bytes.
+    NUMBYTES byteCount = (NUMBYTES)BITS_TO_BYTES(bits);
+    if(DRBG_Generate(rand, pBuffer, byteCount) == byteCount)
+	{
+	    // now flip the buffer order - this exists only to maintain
+	    // compatibility with existing Known-value tests that expect the
+	    // GetRandomInteger behavior of generating the value in little-endian
+	    // order.
+	    BYTE* pFrom = pBuffer + byteCount - 1;
+	    BYTE* pTo   = pBuffer;
+	    while(pTo < pFrom)
+		{
+		    BYTE t = *pTo;
+		    *pTo   = *pFrom;
+		    *pFrom = t;
+		    pTo++;
+		    pFrom--;
+		}
+	    // For a little-endian machine, the conversion is a straight byte
+	    // reversal, done above. For a big-endian machine, we have to put the
+	    // words in big-endian byte order.  COMPATIBILITY NOTE: This code does
+	    // not exactly reproduce the original code, because the original big-num
+	    // code always generated data in units of crypt_word_t sizes.  I.e. you
+	    // couldn't generate just 9 bits for example.  This revised version of
+	    // the function could; and would generate 2 bytes with the first byte
+	    // masked to 1 bit.  In order to avoid running over the buffer when
+	    // swapping crypt_uword_t blocks, this loop intentionally doesn't swap
+	    // the last word if it is smaller than crypt_word_t size (which is the
+	    // same as saying the buffer isn't an integral number of crypt_word_t
+	    // units.) This is okay in this particular case _because_ this whole
+	    // block of swapping code is to maintain compatibilty with existing
+	    // KNOWN ANSWER TESTS, and said existing tests use sizes that this
+	    // assumption is true for.  Any new code with a different size where
+	    // this last partial value isn't swapped will be creating a new KAT, and
+	    // thus any (cryptographically valid) value is still random; swapping
+	    // doesn't make a cryptographic random buffer more or less random, so
+	    // the failure to swap is fine.
+#if BIG_ENDIAN_TPM
+	    crypt_uword_t* pTemp = pBuffer;
+	    for(size_t t = 0; t < (byteCount / sizeof(crypt_uword_t)); t++)
+		*pTemp = SWAP_CRYPT_WORD(*pTemp);
+#endif
+	    // if the number of bits % 8 != 0, mask the high order (first) byte to the relevant number of bits
+	    // bits % 8     desired mask   right-shift of 0xFF
+	    //     0           0xFF             0 = (8 - 0) % 8
+	    //     1           0x01             7 = (8 - 1) % 8
+	    //     2           0x03             6 = (8 - 2) % 8
+	    //     ... etc ...
+	    //     7           0x7F             1 = (8 - 7) % 8
+	    int  excessBits = bits % 8;
+	    static const BYTE mask[8] = {0xff, 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f};	// libtpms changed: fix
+	    pBuffer[0] &= mask[excessBits];							// libtpms changed: fix
+	    return TRUE;
+	}
+    return FALSE;
+}
+
 //*** TpmMath_GetRandomInteger()
 // This function gets random bits for use in various places. To make sure that the
 // number is generated in a portable format, it is created as a TPM2B and then

--- a/src/tpm2/TpmMath_Util_fp.h
+++ b/src/tpm2/TpmMath_Util_fp.h
@@ -83,6 +83,22 @@ LIB_EXPORT BOOL TpmMath_IntTo2B(
 				NUMBYTES         size    // IN: Size of output buffer - see comments.
 				);
 
+//*** TpmMath_GetRandomBits()
+// This function gets random bits for use in various places.
+//
+// One consequence of the generation scheme is that, if the number of bits requested
+// is not a multiple of 8, then the high-order bits are set to zero. This would come
+// into play when generating a 521-bit ECC key. A 66-byte (528-bit) value is
+// generated and the high order 7 bits are masked off (CLEAR).
+// In this situation, the highest order byte is the first byte (big-endian/TPM2B format)
+//  Return Type: BOOL
+//      TRUE(1)         success
+//      FALSE(0)        failure
+LIB_EXPORT BOOL TpmMath_GetRandomBits(
+				      BYTE*       pBuffer,  // OUT: buffer to set
+				      size_t      bits,     // IN: number of bits to generate (see remarks)
+				      RAND_STATE* rand      // IN: random engine
+				      );
 
 //*** TpmMath_GetRandomInteger
 // This function generates a random integer with the requested number of bits.

--- a/src/tpm2/crypto/CryptPrimeSieve_fp.h
+++ b/src/tpm2/crypto/CryptPrimeSieve_fp.h
@@ -75,7 +75,9 @@
 // limit (primeLimit) set up by this function. This causes the sieve
 // process to stop when an appropriate number of primes have been
 // sieved.
-LIB_EXPORT void RsaAdjustPrimeLimit(uint32_t requestedPrimes);
+LIB_EXPORT void RsaAdjustPrimeLimit(uint32_t requestedPrimes,
+				    SEED_COMPAT_LEVEL seedCompatLevel	// libtpms added
+				    );
 
 //*** RsaNextPrime()
 // This the iterator used during the sieve process. The input is the

--- a/src/tpm2/crypto/CryptPrime_fp.h
+++ b/src/tpm2/crypto/CryptPrime_fp.h
@@ -124,12 +124,6 @@ TpmRsa_GeneratePrimeForRSA(
 			   RAND_STATE* rand       // IN: the random state
 			   );
 
-				// libtpms: added begin
-void RsaAdjustPrimeCandidate(Crypt_Int*        prime,
-			     SEED_COMPAT_LEVEL seedCompatLevel  // IN: compatibility level
-			     );
-				// libtpms: added end
-
 #endif  // ALG_RSA
 
 #endif  // _CRYPT_PRIME_FP_H_

--- a/src/tpm2/crypto/openssl/CryptPrime.c
+++ b/src/tpm2/crypto/openssl/CryptPrime.c
@@ -427,9 +427,8 @@ TPM_RC TpmRsa_GeneratePrimeForRSA(
 		    return TPM_RC_FAILURE;
 		RsaAdjustPrimeCandidate_PreRev155(prime);
 		break;
-	    case SEED_COMPAT_LEVEL_LAST:
-	    /* case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX: */
-		if(!TpmMath_GetRandomInteger(prime, bits, rand))                              // new
+	    case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169:
+		if(!TpmMath_GetRandomInteger(prime, bits, rand))
 		    return TPM_RC_FAILURE;
 		RsaAdjustPrimeCandidate_PreRev169(prime);
 		break;

--- a/src/tpm2/crypto/openssl/CryptPrime.c
+++ b/src/tpm2/crypto/openssl/CryptPrime.c
@@ -392,25 +392,6 @@ RsaAdjustPrimeCandidate_PreRev169(
 // issues.
 //
 
-
-
-LIB_EXPORT void RsaAdjustPrimeCandidate(Crypt_Int*        prime,
-				        SEED_COMPAT_LEVEL seedCompatLevel  // IN: compatibility level; libtpms added
-					)
-{
-    switch (seedCompatLevel) {
-    case SEED_COMPAT_LEVEL_ORIGINAL:
-        RsaAdjustPrimeCandidate_PreRev155(prime);
-        break;
-    case SEED_COMPAT_LEVEL_LAST:
-    /* case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX: */
-        RsaAdjustPrimeCandidate_PreRev169(prime);
-        break;
-    default:
-        FAIL(FATAL_ERROR_INTERNAL);
-    }
-}
-
 //***TpmRsa_GeneratePrimeForRSA()
 // Function to generate a prime of the desired size with the proper attributes
 // for an RSA prime.
@@ -444,16 +425,17 @@ TPM_RC TpmRsa_GeneratePrimeForRSA(
 		DRBG_Generate(rand, (BYTE *)prime->d, (UINT16)BITS_TO_BYTES(bits));
 		if (g_inFailureMode)
 		    return TPM_RC_FAILURE;
+		RsaAdjustPrimeCandidate_PreRev155(prime);
 		break;
 	    case SEED_COMPAT_LEVEL_LAST:
-            /* case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX: */
+	    /* case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX: */
 		if(!TpmMath_GetRandomInteger(prime, bits, rand))                              // new
 		    return TPM_RC_FAILURE;
-                break;
-            default:
-                FAIL(FATAL_ERROR_INTERNAL);
+		RsaAdjustPrimeCandidate_PreRev169(prime);
+		break;
+	    default:
+		FAIL(FATAL_ERROR_INTERNAL);
 	    }
-	    RsaAdjustPrimeCandidate(prime, DRBG_GetSeedCompatLevel(rand));
 	// libtpms changed end
 	    found = RsaCheckPrime(prime, exponent, rand) == TPM_RC_SUCCESS;
 	}

--- a/src/tpm2/crypto/openssl/CryptPrime.c
+++ b/src/tpm2/crypto/openssl/CryptPrime.c
@@ -338,6 +338,29 @@ RsaAdjustPrimeCandidate_PreRev155(
     prime->d[0] |= 1;
 }
 
+static void
+RsaAdjustPrimeCandidate_PreRev169(
+			    Crypt_Int* prime
+			   )
+{
+    // If the radix is 32, the compiler should turn this into a simple assignment
+    uint32_t msw = prime->d[prime->size - 1] >> ((RADIX_BITS == 64) ? 32 : 0);
+    // Multiplying 0xff...f by 0x4AFB gives 0xff..f - 0xB5050...0
+    uint32_t adjusted = (msw >> 16) * 0x4AFB;
+    adjusted += ((msw & 0xFFFF) * 0x4AFB) >> 16;
+    adjusted += 0xB5050000UL;
+#if RADIX_BITS == 64
+    // Save the low-order 32 bits
+    prime->d[prime->size - 1] &= 0xFFFFFFFFUL;
+    // replace the upper 32-bits
+    prime->d[prime->size -1] |= ((crypt_uword_t)adjusted << 32);
+#else
+    prime->d[prime->size - 1] = (crypt_uword_t)adjusted;
+#endif
+    // make sure the number is odd
+    prime->d[0] |= 1;
+}
+
 /* 10.2.14.1.7 RsaAdjustPrimeCandidate() */
 
 //*** RsaAdjustPrimeCandiate()
@@ -368,28 +391,7 @@ RsaAdjustPrimeCandidate_PreRev155(
 // significant bits of each prime candidate without introducing any computational
 // issues.
 //
-static void
-RsaAdjustPrimeCandidate_New(
-			    Crypt_Int* prime
-			   )
-{
-    // If the radix is 32, the compiler should turn this into a simple assignment
-    uint32_t msw = prime->d[prime->size - 1] >> ((RADIX_BITS == 64) ? 32 : 0);
-    // Multiplying 0xff...f by 0x4AFB gives 0xff..f - 0xB5050...0
-    uint32_t adjusted = (msw >> 16) * 0x4AFB;
-    adjusted += ((msw & 0xFFFF) * 0x4AFB) >> 16;
-    adjusted += 0xB5050000UL;
-#if RADIX_BITS == 64
-    // Save the low-order 32 bits
-    prime->d[prime->size - 1] &= 0xFFFFFFFFUL;
-    // replace the upper 32-bits
-    prime->d[prime->size -1] |= ((crypt_uword_t)adjusted << 32);
-#else
-    prime->d[prime->size - 1] = (crypt_uword_t)adjusted;
-#endif
-    // make sure the number is odd
-    prime->d[0] |= 1;
-}
+
 
 
 LIB_EXPORT void RsaAdjustPrimeCandidate(Crypt_Int*        prime,
@@ -402,7 +404,7 @@ LIB_EXPORT void RsaAdjustPrimeCandidate(Crypt_Int*        prime,
         break;
     case SEED_COMPAT_LEVEL_LAST:
     /* case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX: */
-        RsaAdjustPrimeCandidate_New(prime);
+        RsaAdjustPrimeCandidate_PreRev169(prime);
         break;
     default:
         FAIL(FATAL_ERROR_INTERNAL);

--- a/src/tpm2/crypto/openssl/CryptPrimeSieve.c
+++ b/src/tpm2/crypto/openssl/CryptPrimeSieve.c
@@ -94,15 +94,19 @@ uint32_t       primeLimit;
 // limit (primeLimit) set up by this function. This causes the sieve
 // process to stop when an appropriate number of primes have been
 // sieved.
-LIB_EXPORT void RsaAdjustPrimeLimit(uint32_t requestedPrimes)
+LIB_EXPORT void RsaAdjustPrimeLimit(uint32_t requestedPrimes,
+				    SEED_COMPAT_LEVEL seedCompatLevel)
 {
     if(requestedPrimes == 0 || requestedPrimes > s_PrimesInTable)
 	requestedPrimes = s_PrimesInTable;
     requestedPrimes = (requestedPrimes - 1) / 1024;
     if(requestedPrimes < s_PrimeMarkersCount)
 	primeLimit = s_PrimeMarkers[requestedPrimes];
-    else
-	primeLimit = s_LastPrimeInTable - 2;  // libtpms: Fix for 3072 bit keys to avoid mark=5
+    else {					// libtpms changed begin
+	primeLimit = s_LastPrimeInTable;
+	if (seedCompatLevel <= SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_PREREV169)
+		primeLimit = s_LastPrimeInTable - 2;  // Previous 'fix' for 3072 bit keys to avoid mark=5
+    }						// libtpms changed end
     primeLimit >>= 1;
 }
 
@@ -241,11 +245,12 @@ typedef struct
     UINT32 prime;
     UINT16 count;
 } SIEVE_MARKS;
-const SIEVE_MARKS sieveMarks[5] = {{31, 7},
+const SIEVE_MARKS sieveMarks[6] = {{31, 7},
 				   {73, 5},
 				   {241, 4},
 				   {1621, 3},
-				   {UINT16_MAX, 2}};
+				   {UINT16_MAX, 2},
+				   {UINT32_MAX, 1}};
 
 const size_t MAX_SIEVE_MARKS = (sizeof(sieveMarks) / sizeof(sieveMarks[0]));
 
@@ -438,6 +443,7 @@ LIB_EXPORT TPM_RC PrimeSelectWithSieve(
     UINT32 fieldSize = MAX_FIELD_SIZE;
 #  endif
     UINT32 primeSize;
+    SEED_COMPAT_LEVEL seedCompatLevel = DRBG_GetSeedCompatLevel(rand);
     //
     // Adjust the field size and prime table list to fit the size of the prime
     // being tested. This is done to try to optimize the trade-off between the
@@ -449,15 +455,15 @@ LIB_EXPORT TPM_RC PrimeSelectWithSieve(
 
     if(primeSize <= 512)
 	{
-	    RsaAdjustPrimeLimit(1024);  // Use just the first 1024 primes
+	    RsaAdjustPrimeLimit(1024, seedCompatLevel);  // Use just the first 1024 primes	// libtpms added seedCompatLevel
 	}
     else if(primeSize <= 1024)
 	{
-	    RsaAdjustPrimeLimit(4096);  // Use just the first 4K primes
+	    RsaAdjustPrimeLimit(4096, seedCompatLevel);  // Use just the first 4K primes	// libtpms added seedCompatLevel
 	}
     else
 	{
-	    RsaAdjustPrimeLimit(0);  // Use all available
+	    RsaAdjustPrimeLimit(0, seedCompatLevel);  // Use all available			// libtpms added seedCompatLevel
 	}
 
     // Save the low-order word to use as a search generator and make sure that

--- a/tests/object_size.c
+++ b/tests/object_size.c
@@ -68,8 +68,8 @@ int main(void)
         },
         .seedCompatLevel = 1,
     };
-    static const size_t exp_sizes[7] = {
-        0, 2580, 2580, 2580, 2580, 2580, 2584,
+    static const size_t exp_sizes[8] = {
+        0, 2580, 2580, 2580, 2580, 2580, 2584, 2584,
     };
     BYTE buffer[2 * MAX_MARSHALLED_OBJECT_SIZE];
     UINT32 stateFormatLevel;

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -59,7 +59,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"default-v1\","
-            "\"StateFormatLevel\":6,"
+            "\"StateFormatLevel\":7,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197,0x199-0x19c\","


### PR DESCRIPTION
This PR syncs the RSA prime number generation algorithm with rev180. Since it now uses a different random number generation function the usage of the new algorithm has to be made dependent on the SEED_COMPAT_LEVEL.
Also, update the sieveMarks array with the missing member and roll back the previously made change to avoid mark=5. Since 3072 bit RSA keys may occasionally be different if the full sieveMarks array is now use, we also have to make the usage of the full (or restricted) sieveMarks array dependent on the SEED_COMPAT_LEVEL.