### PR TITLE
tests: oss-fuzz.sh: Append -fno-sanitize=bounds to CFLAGS

### DIFF
--- a/tests/oss-fuzz.sh
+++ b/tests/oss-fuzz.sh
@@ -6,6 +6,7 @@ export CC=${CC:-clang}
 export CXX=${CXX:-clang++}
 export WORK=${WORK:-$(pwd)}
 export OUT=${OUT:-$(pwd)/out}
+CFLAGS="${CFLAGS} -fno-sanitize=bounds"  # due to casts to Crypt_Int*
 
 mkdir -p $OUT
 


### PR DESCRIPTION
The new TPM 2 code casts bigNum's to Crypt_Int, which has an array 'd' of type 'crypt_uword_t[2]' which then leads to the following types of errors that we haven't found another solution for so far.

Running: /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-2675de6341d4e056d04ab49179b8e5b8bd456589
	/src/libtpms/src/tpm2/crypto/openssl/CryptPrime.c:377:20: runtime error: index 23 out of bounds for type 'crypt_uword_t[2]' (aka 'unsigned long[2]')
 #0 0x5b4196 in RsaAdjustPrimeCandidate_New libtpms/src/tpm2/crypto/openssl/CryptPrime.c:377:20
 #1 0x5b4196 in RsaAdjustPrimeCandidate libtpms/src/tpm2/crypto/openssl/CryptPrime.c:405:9
 #2 0x5b4366 in TpmRsa_GeneratePrimeForRSA libtpms/src/tpm2/crypto/openssl/CryptPrime.c:454:6
 #3 0x590953 in CryptRsaGenerateKey libtpms/src/tpm2/crypto/openssl/CryptRsa.c:1433:9