### PR TITLE
tpm2: Remove trailing space in MANUFACTURER #define

### DIFF
--- a/src/tpm2/VendorInfo.c
+++ b/src/tpm2/VendorInfo.c
@@ -68,7 +68,7 @@
 #include "Platform.h"
 
 // In this sample platform, these are compile time constants, but are not required to be.
-#define MANUFACTURER    "IBM "
+#define MANUFACTURER    "IBM"
 #define VENDOR_STRING_1 "SW  "
 #define VENDOR_STRING_2 " TPM"
 #define VENDOR_STRING_3 "\0\0\0\0"


### PR DESCRIPTION
Restore the MANUFACTURER string "IBM" to what it was before commit 6dcb416ddf5c05b.