### PR TITLE
rev180: Introduce IsCpHashUnionOccupied and use it in simple case

### DIFF
--- a/src/tpm2/EACommands.c
+++ b/src/tpm2/EACommands.c
@@ -1029,7 +1029,7 @@ TPM2_PolicyCpHash(PolicyCpHash_In* in  // IN: input parameter list
 
     // error if the cpHash in session context is not empty and is not the same
     // as the input or is not a cpHash
-    if((session->u1.cpHash.t.size != 0)
+    if((IsCpHashUnionOccupied(session->attributes))
        && (!session->attributes.isCpHashDefined
 	   || !MemoryEqual2B(&in->cpHashA.b, &session->u1.cpHash.b)))
 	return TPM_RC_CPHASH;
@@ -1092,11 +1092,9 @@ TPM2_PolicyNameHash(PolicyNameHash_In* in  // IN: input parameter list
     // is always non-zero.
     if(in->nameHash.t.size != CryptHashGetDigestSize(session->authHashAlg))
 	return TPM_RCS_SIZE + RC_PolicyNameHash_nameHash;
-    // u1 in the policy session context cannot otherwise be occupied
-    if(session->u1.cpHash.b.size != 0
-       || session->attributes.isBound
-       || session->attributes.isCpHashDefined
-       || session->attributes.isTemplateHashDefined)
+
+    // error if the nameHash in session context is not empty
+    if(IsCpHashUnionOccupied(session->attributes))
 	return TPM_RC_CPHASH;
 
     // Internal Data Update

--- a/src/tpm2/Global.h
+++ b/src/tpm2/Global.h
@@ -396,6 +396,11 @@ typedef struct SESSION_ATTRIBUTES
 #endif                                           /* libtpms added end */
 } SESSION_ATTRIBUTES;
 
+//*** IsCpHashUnionOccupied()
+// This function indicates whether the session attributes indicate that one of
+// the members of the union containing `cpHash` are set.
+BOOL IsCpHashUnionOccupied(SESSION_ATTRIBUTES attrs);
+
 //*** SESSION Structure
 // The SESSION structure contains all the context of a session except for the
 // associated contextID.

--- a/src/tpm2/Session.c
+++ b/src/tpm2/Session.c
@@ -1059,3 +1059,11 @@ SessionCapGetActiveAvail(void)
     return num;
 }
 
+//*** IsCpHashUnionOccupied()
+// This function indicates whether the session attributes indicate that one of
+// the members of the union containing `cpHash` are set.
+BOOL IsCpHashUnionOccupied(SESSION_ATTRIBUTES attrs)
+{
+    return attrs.isBound || attrs.isCpHashDefined
+	|| attrs.isTemplateHashDefined;
+}


### PR DESCRIPTION
Replace the check for several session attributes flags with a call to IsCpHashUnionOccupied.

Note that the existing check for

session->u1.cpHash.b.size != 0 || session->attributes.isCpHashDefined

can be replaced with just session->attributes.isCpHashDefined since isCpHashDefined is always assigned '1' (SET) when session.u1.cpHash is given a value. isCpHashDefined is reset in SessionResetPolicyData() as part of resetting all attribute flags and cpHash size is set to 0.