### PR TITLE
tpm12: Replace include of engine.h with err.h

### DIFF
--- a/src/tpm12/tpm_crypto.c
+++ b/src/tpm12/tpm_crypto.c
@@ -47,7 +47,9 @@
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <openssl/sha.h>
-#include <openssl/engine.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
 
 #include "tpm_cryptoh.h"
 #include "tpm_debug.h"


### PR DESCRIPTION
Fedora Rawhide and CentOS 10 do not support OpenSSL engine anymore. Therefore, replace include of engine.h with err.h since the engine is not needed anyway but we only need the prototype of ERR_get_error_line_data. Add missing includes for evp.h and rsa.h.