### PR TITLE
tpm2: Print error message when invalid hash algorithm id appears (Cov…

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -806,7 +806,12 @@ pcrbanks_algs_active(const TPML_PCR_SELECTION *pcrAllocated)
     for(i = 0; i < pcrAllocated->count; i++) {
         for (j = 0; j < pcrAllocated->pcrSelections[i].sizeofSelect; j++) {
             if (pcrAllocated->pcrSelections[i].pcrSelect[j]) {
-                algs_active |= ((UINT64)1 << pcrAllocated->pcrSelections[i].hash);
+                if (pcrAllocated->pcrSelections[i].hash >= 64) {
+                    TPMLIB_LogTPM2Error("pcrbanks_algs_active: invalid hash alg id: %d\n",
+                                        pcrAllocated->pcrSelections[i].hash);
+                } else {
+                    algs_active |= ((UINT64)1 << pcrAllocated->pcrSelections[i].hash);
+                }
                 break;
             }
         }


### PR DESCRIPTION
…erity)

In case a hash algorithm id has a value >= 64 print out and error. This should never occur since any hash algorithm id should have been set through unmarshalling or by TPM 2-internal code.