### PR TITLE
Disable COMPRESSED_LISTS and convert arrays before enabling algorithms and commands

### DIFF
--- a/man/man3/TPMLIB_SetProfile.pod
+++ b/man/man3/TPMLIB_SetProfile.pod
@@ -132,6 +132,11 @@ of the state.
 This I<StateFormatLevel> enabled the writing of the profile as part of the
 state.
 
+=item 3: (since v0.10)
+
+This I<StateFormatLevel> enabled the TPM 2 commands ECC_Encrypt (0x199) and
+ECC_Decrypt (0x19a).
+
 =back
 
 A user may specify the I<StateFormatLevel> when using the I<custom> profile.

--- a/man/man3/TPMLIB_SetProfile.pod
+++ b/man/man3/TPMLIB_SetProfile.pod
@@ -137,6 +137,10 @@ state.
 This I<StateFormatLevel> enabled the TPM 2 commands ECC_Encrypt (0x199) and
 ECC_Decrypt (0x19a).
 
+=item 4: (since v0.10)
+
+This I<StateFormatLevel> enabled Camellia-192 and AES-192.
+
 =back
 
 A user may specify the I<StateFormatLevel> when using the I<custom> profile.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -293,6 +293,7 @@ libtpms_tpm2_la_SOURCES = \
 	tpm_tpm2_interface.c \
 	tpm_tpm2_tis.c \
 	\
+	tpm2/BackwardsCompatibilityBitArray.c \
 	tpm2/BackwardsCompatibilityObject.c \
 	tpm2/LibtpmsCallbacks.c \
 	tpm2/NVMarshal.c \
@@ -566,6 +567,7 @@ noinst_HEADERS += \
 	tpm2/ZGen_2Phase_fp.h \
 	\
 	tpm2/BackwardsCompatibility.h \
+	tpm2/BackwardsCompatibilityBitArray.h \
 	tpm2/BackwardsCompatibilityObject.h \
 	tpm2/LibtpmsCallbacks.h \
 	tpm2/NVMarshal.h \

--- a/src/tpm2/BackwardsCompatibilityBitArray.c
+++ b/src/tpm2/BackwardsCompatibilityBitArray.c
@@ -1,0 +1,277 @@
+/********************************************************************************/
+/*										*/
+/*	Backwards compatibility support related to command code arrays		*/
+/*			     Written by Stefan Berger				*/
+/*		       IBM Thomas J. Watson Research Center			*/
+/*										*/
+/* (c) Copyright IBM Corporation 2023.						*/
+/*										*/
+/* All rights reserved.								*/
+/* 										*/
+/* Redistribution and use in source and binary forms, with or without		*/
+/* modification, are permitted provided that the following conditions are	*/
+/* met:										*/
+/* 										*/
+/* Redistributions of source code must retain the above copyright notice,	*/
+/* this list of conditions and the following disclaimer.			*/
+/* 										*/
+/* Redistributions in binary form must reproduce the above copyright		*/
+/* notice, this list of conditions and the following disclaimer in the		*/
+/* documentation and/or other materials provided with the distribution.		*/
+/* 										*/
+/* Neither the names of the IBM Corporation nor the names of its		*/
+/* contributors may be used to endorse or promote products derived from		*/
+/* this software without specific prior written permission.			*/
+/* 										*/
+/* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS		*/
+/* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT		*/
+/* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR	*/
+/* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT		*/
+/* HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,	*/
+/* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT		*/
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,	*/
+/* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY	*/
+/* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT		*/
+/* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE	*/
+/* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.		*/
+/********************************************************************************/
+
+#include <assert.h>
+
+#include "BackwardsCompatibilityBitArray.h"
+
+/* The following array contains exactly the commands that libtpms v0.9 had enabled
+ * when 'compressed lists' were used. Do not change this array anymore!
+ * A bit in the PERSISTEN_DATA.auditCommands array corresponds to the index in
+ * this array where the command code can be found.
+ */
+static const struct {
+    TPM_CC cc;
+
+#define ENTRY(CC, INDEX)  \
+    [INDEX] = { .cc = CC }
+
+} CCToCompressedListIndex[] = {
+    ENTRY(TPM_CC_NV_UndefineSpaceSpecial, 0),
+    ENTRY(TPM_CC_EvictControl, 1),
+    ENTRY(TPM_CC_HierarchyControl, 2),
+    ENTRY(TPM_CC_NV_UndefineSpace, 3),
+    ENTRY(TPM_CC_ChangeEPS, 4),
+    ENTRY(TPM_CC_ChangePPS, 5),
+    ENTRY(TPM_CC_Clear, 6),
+    ENTRY(TPM_CC_ClearControl, 7),
+    ENTRY(TPM_CC_ClockSet, 8),
+    ENTRY(TPM_CC_HierarchyChangeAuth, 9),
+    ENTRY(TPM_CC_NV_DefineSpace, 10),
+    ENTRY(TPM_CC_PCR_Allocate, 11),
+    ENTRY(TPM_CC_PCR_SetAuthPolicy, 12),
+    ENTRY(TPM_CC_PP_Commands, 13),
+    ENTRY(TPM_CC_SetPrimaryPolicy, 14),
+    /* CC_FieldUpdateStart */
+    ENTRY(TPM_CC_ClockRateAdjust, 15),
+    ENTRY(TPM_CC_CreatePrimary, 16),
+    ENTRY(TPM_CC_NV_GlobalWriteLock, 17),
+    ENTRY(TPM_CC_GetCommandAuditDigest, 18),
+    ENTRY(TPM_CC_NV_Increment, 19),
+    ENTRY(TPM_CC_NV_SetBits, 20),
+    ENTRY(TPM_CC_NV_Extend, 21),
+    ENTRY(TPM_CC_NV_Write, 22),
+    ENTRY(TPM_CC_NV_WriteLock, 23),
+    ENTRY(TPM_CC_DictionaryAttackLockReset, 24),
+    ENTRY(TPM_CC_DictionaryAttackParameters, 25),
+    ENTRY(TPM_CC_NV_ChangeAuth, 26),
+    ENTRY(TPM_CC_PCR_Event, 27),
+    ENTRY(TPM_CC_PCR_Reset, 28),
+    ENTRY(TPM_CC_SequenceComplete, 29),
+    ENTRY(TPM_CC_SetAlgorithmSet, 30),
+    ENTRY(TPM_CC_SetCommandCodeAuditStatus, 31),
+    /* CC_FieldUpgradeData */
+    ENTRY(TPM_CC_IncrementalSelfTest, 32),
+    ENTRY(TPM_CC_SelfTest, 33),
+    ENTRY(TPM_CC_Startup, 34),
+    ENTRY(TPM_CC_Shutdown, 35),
+    ENTRY(TPM_CC_StirRandom, 36),
+    ENTRY(TPM_CC_ActivateCredential, 37),
+    ENTRY(TPM_CC_Certify, 38),
+    ENTRY(TPM_CC_PolicyNV, 39),
+    ENTRY(TPM_CC_CertifyCreation, 40),
+    ENTRY(TPM_CC_Duplicate, 41),
+    ENTRY(TPM_CC_GetTime, 42),
+    ENTRY(TPM_CC_GetSessionAuditDigest, 43),
+    ENTRY(TPM_CC_NV_Read, 44),
+    ENTRY(TPM_CC_NV_ReadLock, 45),
+    ENTRY(TPM_CC_ObjectChangeAuth, 46),
+    ENTRY(TPM_CC_PolicySecret, 47),
+    ENTRY(TPM_CC_Rewrap, 48),
+    ENTRY(TPM_CC_Create, 49),
+    ENTRY(TPM_CC_ECDH_ZGen, 50),
+    ENTRY(TPM_CC_HMAC, 51),
+    ENTRY(TPM_CC_Import, 52),
+    ENTRY(TPM_CC_Load, 53),
+    ENTRY(TPM_CC_Quote, 54),
+    ENTRY(TPM_CC_RSA_Decrypt, 55),
+    ENTRY(TPM_CC_HMAC_Start, 56),
+    ENTRY(TPM_CC_SequenceUpdate, 57),
+    ENTRY(TPM_CC_Sign, 58),
+    ENTRY(TPM_CC_Unseal, 59),
+    ENTRY(TPM_CC_PolicySigned, 60),
+    ENTRY(TPM_CC_ContextLoad, 61),
+    ENTRY(TPM_CC_ContextSave, 62),
+    ENTRY(TPM_CC_ECDH_KeyGen, 63),
+    ENTRY(TPM_CC_EncryptDecrypt, 64),
+    ENTRY(TPM_CC_FlushContext, 65),
+    ENTRY(TPM_CC_LoadExternal, 66),
+    ENTRY(TPM_CC_MakeCredential, 67),
+    ENTRY(TPM_CC_NV_ReadPublic, 68),
+    ENTRY(TPM_CC_PolicyAuthorize, 69),
+    ENTRY(TPM_CC_PolicyAuthValue, 70),
+    ENTRY(TPM_CC_PolicyCommandCode, 71),
+    ENTRY(TPM_CC_PolicyCounterTimer, 72),
+    ENTRY(TPM_CC_PolicyCpHash, 73),
+    ENTRY(TPM_CC_PolicyLocality, 74),
+    ENTRY(TPM_CC_PolicyNameHash, 75),
+    ENTRY(TPM_CC_PolicyOR, 76),
+    ENTRY(TPM_CC_PolicyTicket, 77),
+    ENTRY(TPM_CC_ReadPublic, 78),
+    ENTRY(TPM_CC_RSA_Encrypt, 79),
+    ENTRY(TPM_CC_StartAuthSession, 80),
+    ENTRY(TPM_CC_VerifySignature, 81),
+    ENTRY(TPM_CC_ECC_Parameters, 82),
+    /* CC_FirmwareRead */
+    ENTRY(TPM_CC_GetCapability, 83),
+    ENTRY(TPM_CC_GetRandom, 84),
+    ENTRY(TPM_CC_GetTestResult, 85),
+    ENTRY(TPM_CC_Hash, 86),
+    ENTRY(TPM_CC_PCR_Read, 87),
+    ENTRY(TPM_CC_PolicyPCR, 88),
+    ENTRY(TPM_CC_PolicyRestart, 89),
+    ENTRY(TPM_CC_ReadClock, 90),
+    ENTRY(TPM_CC_PCR_Extend, 91),
+    ENTRY(TPM_CC_PCR_SetAuthValue, 92),
+    ENTRY(TPM_CC_NV_Certify, 93),
+    ENTRY(TPM_CC_EventSequenceComplete, 94),
+    ENTRY(TPM_CC_HashSequenceStart, 95),
+    ENTRY(TPM_CC_PolicyPhysicalPresence, 96),
+    ENTRY(TPM_CC_PolicyDuplicationSelect, 97),
+    ENTRY(TPM_CC_PolicyGetDigest, 98),
+    ENTRY(TPM_CC_TestParms, 99),
+    ENTRY(TPM_CC_Commit, 100),
+    ENTRY(TPM_CC_PolicyPassword, 101),
+    ENTRY(TPM_CC_ZGen_2Phase, 102),
+    ENTRY(TPM_CC_EC_Ephemeral, 103),
+    ENTRY(TPM_CC_PolicyNvWritten, 104),
+    ENTRY(TPM_CC_PolicyTemplate, 105),
+    ENTRY(TPM_CC_CreateLoaded, 106),
+    ENTRY(TPM_CC_PolicyAuthorizeNV, 107),
+    ENTRY(TPM_CC_EncryptDecrypt2, 108),
+    /* CC_AC_GetCapability -- never enable here */
+    /* CC_AC_Send -- never enable here */
+    /* CC_Policy_AC_SendSelect */
+    ENTRY(TPM_CC_CertifyX509, 109),
+    /* CC_ACT_SetTimeout -- never enable here */
+    /* CC_ECC_Encrypt -- never enable here */
+    /* CC_ECC_Decrypt -- never enable here */
+    /* never add new commands */
+};
+
+/* Convert from a bit array from the time when COMPRESSED_LIST was YES
+ * to an array where the indices do NOT correspond to a COMPRESSED_LIST.
+ */
+TPM_RC
+ConvertFromCompressedBitArray(BYTE         *inAuditCommands,
+			      size_t        inAuditCommandsLen,
+			      BYTE         *outAuditCommands,
+			      size_t        outAuditCommandsLen)
+{
+    size_t max_bit = MIN(inAuditCommandsLen * 8, ARRAY_SIZE(CCToCompressedListIndex));
+    size_t bit = 0;
+
+    MemorySet(outAuditCommands, 0, outAuditCommandsLen);
+
+    while (bit < max_bit) {
+	BYTE bits = inAuditCommands[bit >> 3];
+	BYTE mask = 1;
+	size_t lbit = bit;
+
+	while (bits != 0 && lbit < max_bit) {
+	    if ((bits & mask) != 0) {
+		TPM_CC cc = CCToCompressedListIndex[lbit].cc;
+		COMMAND_INDEX idx = cc - TPM_CC_NV_UndefineSpaceSpecial;
+
+		assert(idx != UNIMPLEMENTED_COMMAND_INDEX);
+
+		SetBit(idx, outAuditCommands, outAuditCommandsLen);
+		bits ^= mask; /* unset bit */
+	    }
+	    mask <<= 1;
+	    lbit++;
+	}
+	bit += 8;
+    }
+
+    return TPM_RC_SUCCESS;
+}
+
+static size_t FindCCInCompressedListIndexArray(TPM_CC cc)
+{
+    size_t e_index = ARRAY_SIZE(CCToCompressedListIndex) - 1;
+    size_t s_index = 0;
+
+    while (true) {
+        size_t index = (e_index + s_index) >> 1;
+
+        if (cc == CCToCompressedListIndex[index].cc) {
+            return index;
+        }
+        if (e_index == s_index) {
+            break;
+        }
+        if (cc < CCToCompressedListIndex[index].cc) {
+            e_index = index;
+        } else {
+            if (s_index != index)
+                s_index = index;
+            else
+                s_index++;
+        }
+    }
+    /* entry must have been found */
+    pAssert(false);
+}
+
+/* Convert to a bit array from the time when COMPRESSED_LIST was YES
+ * from an array where the indices do NOT correspond to a COMPRESSED_LIST.
+ */
+TPM_RC
+ConvertToCompressedBitArray(BYTE         *inAuditCommands,
+			    size_t        inAuditCommandsLen,
+			    BYTE         *outAuditCommands,
+			    size_t        outAuditCommandsLen)
+{
+    size_t max_idx = inAuditCommandsLen * 8;
+    size_t idx = 0;
+
+    MemorySet(outAuditCommands, 0, outAuditCommandsLen);
+
+    while (idx < max_idx) {
+	BYTE bits = inAuditCommands[idx >> 3];
+	BYTE mask = 1;
+	size_t lidx = idx;
+
+	/* handle bits set in one byte in the loop */
+	while (bits != 0 && lidx < max_idx) {
+	    if ((bits & mask) != 0) {
+		TPM_CC cc = lidx + TPM_CC_NV_UndefineSpaceSpecial;
+		size_t bit = FindCCInCompressedListIndexArray(cc);
+
+		SetBit(bit, outAuditCommands, outAuditCommandsLen);
+		bits ^= mask; /* unset bit */
+	    }
+	    mask <<= 1;
+	    lidx++;
+	}
+	idx += 8;
+    }
+
+    return TPM_RC_SUCCESS;
+}

--- a/src/tpm2/BackwardsCompatibilityBitArray.h
+++ b/src/tpm2/BackwardsCompatibilityBitArray.h
@@ -1,0 +1,57 @@
+/********************************************************************************/
+/*										*/
+/*	Backwards compatibility support related to command code arrays		*/
+/*			     Written by Stefan Berger				*/
+/*		       IBM Thomas J. Watson Research Center			*/
+/*										*/
+/* (c) Copyright IBM Corporation 2023.						*/
+/*										*/
+/* All rights reserved.								*/
+/* 										*/
+/* Redistribution and use in source and binary forms, with or without		*/
+/* modification, are permitted provided that the following conditions are	*/
+/* met:										*/
+/* 										*/
+/* Redistributions of source code must retain the above copyright notice,	*/
+/* this list of conditions and the following disclaimer.			*/
+/* 										*/
+/* Redistributions in binary form must reproduce the above copyright		*/
+/* notice, this list of conditions and the following disclaimer in the		*/
+/* documentation and/or other materials provided with the distribution.		*/
+/* 										*/
+/* Neither the names of the IBM Corporation nor the names of its		*/
+/* contributors may be used to endorse or promote products derived from		*/
+/* this software without specific prior written permission.			*/
+/* 										*/
+/* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS		*/
+/* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT		*/
+/* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR	*/
+/* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT		*/
+/* HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,	*/
+/* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT		*/
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,	*/
+/* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY	*/
+/* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT		*/
+/* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE	*/
+/* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.		*/
+/********************************************************************************/
+
+#ifndef BACKWARDS_COMPATIBILITY_BIT_ARRAY_H
+#define BACKWARDS_COMPATIBILITY_BIT_ARRAY_H
+
+#include "Tpm.h"
+#include "TpmTypes.h"
+
+TPM_RC
+ConvertFromCompressedBitArray(BYTE         *inAuditCommands,
+                              size_t        inAuditCommandsLen,
+                              BYTE         *outAuditCommands,
+                              size_t        outAuditCommandsLen);
+
+TPM_RC
+ConvertToCompressedBitArray(BYTE         *inAuditCommands,
+                            size_t        inAuditCommandsLen,
+                            BYTE         *outAuditCommands,
+                            size_t        outAuditCommandsLen);
+
+#endif

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -4205,7 +4205,16 @@ PERSISTENT_DATA_Marshal(PERSISTENT_DATA *data, BYTE **buffer, INT32 *size,
     UINT8 clocksize;
     BOOL has_block;
     BLOCK_SKIP_INIT;
-    UINT16 blob_version = 4;  // FIXME: RuntimeProfile must cause this to become v5!
+    UINT16 blob_version;
+
+    switch (RuntimeProfile->stateFormatLevel) {
+    case 1 ... 2:
+        blob_version = 4;
+        break;
+    default:
+        blob_version = 5; /* since stateFormatLevel 3 */
+        break;
+    }
 
     written = NV_HEADER_Marshal(buffer, size,
                                 blob_version,

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -3894,12 +3894,12 @@ static const struct _entry {
 
     /* added for PA_COMPILE_CONSTANTS_VERSION == 3 */
     { COMPILE_CONSTANT(AES_128, LE) },
-    { COMPILE_CONSTANT(AES_192, LE) },
+    { COMPILE_CONSTANT(0, LE) }, /* was: AES_192; now handled via profile */
     { COMPILE_CONSTANT(AES_256, LE) },
     { COMPILE_CONSTANT(SM4_128, LE) },
     { COMPILE_CONSTANT(ALG_CAMELLIA, LE) },
     { COMPILE_CONSTANT(CAMELLIA_128, LE) },
-    { COMPILE_CONSTANT(CAMELLIA_192, LE) },
+    { COMPILE_CONSTANT(0, LE) }, /* was: CAMELLIA_192; now handled via profile */
     { COMPILE_CONSTANT(CAMELLIA_256, LE) },
     { COMPILE_CONSTANT(ALG_SHA3_256, LE) },
     { COMPILE_CONSTANT(ALG_SHA3_384, LE) },

--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -59,7 +59,7 @@ struct KeySizes {
 
 static const struct KeySizes s_KeySizesAES[] = {
     { .enabled = AES_128, .size = 128, .stateFormatLevel = 1 },
-    { .enabled = AES_192, .size = 192, .stateFormatLevel = 0 }, // not supported
+    { .enabled = AES_192, .size = 192, .stateFormatLevel = 4 },
     { .enabled = AES_256, .size = 256, .stateFormatLevel = 1 },
     { .enabled = false  , .size = 0  , .stateFormatLevel = 0 },
 };
@@ -69,7 +69,7 @@ static const struct KeySizes s_KeySizesSM4[] = {
 };
 static const struct KeySizes s_KeySizesCamellia[] = {
     { .enabled = CAMELLIA_128, .size = 128, .stateFormatLevel = 1 },
-    { .enabled = CAMELLIA_192, .size = 192, .stateFormatLevel = 0 }, // not supported
+    { .enabled = CAMELLIA_192, .size = 192, .stateFormatLevel = 4 },
     { .enabled = CAMELLIA_256, .size = 256, .stateFormatLevel = 1 },
     { .enabled = false       , .size = 0  , .stateFormatLevel = 0 },
 };

--- a/src/tpm2/RuntimeCommands.c
+++ b/src/tpm2/RuntimeCommands.c
@@ -184,8 +184,8 @@ static const struct {
     COMMAND(Policy_AC_SendSelect, true, 0), // not supported
     COMMAND(CertifyX509, true, 1),
     COMMAND(ACT_SetTimeout, true, 0), // not supported
-    COMMAND(ECC_Encrypt, true, 0), // not supported
-    COMMAND(ECC_Decrypt, true, 0), // not supported
+    COMMAND(ECC_Encrypt, true, 3),
+    COMMAND(ECC_Decrypt, true, 3),
     COMMAND(PolicyCapability, true, 0), // not supported
     /* all new commands added here MUST have CAN_BE_DISABLE = true */
 #undef COMMAND

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -73,7 +73,7 @@ static const struct RuntimeProfileDesc {
      * This basically locks the name of the profile to the stateFormatLevel.
      */
     unsigned int stateFormatLevel;
-#define STATE_FORMAT_LEVEL_CURRENT 3
+#define STATE_FORMAT_LEVEL_CURRENT 4
 #define STATE_FORMAT_LEVEL_UNKNOWN 0 /* JSON didn't provide StateFormatLevel; this is only
 					allowed for the 'default' profile or when user
 					passed JSON via SetProfile() */
@@ -83,6 +83,7 @@ static const struct RuntimeProfileDesc {
  *  3 : Enabled ECC_Encrypt (0x199) & ECC_Decrypt (0x19a) along with disabling COMPRESSED_LIST.
  *      PERSISTENT_DATA.ppList and PERSISTENT_DATA.auditCommands became bigger and need to
  *      be written differently.
+ *  4 : Camellia-192 & AES-192 enabled
  */
     const char *description;
 #define DESCRIPTION_MAX_SIZE        250
@@ -770,8 +771,8 @@ RuntimeProfileGetSeedCompatLevel(void)
     case 1: /* profile runs on v0.9 */
 	return SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX;
 
-    case 2 ... 3: /* profile runs on v0.10 */ {
-	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 3); // force update when this changes
+    case 2 ... 4: /* profile runs on v0.10 */ {
+	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 4); // force update when this changes
 	return SEED_COMPAT_LEVEL_LAST;
     }
 

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -52,7 +52,7 @@ struct RuntimeProfile g_RuntimeProfile;
 
 const char defaultCommandsProfile[] =
     "0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,0x15b-0x15e,"
-    "0x160-0x165,0x167-0x174,0x176-0x178,0x17a-0x193,0x197";
+    "0x160-0x165,0x167-0x174,0x176-0x178,0x17a-0x193,0x197,0x199-0x19a";
 
 const char defaultAlgorithmsProfile[] =
     "rsa,rsa-min-size=1024,tdes,tdes-min-size=128,sha1,hmac,"
@@ -73,13 +73,16 @@ static const struct RuntimeProfileDesc {
      * This basically locks the name of the profile to the stateFormatLevel.
      */
     unsigned int stateFormatLevel;
-#define STATE_FORMAT_LEVEL_CURRENT 2
+#define STATE_FORMAT_LEVEL_CURRENT 3
 #define STATE_FORMAT_LEVEL_UNKNOWN 0 /* JSON didn't provide StateFormatLevel; this is only
 					allowed for the 'default' profile or when user
 					passed JSON via SetProfile() */
 /* State Format Levels:
  *  1 : write the state in format of libtpms v0.9 : only 'null' profile may have this
  *  2 : write the state in format of libtpms v0.10: the profile will be written into the state
+ *  3 : Enabled ECC_Encrypt (0x199) & ECC_Decrypt (0x19a) along with disabling COMPRESSED_LIST.
+ *      PERSISTENT_DATA.ppList and PERSISTENT_DATA.auditCommands became bigger and need to
+ *      be written differently.
  */
     const char *description;
 #define DESCRIPTION_MAX_SIZE        250
@@ -767,8 +770,8 @@ RuntimeProfileGetSeedCompatLevel(void)
     case 1: /* profile runs on v0.9 */
 	return SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX;
 
-    case 2 ... 2: /* profile runs on v0.10 */ {
-	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 2); // force update when this changes
+    case 2 ... 3: /* profile runs on v0.10 */ {
+	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 3); // force update when this changes
 	return SEED_COMPAT_LEVEL_LAST;
     }
 

--- a/src/tpm2/TpmBuildSwitches.h
+++ b/src/tpm2/TpmBuildSwitches.h
@@ -217,7 +217,7 @@
 // unimplemented commands. Comment this out to use linear lists.
 // Note: if vendor specific commands are present, the associated list is always
 // in compressed form.
-#define COMPRESSED_LISTS            YES
+#define COMPRESSED_LISTS            NO /* libtpms: change in v0.10 */
 
 // This define is used to eliminate the use of bit-fields. It can be enabled for big-
 // or little-endian machines. For big-endian architectures that numbers bits in

--- a/src/tpm2/TpmProfile_CommandList.h
+++ b/src/tpm2/TpmProfile_CommandList.h
@@ -118,8 +118,8 @@
 #define CC_DictionaryAttackLockReset  CC_YES
 #define CC_DictionaryAttackParameters CC_YES
 #define CC_Duplicate                  CC_YES
-#define CC_ECC_Decrypt                (CC_NO)		/* libtpms: NO */
-#define CC_ECC_Encrypt                (CC_NO)		/* libtpms: NO */
+#define CC_ECC_Decrypt                (CC_YES)		/* libtpms: YES since v0.10 */
+#define CC_ECC_Encrypt                (CC_YES)		/* libtpms: YES since v0.10 */
 #define CC_ECC_Parameters             (CC_YES && ALG_ECC)
 #define CC_ECDH_KeyGen                (CC_YES && ALG_ECC)
 #define CC_ECDH_ZGen                  (CC_YES && ALG_ECC)

--- a/src/tpm2/TpmProfile_Common.h
+++ b/src/tpm2/TpmProfile_Common.h
@@ -126,7 +126,7 @@
 #define ALG_AES                     ALG_YES
 
 #define     AES_128                     (YES * ALG_AES)
-#define     AES_192                     (NO  * ALG_AES)
+#define     AES_192                     (YES * ALG_AES) /* since libtpms v0.10 stateFormatLevel 4 */
 #define     AES_256                     (YES * ALG_AES)
 
 #define ALG_SM4                     ALG_NO
@@ -136,7 +136,7 @@
 #define ALG_CAMELLIA                ALG_YES
 
 #define     CAMELLIA_128                (YES * ALG_CAMELLIA)
-#define     CAMELLIA_192                (NO  * ALG_CAMELLIA)
+#define     CAMELLIA_192                (YES * ALG_CAMELLIA) /* since libtpms v0.10 stateFormatLevel 4 */
 #define     CAMELLIA_256                (YES * ALG_CAMELLIA)
 
 #define ALG_TDES                        ALG_YES /* libtpms enabled */

--- a/tests/nvram_offsets.c
+++ b/tests/nvram_offsets.c
@@ -11,7 +11,8 @@ int main(void)
     PERSISTENT_DATA pd;
 
     /* Check size of ppList that expands with new commands */
-#define PD_PP_LIST_EXP_SIZE 14
+    /* was 14 when COMPRESSED_LISTS was enabled */
+#define PD_PP_LIST_EXP_SIZE 16
     if (sizeof(pd.ppList) != PD_PP_LIST_EXP_SIZE) {
         fprintf(stderr,
                 "sizeof(PERSISTENT_DATA.ppList) does not have expected size "
@@ -21,7 +22,8 @@ int main(void)
     }
 
     /* Check size of auditCommands that expands with new commands */
-#define PD_AUDIT_COMMANDS_EXP_SIZE 14
+    /* was 14 when COMPRESSED_LISTS was enabled */
+#define PD_AUDIT_COMMANDS_EXP_SIZE 16
     if (sizeof(pd.auditCommands) != PD_AUDIT_COMMANDS_EXP_SIZE) {
         fprintf(stderr,
                 "sizeof(PERSISTENT_DATA.auditCommands) does not have expected size "

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -59,10 +59,10 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"default-v1\","
-            "\"StateFormatLevel\":2,"
+            "\"StateFormatLevel\":3,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
-                           "0x17a-0x193,0x197\","
+                           "0x17a-0x193,0x197,0x199-0x19a\","
             "\"Algorithms\":\"rsa,rsa-min-size=1024,tdes,tdes-min-size=128,"
                              "sha1,hmac,aes,aes-min-size=128,mgf1,keyedhash,"
                              "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
@@ -211,6 +211,43 @@ static const struct {
                // keep last
             }
         }
+    }, {
+        // commands 0x199-0x19a require StateFormatLevel 3
+        .profile = "{"
+                    "\"Name\":\"custom\","
+                    "\"StateFormatLevel\":2,"
+                    "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
+                                   "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
+                                   "0x17a-0x193,0x197,0x199-0x19a\","
+                    "\"Description\":\"test\""
+                   "}",
+        .exp_fail = true,
+    }, {
+        .profile = "{"
+                    "\"Name\":\"custom\","
+                    "\"StateFormatLevel\":3,"
+                    "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
+                                   "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
+                                   "0x17a-0x193,0x197,0x199-0x19a\","
+                    "\"Description\":\"test\""
+                   "}",
+        .exp_fail = false,
+        .exp_profile =
+          "{\"ActiveProfile\":{"
+            "\"Name\":\"custom\","
+            "\"StateFormatLevel\":3,"
+            "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
+                           "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
+                           "0x17a-0x193,0x197,0x199-0x19a\","
+            "\"Algorithms\":\"rsa,rsa-min-size=1024,tdes,tdes-min-size=128,"
+                             "sha1,hmac,aes,aes-min-size=128,mgf1,keyedhash,"
+                             "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
+                             "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
+                             "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
+                             "ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,"
+                             "cmac,ctr,ofb,cbc,cfb,ecb\","
+            "\"Description\":\"test\""
+          "}}",
     }, {
         // keep last
     }

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -59,7 +59,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"default-v1\","
-            "\"StateFormatLevel\":3,"
+            "\"StateFormatLevel\":4,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197,0x199-0x19a\","


### PR DESCRIPTION
Set COMPRESSED_LISTS to NO now and convert older representations to new one and new one to old one when necessary. The conversion is necessary when older state is read but the TPM does not work with COMPRESSED_LISTS anymore. It is also necessary to convert to older state when writing backwards compatible state that libtpms v0.9 is supposed to be able to read.