### PR TITLE
DO-NOT-MERGE: Implement TPM 2's KDFa using OpenSSL KBKDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Makefile
 /tests/base64decode
 /tests/fuzz
 /tests/freebl_sha1flattensize
+/tests/kdfe_openssl
 /tests/nvram_offsets
 /tests/object_size
 /tests/tpm2_createprimary

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Makefile
 /tests/base64decode
 /tests/fuzz
 /tests/freebl_sha1flattensize
+/tests/kdfa_openssl
 /tests/kdfe_openssl
 /tests/nvram_offsets
 /tests/object_size

--- a/configure.ac
+++ b/configure.ac
@@ -164,6 +164,7 @@ use_openssl_functions_symmetric=0
 use_openssl_functions_ec=0
 use_openssl_functions_ecdsa=0
 use_openssl_functions_rsa=0
+use_openssl_functions_sskdf=0
 AC_ARG_ENABLE(use-openssl-functions,
 	AS_HELP_STRING([--disable-use-openssl-functions],
 		       [Use TPM 2 crypot code rather than OpenSSL crypto functions]),
@@ -240,12 +241,20 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 		use_openssl_functions_rsa=1
 		use_openssl_functions_for="${use_openssl_functions_for}RSA "
 	fi
+
+	not_found=0
+	AX_CHECK_DEFINE([<openssl/core_names.h>], [OSSL_KDF_NAME_SSKDF],, not_found=1)
+	if test "x$not_found" = "x0"; then
+		use_openssl_functions_sskdf=1
+		use_openssl_functions_for="${use_openssl_functions_for}SSKDF (KDFe) "
+	fi
 	LIBS=$LIBS_save
 ])
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=$use_openssl_functions_symmetric"
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_EC=$use_openssl_functions_ec"
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_ECDSA=$use_openssl_functions_ecdsa"
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_RSA=$use_openssl_functions_rsa"
+CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_SSKDF=$use_openssl_functions_sskdf"
 
 AC_CHECK_LIB([crypto], [EC_POINT_get_affine_coordinates], found=1, found=0)
 CFLAGS="$CFLAGS -DUSE_EC_POINT_GET_AFFINE_COORDINATES_API=$found"

--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,7 @@ use_openssl_functions_ec=0
 use_openssl_functions_ecdsa=0
 use_openssl_functions_rsa=0
 use_openssl_functions_sskdf=0
+use_openssl_functions_kbkdf=0
 AC_ARG_ENABLE(use-openssl-functions,
 	AS_HELP_STRING([--disable-use-openssl-functions],
 		       [Use TPM 2 crypot code rather than OpenSSL crypto functions]),
@@ -248,6 +249,13 @@ AS_IF([test "x$enable_use_openssl_functions" != "xno"], [
 		use_openssl_functions_sskdf=1
 		use_openssl_functions_for="${use_openssl_functions_for}SSKDF (KDFe) "
 	fi
+
+	not_found=0
+	AX_CHECK_DEFINE([<openssl/core_names.h>], [OSSL_KDF_NAME_KBKDF],, not_found=1)
+	if test "x$not_found" = "x0"; then
+		use_openssl_functions_kbkdf=1
+		use_openssl_functions_for="${use_openssl_functions_for}KBKDF "
+	fi
 	LIBS=$LIBS_save
 ])
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=$use_openssl_functions_symmetric"
@@ -255,6 +263,7 @@ CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_EC=$use_openssl_functions_ec"
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_ECDSA=$use_openssl_functions_ecdsa"
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_RSA=$use_openssl_functions_rsa"
 CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_SSKDF=$use_openssl_functions_sskdf"
+CFLAGS="$CFLAGS -DUSE_OPENSSL_FUNCTIONS_KBKDF=$use_openssl_functions_kbkdf"
 
 AC_CHECK_LIB([crypto], [EC_POINT_get_affine_coordinates], found=1, found=0)
 CFLAGS="$CFLAGS -DUSE_EC_POINT_GET_AFFINE_COORDINATES_API=$found"

--- a/src/tpm2/crypto/CryptHash_fp.h
+++ b/src/tpm2/crypto/CryptHash_fp.h
@@ -392,4 +392,15 @@ LIB_EXPORT UINT16 CryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in
 			    BYTE*  keyStream    // OUT: key buffer
 			    );
 
+#if USE_OPENSSL_FUNCTIONS_SSKDF			// libtpms added begin: for test case
+LIB_EXPORT UINT16 ReferenceCryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in HMAC
+				     TPM2B*       Z,        // IN: Z
+				     const TPM2B* label,    // IN: a label value for the KDF
+				     TPM2B*       partyUInfo,  // IN: PartyUInfo
+				     TPM2B*       partyVInfo,  // IN: PartyVInfo
+				     UINT32 sizeInBits,  // IN: size of generated key in bits
+				     BYTE*  keyStream    // OUT: key buffer
+				     );
+#endif // USE_OPENSSL_FUNCTIONS_SSKDF		// libtpms added end
+
 #endif  // _CRYPT_HASH_FP_H_

--- a/src/tpm2/crypto/openssl/CryptHash.c
+++ b/src/tpm2/crypto/openssl/CryptHash.c
@@ -815,8 +815,12 @@ LIB_EXPORT UINT16 CryptKDFa(
 //     0            hash algorithm is not supported or is TPM_ALG_NULL
 //    > 0           the number of bytes in the 'keyStream' buffer
 //
-#if ! USE_OPENSSL_FUNCTIONS_SSKDF
-LIB_EXPORT UINT16 CryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in HMAC
+#if USE_OPENSSL_FUNCTIONS_SSKDF			// libtpms added: begin
+LIB_EXPORT UINT16 ReferenceCryptKDFe		// Renamed for test case
+#else
+LIB_EXPORT UINT16 CryptKDFe
+#endif						// libtpms added
+                           (TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in HMAC
 			    TPM2B*       Z,        // IN: Z
 			    const TPM2B* label,    // IN: a label value for the KDF
 			    TPM2B*       partyUInfo,  // IN: PartyUInfo
@@ -895,7 +899,8 @@ LIB_EXPORT UINT16 CryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in
 
     return (UINT16)((sizeInBits + 7) / 8);
 }
-#else
+
+#if USE_OPENSSL_FUNCTIONS_SSKDF
 LIB_EXPORT UINT16 CryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in HMAC
 			    TPM2B*       Z,        // IN: Z
 			    const TPM2B* label,    // IN: a label value for the KDF

--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -131,4 +131,23 @@ OSSLCryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in HMAC
 	     );
 #endif // USE_OPENSSL_FUNCTIONS_SSKDF
 
+#if USE_OPENSSL_FUNCTIONS_KBKDF
+LIB_EXPORT UINT16
+OSSLCryptKDFa(
+	      TPM_ALG_ID   hashAlg,       // IN: hash algorithm used in HMAC
+	      const TPM2B* key,           // IN: HMAC key
+	      const TPM2B* label,         // IN: a label for the KDF
+	      const TPM2B* contextU,      // IN: context U
+	      const TPM2B* contextV,      // IN: context V
+	      UINT32       sizeInBits,    // IN: size of generated key in bits
+	      BYTE*        keyStream,     // OUT: key buffer
+	      UINT32*      counterInOut,  // IN/OUT: caller may provide the iteration
+					  //     counter for incremental operations to
+					  //     avoid large intermediate buffers.
+	      UINT16 blocks               // IN: If non-zero, this is the maximum number
+					  //     of blocks to be returned, regardless
+					  //     of sizeInBits
+	     );
+#endif // USE_OPENSSL_FUNCTIONS_KBKDF
+
 #endif  /* HELPERS_FP_H */

--- a/src/tpm2/crypto/openssl/Helpers_fp.h
+++ b/src/tpm2/crypto/openssl/Helpers_fp.h
@@ -119,4 +119,16 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
 
 #endif // USE_OPENSSL_FUNCTIONS_RSA
 
+#if USE_OPENSSL_FUNCTIONS_SSKDF
+LIB_EXPORT UINT16
+OSSLCryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in HMAC
+	      TPM2B*       Z,        // IN: Z
+	      const TPM2B* label,    // IN: a label value for the KDF
+	      TPM2B*       partyUInfo,  // IN: PartyUInfo
+	      TPM2B*       partyVInfo,  // IN: PartyVInfo
+	      UINT32       sizeInBits,  // IN: size of generated key in bits
+	      BYTE*        keyStream    // OUT: key buffer
+	     );
+#endif // USE_OPENSSL_FUNCTIONS_SSKDF
+
 #endif  /* HELPERS_FP_H */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -56,9 +56,11 @@ if ENABLE_STATIC_TESTS
 
 # object_size needs ANY_OBJECT_Marshal which only is accessible with '-static'
 check_PROGRAMS += \
-	object_size
+	object_size \
+	kdfe_openssl
 TESTS += \
-	object_size
+	object_size \
+	kdfe_openssl
 
 object_size_SOURCES = object_size.c
 object_size_CFLAGS = $(AM_CFLAGS) \
@@ -70,6 +72,19 @@ object_size_CFLAGS = $(AM_CFLAGS) \
 	-I$(top_srcdir)/src/tpm2/crypto/openssl \
 	-DTPM_POSIX
 object_size_LDFLAGS = $(AM_LDFLAGS)
+
+kdfe_openssl_SOURCES = kdfe_openssl.c
+kdfe_openssl_CFLAGS = $(AM_CFLAGS) \
+	-static \
+	-g -ggdb \
+	-I$(top_srcdir)/include/libtpms \
+	-I$(top_srcdir)/src \
+	-I$(top_srcdir)/src/tpm2 \
+	-I$(top_srcdir)/src/tpm2/crypto \
+	-I$(top_srcdir)/src/tpm2/crypto/openssl \
+	-DTPM_POSIX
+kdfe_openssl_LDFLAGS = $(AM_LDFLAGS)
+
 endif # ENABLE_STATIC_TESTS
 endif # WITH_TPM2
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -57,10 +57,12 @@ if ENABLE_STATIC_TESTS
 # object_size needs ANY_OBJECT_Marshal which only is accessible with '-static'
 check_PROGRAMS += \
 	object_size \
-	kdfe_openssl
+	kdfe_openssl \
+	kdfa_openssl
 TESTS += \
 	object_size \
-	kdfe_openssl
+	kdfe_openssl \
+	kdfa_openssl
 
 object_size_SOURCES = object_size.c
 object_size_CFLAGS = $(AM_CFLAGS) \
@@ -84,6 +86,18 @@ kdfe_openssl_CFLAGS = $(AM_CFLAGS) \
 	-I$(top_srcdir)/src/tpm2/crypto/openssl \
 	-DTPM_POSIX
 kdfe_openssl_LDFLAGS = $(AM_LDFLAGS)
+
+kdfa_openssl_SOURCES = kdfa_openssl.c
+kdfa_openssl_CFLAGS = $(AM_CFLAGS) \
+	-static \
+	-g -ggdb \
+	-I$(top_srcdir)/include/libtpms \
+	-I$(top_srcdir)/src \
+	-I$(top_srcdir)/src/tpm2 \
+	-I$(top_srcdir)/src/tpm2/crypto \
+	-I$(top_srcdir)/src/tpm2/crypto/openssl \
+	-DTPM_POSIX
+kdfa_openssl_LDFLAGS = $(AM_LDFLAGS)
 
 endif # ENABLE_STATIC_TESTS
 endif # WITH_TPM2

--- a/tests/kdfa_openssl.c
+++ b/tests/kdfa_openssl.c
@@ -1,0 +1,76 @@
+#if USE_OPENSSL_FUNCTIONS_SSKDF
+
+#include "Tpm.h"
+#include "Helpers_fp.h"
+
+int main(void)
+{
+    UINT16 gen1, gen2;
+    TPM2B_LABEL key = {
+	.t.size = 0x20,
+	.t.buffer = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+	             0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+	             0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f},
+    };
+    TPM2B_LABEL label = {
+	.t.size = 5,
+	.t.buffer = "label",
+    };
+    TPM2B_LABEL contextU = {
+	.t.size = 6,
+	.t.buffer = "test12",
+    };
+    TPM2B_LABEL contextV = {
+	.t.size = 7,
+	.t.buffer = "test123",
+    };
+    BYTE keyStream1[256] = {0, }, keyStream2[256] = {0, };
+    UINT32 counter1, counter2;
+    const TPM_ALG_ID hashAlgs[] = {
+        TPM_ALG_SHA1,
+        TPM_ALG_SHA256,
+        TPM_ALG_SHA384,
+        TPM_ALG_SHA512
+    };
+    UINT32 sizeInBits;
+    UINT16 blocks;
+    size_t i;
+
+    for (sizeInBits = 0; sizeInBits < 8 * sizeof(keyStream1); sizeInBits += 8) {
+	for (i = 0; i < ARRAY_SIZE(hashAlgs); i++) {
+	    counter1 = 0;
+	    memset(keyStream1, 0, sizeof(keyStream1));
+	    gen1 = CryptKDFa(hashAlgs[i], &key.b, &label.b,
+			     &contextU.b, &contextV.b, sizeInBits, keyStream1,
+			     &counter1, blocks);
+
+	    counter2 = 0;
+	    memset(keyStream2, 0, sizeof(keyStream2));
+	    gen2 = OSSLCryptKDFa(hashAlgs[i], &key.b, &label.b,
+				 &contextU.b, &contextV.b, sizeInBits, keyStream2,
+				 &counter2, blocks);
+
+	    if (gen1 != gen2 || memcmp(keyStream1, keyStream2, gen1)) {
+		fprintf(stderr, "results are not equal: gen1: %d  gen2: %d  hash: %d sizeInBits: %d\n",
+			gen1, gen2, hashAlgs[i], sizeInBits);
+		fprintf(stderr, "%02x %02x %02x ... %02x\n",
+			keyStream1[0], keyStream1[1], keyStream1[2], keyStream1[gen1 - 1]);
+		fprintf(stderr, "%02x %02x %02x ... %02x\n",
+			keyStream2[0], keyStream2[1], keyStream2[2], keyStream2[gen2 - 1]);
+		return 1;
+	    }
+	    fprintf(stdout, "Success with hash %d, sizeInBits %d\n",
+		    hashAlgs[i], sizeInBits);
+	}
+    }
+}
+
+#else
+
+int main(void)
+{
+    return 0;
+}
+
+#endif

--- a/tests/kdfe_openssl.c
+++ b/tests/kdfe_openssl.c
@@ -1,0 +1,61 @@
+#if USE_OPENSSL_FUNCTIONS_SSKDF
+
+#include "Tpm.h"
+#include "Helpers_fp.h"
+
+int main(void)
+{
+    UINT16 gen1, gen2;
+    TPM2B_LABEL Z = {
+	.t.size = 6,
+	.t.buffer = {1, 2, 3, 4, 5, 6},
+    };
+    TPM2B_LABEL label = {
+	.t.size = 5,
+	.t.buffer = "label",
+    };
+    TPM2B_LABEL partyUInfo = {
+	.t.size = 6,
+	.t.buffer = "test12",
+    };
+    TPM2B_LABEL partyVInfo = {
+	.t.size = 7,
+	.t.buffer = "test123",
+    };
+    TPM2B_LABEL info = {
+	.t.size = 8,
+	.t.buffer = "label123",
+    };
+    BYTE keyStream1[128] = {0, }, keyStream2[128] = {0, };
+    UINT32 sizeInBits = 8 * sizeof(keyStream2);
+    TPM_ALG_ID hashAlgs[] = { TPM_ALG_SHA1, TPM_ALG_SHA256, TPM_ALG_SHA384, TPM_ALG_SHA512 };
+    size_t i, o;
+
+    for (o = 0; o < 8; o++) {
+	for (i = 0; i < ARRAY_SIZE(hashAlgs); i++) {
+	    gen1 = CryptKDFe(hashAlgs[i], &Z.b, &label.b,
+			     &partyUInfo.b, &partyVInfo.b, sizeInBits - o, keyStream1);
+
+	    gen2 = OSSLCryptKDFe(hashAlgs[i], &Z.b, &label.b,
+				 &partyUInfo.b, &partyVInfo.b, sizeInBits - o, keyStream2);
+
+	    if (gen1 != gen2 || memcmp(keyStream1, keyStream2, gen1)) {
+		fprintf(stderr, "results are not equal: gen1: %d  gen2: %d  o: %d\n", gen1, gen2, o);
+		fprintf(stderr, "%02x %02x %02x .. %02x\n",
+		        keyStream1[0], keyStream1[1], keyStream1[2], keyStream1[gen1 - 1]);
+		fprintf(stderr, "%02x %02x %02x .. %02x\n",
+		        keyStream2[0], keyStream2[1], keyStream2[2], keyStream2[gen2 - 1]);
+		return 1;
+	    }
+	}
+    }
+}
+
+#else
+
+int main(void)
+{
+    return 0;
+}
+
+#endif

--- a/tests/kdfe_openssl.c
+++ b/tests/kdfe_openssl.c
@@ -33,8 +33,8 @@ int main(void)
 
     for (o = 0; o < 8; o++) {
 	for (i = 0; i < ARRAY_SIZE(hashAlgs); i++) {
-	    gen1 = CryptKDFe(hashAlgs[i], &Z.b, &label.b,
-			     &partyUInfo.b, &partyVInfo.b, sizeInBits - o, keyStream1);
+	    gen1 = ReferenceCryptKDFe(hashAlgs[i], &Z.b, &label.b,
+				      &partyUInfo.b, &partyVInfo.b, sizeInBits - o, keyStream1);
 
 	    gen2 = OSSLCryptKDFe(hashAlgs[i], &Z.b, &label.b,
 				 &partyUInfo.b, &partyVInfo.b, sizeInBits - o, keyStream2);


### PR DESCRIPTION
This PR currently builds on top of the KDFe patches/PR.

Implement TPM 2's KDFa using OpenSSL KBKDF. However, due to the flexibility of the reference implementation (allow to 'resume' the KDFe at a later point) and restrictions by OpenSSL's KBKDF it will not be possible to use the OpenSSL-based implementation -> DO NOT MERGE! See commit messages on ''tests: Add test case for KDFa replacement by OpenSSL 'KBKDF'".