### PR TITLE
tpm2: Extend buffer for printing a UINT16 into to 16 bytes (older gcc)

### DIFF
--- a/src/tpm2/EACommands.c
+++ b/src/tpm2/EACommands.c
@@ -1702,7 +1702,7 @@ TPM2_PolicyCapability(PolicyCapability_In* in  // IN: input parameter list
 					   (&propertyUnion.alg, &buffer, &bufferSize);
 			}
 		    break;
-		  case TPM_CAP_HANDLES:
+		  case TPM_CAP_HANDLES: {			// libtpms changed: older gcc
 		    BOOL foundHandle = FALSE;
 		    switch(HandleGetType((TPM_HANDLE)in->property))
 			{
@@ -1733,13 +1733,14 @@ TPM2_PolicyCapability(PolicyCapability_In* in  // IN: input parameter list
 			    // Unsupported input handle type
 			    return TPM_RCS_HANDLE + RC_PolicyCapability_property;
 			    break;
-			}
+			}					// libtpms added
 		    if(foundHandle)
 			{
 			    TPM_HANDLE handle = (TPM_HANDLE)in->property;
 			    propertySize = TPM_HANDLE_Marshal(&handle, &buffer, &bufferSize);
 			}
 		    break;
+		  }
 		  case TPM_CAP_COMMANDS:
 		    if(CommandCapGetOneCC((TPM_CC)in->property,
 					  &propertyUnion.commandAttributes))
@@ -1780,7 +1781,7 @@ TPM2_PolicyCapability(PolicyCapability_In* in  // IN: input parameter list
 			}
 		    break;
 #  if ALG_ECC
-		  case TPM_CAP_ECC_CURVES:
+		  case TPM_CAP_ECC_CURVES: {			// libtpms changed: older gcc
 		    TPM_ECC_CURVE curve = (TPM_ECC_CURVE)in->property;
 		    if(CryptCapGetOneECCCurve(curve))
 			{
@@ -1788,6 +1789,7 @@ TPM2_PolicyCapability(PolicyCapability_In* in  // IN: input parameter list
 				TPM_ECC_CURVE_Marshal(&curve, &buffer, &bufferSize);
 			}
 		    break;
+		  }						// libtpms added: older gcc
 #  endif  // ALG_ECC
 		  case TPM_CAP_AUTH_POLICIES:
 		    if(HandleGetType((TPM_HANDLE)in->property) != TPM_HT_PERMANENT)

--- a/src/tpm2/RuntimeCommands.c
+++ b/src/tpm2/RuntimeCommands.c
@@ -435,8 +435,7 @@ RuntimeCommandPrint(char           *buffer,
 		    COMMAND_INDEX   commandCodeLo,
 		    COMMAND_INDEX   commandCodeHi)
 {
-    MUST_BE(sizeof(COMMAND_INDEX) == 2);
-    char bufferlo[10], bufferhi[10];
+    char bufferlo[12], bufferhi[12];
     char *nbuffer = NULL;
     int n;
 


### PR DESCRIPTION
Even though UINT16 when printed as hex number will only use up to 4 bytes and 3 more bytes for the prefix '0x' and terminating NUL (0xffff), extend the buffer to 16 bytes to address the following gcc issue:

tpm2/RuntimeCommands.c:450:44: error: ‘__builtin___snprintf_chk’ output
   may be truncated before the last format character
   [-Werror=format-truncation=]

  snprintf(bufferhi, sizeof(bufferhi), "0x%x", commandCodeHi);

/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: note:
   ‘__builtin___snprintf_chk’ output between 4 and 11 bytes into a
   destination of size 10