### PR TITLE
RuntimeProfiles: Replace TPM_RC_FAILURE with TPM_RC_VALUE

### DIFF
--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -394,7 +394,7 @@ RuntimeAlgorithmSetProfile(struct RuntimeAlgorithm  *RuntimeAlgorithm,
 						s_EccAlgorithmProperties[curveId].name,
 						s_EccAlgorithmProperties[curveId].stateFormatLevel,
 						maxStateFormatLevel);
-			    retVal = TPM_RC_FAILURE;
+			    retVal = TPM_RC_VALUE;
 			    goto exit;
 			}
 			continue;
@@ -414,7 +414,7 @@ RuntimeAlgorithmSetProfile(struct RuntimeAlgorithm  *RuntimeAlgorithm,
 	if (!found) {
 	    TPMLIB_LogTPM2Error("Requested algorithm specifier %.*s is not supported.\n",
 				(int)toklen, token);
-	    retVal = TPM_RC_FAILURE;
+	    retVal = TPM_RC_VALUE;
 	    goto exit;
 	}
 
@@ -432,7 +432,7 @@ RuntimeAlgorithmSetProfile(struct RuntimeAlgorithm  *RuntimeAlgorithm,
 	    !TEST_BIT(algId, RuntimeAlgorithm->enabledAlgorithms)) {
 	    TPMLIB_LogTPM2Error("Algorithm %s must be enabled.\n",
 				s_AlgorithmProperties[algId].name);
-	    retVal = TPM_RC_FAILURE;
+	    retVal = TPM_RC_VALUE;
 	    goto exit;
 	}
     }
@@ -443,7 +443,7 @@ RuntimeAlgorithmSetProfile(struct RuntimeAlgorithm  *RuntimeAlgorithm,
 	    !TEST_BIT(curveId, RuntimeAlgorithm->enabledEccCurves)) {
 	    TPMLIB_LogTPM2Error("Elliptic curve %s must be enabled.\n",
 				s_EccAlgorithmProperties[curveId].name);
-	    retVal = TPM_RC_FAILURE;
+	    retVal = TPM_RC_VALUE;
 	    goto exit;
 	}
     }

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -293,7 +293,7 @@ GetStateFormatLevelFromJSON(const char   *json,
     if (v > UINT_MAX || errno) {
 	TPMLIB_LogTPM2Error("StateFormatLevel value '%s' is not a valid positive number.\n",
 			    str);
-	retVal = TPM_RC_FAILURE;
+	retVal = TPM_RC_VALUE;
     } else {
 	*stateFormatLevel = v;
     }
@@ -368,18 +368,18 @@ GetParametersFromJSON(const char    *jsonProfile,
 	/* StateFormatLevel may be missing */
 	retVal = GetStateFormatLevelFromJSON(jsonProfile, stateFormatLevel);
 	switch (retVal) {
-	case TPM_RC_FAILURE:
-	    goto err_free_profilename;
 	case TPM_RC_NO_RESULT:
 	    *stateFormatLevel = STATE_FORMAT_LEVEL_UNKNOWN;
 	    break;
+        case TPM_RC_SUCCESS:
+            break;
+	default:
+	    goto err_free_profilename;
 	}
     } else {
 	retVal = GetStateFormatLevelFromJSON(jsonProfile, stateFormatLevel);
-	if (retVal != TPM_RC_SUCCESS) {
-	    retVal = TPM_RC_FAILURE;
+	if (retVal != TPM_RC_SUCCESS)
 	    goto err_free_profilename;
-	}
     }
     if (*stateFormatLevel > STATE_FORMAT_LEVEL_CURRENT) {
 	TPMLIB_LogTPM2Error("The stateFormatLevel '%u' from the JSON exceeds the maximum supported '%u'\n",

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -568,7 +568,7 @@ RuntimeProfileSet(struct RuntimeProfile *RuntimeProfile,
 				  algorithmsProfile,
 				  profileDescription);
     if (!rp) {
-	retVal = TPM_RC_FAILURE;
+	retVal = TPM_RC_VALUE;
 	goto error;
     }
 
@@ -698,7 +698,7 @@ RuntimeProfileTest(struct RuntimeProfile *RuntimeProfile,
 				  algorithmsProfile,
 				  profileDescription);
     if (!rp) {
-	retVal = TPM_RC_FAILURE;
+	retVal = TPM_RC_VALUE;
 	goto error;
     }
 


### PR DESCRIPTION
Leave TPM_RC_FAILURE to severe cases that should never occur (regex cannot be compiled) and in other cases use TPM_RC_VALUE.
