### PR TITLE
Add missing filters to PolicyCapability related functions

### DIFF
--- a/src/tpm2/AlgorithmCap.c
+++ b/src/tpm2/AlgorithmCap.c
@@ -236,6 +236,9 @@ BOOL AlgorithmCapGetOneImplemented(
     UINT32 i;
     UINT32 algNum;
 
+    if(!RuntimeAlgorithmCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm, algID))// libtpms added
+	return FALSE;								// libtpms added
+
     // Compute how many algorithms are defined in s_algorithms array.
     algNum = sizeof(s_algorithms) / sizeof(s_algorithms[0]);
 

--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -536,7 +536,9 @@ RuntimeAlgorithmKeySizeCheckEnabled(struct RuntimeAlgorithm *RuntimeAlgorithm,
 	return FALSE;
 
     if (algId == TPM_ALG_ECC) {
-	if (!TEST_BIT(curveId, RuntimeAlgorithm->enabledEccCurves)) {
+	if ((curveId >> 3) >= sizeof(RuntimeAlgorithm->enabledEccCurves) ||
+	    !TestBit(curveId, RuntimeAlgorithm->enabledEccCurves,
+	             sizeof(RuntimeAlgorithm->enabledEccCurves))) {
 	    return FALSE;
 	}
     }

--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -499,7 +499,9 @@ RuntimeAlgorithmCheckEnabled(struct RuntimeAlgorithm *RuntimeAlgorithm,
 			     TPM_ALG_ID	              algId      // IN: the algorithm to check
 			     )
 {
-    if (!TEST_BIT(algId, RuntimeAlgorithm->enabledAlgorithms))
+    if ((algId >> 3) >= sizeof(RuntimeAlgorithm->enabledAlgorithms) ||
+        !TestBit(algId, RuntimeAlgorithm->enabledAlgorithms,
+                 sizeof(RuntimeAlgorithm->enabledAlgorithms)))
 	return FALSE;
     return TRUE;
 }

--- a/src/tpm2/crypto/openssl/CryptEccMain.c
+++ b/src/tpm2/crypto/openssl/CryptEccMain.c
@@ -216,6 +216,14 @@ BOOL CryptCapGetOneECCCurve(TPM_ECC_CURVE curveID  // IN: the  ECC curve
 {
     UINT16 i;
 
+    if (!CryptEccIsCurveRuntimeUsable(curveID) ||	// libtpms added begin
+	!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
+					     TPM_ALG_ECC,
+					     CryptEccGetKeySizeForCurve(curveID),
+					     curveID,
+					     g_RuntimeProfile.stateFormatLevel))
+	return FALSE;					// libtpms added end
+
     // Scan the eccCurveValues array
     for(i = 0; i < ECC_CURVE_COUNT; i++)
 	{


### PR DESCRIPTION
Some PolicyCapability related function were missing filters for runtime-enabled curves and algorithms. Add them.