### PR TITLE
tests: Add test case when user chooses specific StateFormatLevel

### DIFF
--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -286,6 +286,34 @@ static const struct {
             "\"Description\":\"test\""
           "}}",
     }, {
+        // choosen StateFormatLevel 4 not require by commands but enables bugfix
+        // -> stays at StateFormatLevel 4
+        .profile = "{"
+                    "\"Name\":\"custom\","
+                    "\"StateFormatLevel\":4,"
+                    "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
+                                   "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
+                                   "0x17a-0x193,0x197\","
+                    "\"Description\":\"test\""
+                   "}",
+        .exp_fail = false,
+        .exp_profile =
+          "{\"ActiveProfile\":{"
+            "\"Name\":\"custom\","
+            "\"StateFormatLevel\":4,"
+            "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
+                           "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
+                           "0x17a-0x193,0x197\","
+            "\"Algorithms\":\"rsa,rsa-min-size=1024,tdes,tdes-min-size=128,"
+                             "sha1,hmac,aes,aes-min-size=128,mgf1,keyedhash,"
+                             "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
+                             "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
+                             "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
+                             "ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,"
+                             "cmac,ctr,ofb,cbc,cfb,ecb\","
+            "\"Description\":\"test\""
+          "}}",
+    }, {
         // keep last
     }
 };


### PR DESCRIPTION
Test that a user is able to choose a specific StateFormatLevel that is not required by any of the chosen commands but enables a bugfix in the TPM 2 code for example.