### PR TITLE
tpm2: NVMarshal: Add missing case of skipping a block when none is there

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -176,6 +176,9 @@ block_skip_read(BOOL needs_block, BYTE **buffer, INT32 *size,
             *buffer += blocksize;
             *size -= blocksize;
             *skip_code = TRUE;
+        } else if (!has_block && !needs_block) {
+            /* no block but also none needed */
+            *skip_code = TRUE;
         }
     }
     return rc;


### PR DESCRIPTION
Add handling of the case of wanting to skip a block of code when no data are in the byte stream. This case has not occurred so far where a block of unmarshalling code needed to be skipped but also no data were there in the byte stream - it would have otherwise lead to errors while trying to unmarshal data that were not there. So far there was simply no code there that should have been skipped.