### PR TITLE
Fix some issue with profiles

### DIFF
--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -440,6 +440,11 @@ RuntimeAlgorithmSetProfile(struct RuntimeAlgorithm  *RuntimeAlgorithm,
 	    retVal = TPM_RC_VALUE;
 	    goto exit;
 	}
+	/* disable curves that can be disabled and not meet min. keysize */
+        if (RuntimeAlgorithm->algosMinimumKeySizes[TPM_ALG_ECC] >
+               s_EccAlgorithmProperties[curveId].keySize &&
+            s_EccAlgorithmProperties[curveId].canBeDisabled)
+            CLEAR_BIT(curveId, RuntimeAlgorithm->enabledEccCurves);
     }
 
     /* some consistency checks */

--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -560,7 +560,8 @@ RuntimeAlgorithmKeySizeCheckEnabled(struct RuntimeAlgorithm *RuntimeAlgorithm,
 static char *
 RuntimeAlgorithmGetEcc(struct RuntimeAlgorithm   *RuntimeAlgorithm,
 		       enum RuntimeAlgorithmType rat,
-		       char                      *buffer)
+		       char                      *buffer,
+		       BOOL                      *first)
 {
     TPM_ECC_CURVE curveId;
     char *nbuffer = NULL;
@@ -588,11 +589,14 @@ RuntimeAlgorithmGetEcc(struct RuntimeAlgorithm   *RuntimeAlgorithm,
 	    break;
 	}
 	n = asprintf(&nbuffer, "%s%s%s",
-		     buffer, ALGO_SEPARATOR_STR, s_EccShortcuts[idx].name);
+		     buffer,
+		     *first ? "" : ALGO_SEPARATOR_STR,
+		     s_EccShortcuts[idx].name);
 	free(buffer);
 	if (n < 0)
 	    return NULL;
 	buffer = nbuffer;
+	*first = false;
     }
 
     for (curveId = 0; curveId < ARRAY_SIZE(s_EccAlgorithmProperties); curveId++) {
@@ -619,11 +623,14 @@ RuntimeAlgorithmGetEcc(struct RuntimeAlgorithm   *RuntimeAlgorithm,
 	    break;
 	}
 	n = asprintf(&nbuffer, "%s%s%s",
-		     buffer, ALGO_SEPARATOR_STR, s_EccAlgorithmProperties[curveId].name);
+		     buffer,
+		     *first ? "" : ALGO_SEPARATOR_STR,
+		     s_EccAlgorithmProperties[curveId].name);
 	free(buffer);
 	if (n < 0)
 	    return NULL;
 	buffer = nbuffer;
+	*first = FALSE;
     }
     return buffer;
 }
@@ -709,7 +716,7 @@ RuntimeAlgorithmPrint(struct RuntimeAlgorithm   *RuntimeAlgorithm,
 
 skip:
 	if (algId == TPM_ALG_ECC)
-	    buffer = RuntimeAlgorithmGetEcc(RuntimeAlgorithm, rat, buffer);
+	    buffer = RuntimeAlgorithmGetEcc(RuntimeAlgorithm, rat, buffer, &first);
     }
 
     n = asprintf(&nbuffer, "%s\"", buffer);

--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -225,7 +225,6 @@ RuntimeAlgorithmEnableAllAlgorithms(struct RuntimeAlgorithm *RuntimeAlgorithm)
     }
 
     MemorySet(RuntimeAlgorithm->enabledEccCurves, 0 , sizeof(RuntimeAlgorithm->enabledEccCurves));
-    MemorySet(RuntimeAlgorithm->enabledEccCurvesPrint, 0 , sizeof(RuntimeAlgorithm->enabledEccCurvesPrint));
 
     for (curveId = 0; curveId < ARRAY_SIZE(s_EccAlgorithmProperties); curveId++) {
         if (!s_EccAlgorithmProperties[curveId].name)
@@ -298,7 +297,6 @@ RuntimeAlgorithmSetProfile(struct RuntimeAlgorithm  *RuntimeAlgorithm,
 
     MemorySet(RuntimeAlgorithm->enabledAlgorithms, 0, sizeof(RuntimeAlgorithm->enabledAlgorithms));
     MemorySet(RuntimeAlgorithm->enabledEccCurves, 0 , sizeof(RuntimeAlgorithm->enabledEccCurves));
-    MemorySet(RuntimeAlgorithm->enabledEccCurvesPrint, 0 , sizeof(RuntimeAlgorithm->enabledEccCurvesPrint));
     MemorySet(RuntimeAlgorithm->enabledEccShortcuts, 0, sizeof(RuntimeAlgorithm->enabledEccShortcuts));
 
     token = newProfile;
@@ -403,10 +401,6 @@ RuntimeAlgorithmSetProfile(struct RuntimeAlgorithm  *RuntimeAlgorithm,
 					    s_EccAlgorithmProperties[curveId].stateFormatLevel);
 		    SET_BIT(curveId, RuntimeAlgorithm->enabledEccCurves);
 		    found = true;
-		    if (match_one) {
-			SET_BIT(curveId, RuntimeAlgorithm->enabledEccCurvesPrint);
-			break;
-		    }
 		}
 	    }
 	}
@@ -612,11 +606,11 @@ RuntimeAlgorithmGetEcc(struct RuntimeAlgorithm   *RuntimeAlgorithm,
 	       continue;
 	    break;
 	case RUNTIME_ALGO_ENABLED:
-	    if (!TEST_BIT(curveId, RuntimeAlgorithm->enabledEccCurvesPrint))
+	    if (!TEST_BIT(curveId, RuntimeAlgorithm->enabledEccCurves))
 		continue;
 	    break;
 	case RUNTIME_ALGO_DISABLED:
-	    if (TEST_BIT(curveId, RuntimeAlgorithm->enabledEccCurvesPrint))
+	    if (TEST_BIT(curveId, RuntimeAlgorithm->enabledEccCurves))
 		continue;
 	    break;
 	default:
@@ -632,6 +626,7 @@ RuntimeAlgorithmGetEcc(struct RuntimeAlgorithm   *RuntimeAlgorithm,
 	buffer = nbuffer;
 	*first = FALSE;
     }
+
     return buffer;
 }
 
@@ -675,7 +670,7 @@ RuntimeAlgorithmPrint(struct RuntimeAlgorithm   *RuntimeAlgorithm,
 	    continue;
 	}
 	n = asprintf(&nbuffer, "%s%s%s",
-		     buffer ? buffer : "",
+		     buffer,
 		     first ? "" : ALGO_SEPARATOR_STR,
 		     s_AlgorithmProperties[algId].name);
 	free(buffer);

--- a/src/tpm2/RuntimeAlgorithm_fp.h
+++ b/src/tpm2/RuntimeAlgorithm_fp.h
@@ -53,7 +53,6 @@ struct RuntimeAlgorithm {
 #define RUNTIME_ALGORITHM_ECC_NIST_BIT      0
 #define RUNTIME_ALGORITHM_ECC_BN_BIT        1
     unsigned char enabledEccCurves[(NUM_ENTRIES_ECC_ALGO_PROPERTIES + 7) / 8];
-    unsigned char enabledEccCurvesPrint[(NUM_ENTRIES_ECC_ALGO_PROPERTIES + 7) / 8];
     char *algorithmProfile;
 };
 

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -59,8 +59,8 @@ const char defaultAlgorithmsProfile[] =
     "aes,aes-min-size=128,mgf1,keyedhash,xor,sha256,sha384,sha512,"
     "null,rsassa,rsaes,rsapss,oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
     "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,ecc-nist,"
-    "ecc-bn,symcipher,camellia,camellia-min-size=128,cmac,ctr,ofb,"
-    "cbc,cfb,ecb";
+    "ecc-bn,ecc-sm2-p256,symcipher,camellia,camellia-min-size=128,cmac,"
+    "ctr,ofb,cbc,cfb,ecb";
 
 static const struct RuntimeProfileDesc {
     const char *name;
@@ -119,8 +119,8 @@ static const struct RuntimeProfileDesc {
 			     "aes,aes-min-size=128,mgf1,keyedhash,xor,sha256,sha384,sha512,"
 			     "null,rsassa,rsaes,rsapss,oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
 			     "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,ecc-nist,"
-			     "ecc-bn,symcipher,camellia,camellia-min-size=128,cmac,ctr,ofb,"
-			     "cbc,cfb,ecb",
+			     "ecc-bn,ecc-sm2-p256,symcipher,camellia,camellia-min-size=128,cmac,"
+			     "ctr,ofb,cbc,cfb,ecb",
 	.stateFormatLevel  = 1, /* NEVER change */
 	.description = "The profile enables the commands and algorithms that were "
 		       "enabled in libtpms v0.9. This profile is automatically used "

--- a/tests/object_size.c
+++ b/tests/object_size.c
@@ -87,7 +87,7 @@ int main(void)
         written = ANY_OBJECT_Marshal(&object, &buf, &size, &g_RuntimeProfile);
         if (written != exp_sizes[stateFormatLevel]) {
             fprintf(stderr,
-                    "Expected flattened OBJECT to have %d bytes, but it has %u.\n",
+                    "Expected flattened OBJECT to have %zu bytes, but it has %u.\n",
                     exp_sizes[stateFormatLevel], written);
             return EXIT_FAILURE;
         }

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -21,8 +21,8 @@ static const char * const null_profile =
                         "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
                         "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
                         "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
-                        "ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,"
-                        "cmac,ctr,ofb,cbc,cfb,ecb\","
+                        "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                        "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb\","
         "\"Description\":\"The profile enables the commands and algorithms that "
                           "were enabled in libtpms v0.9. This profile is "
                           "automatically used when the state does not have a "
@@ -68,8 +68,8 @@ static const struct {
                              "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
                              "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
                              "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
-                             "ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,"
-                             "cmac,ctr,ofb,cbc,cfb,ecb\","
+                             "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                             "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb\","
             "\"Description\":\"This profile enables all libtpms v0.10-supported "
                               "commands and algorithms. This profile is compatible with "
                               "libtpms >= v0.10.\""
@@ -96,8 +96,8 @@ static const struct {
                              "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
                              "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
                              "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
-                             "ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,"
-                             "cmac,ctr,ofb,cbc,cfb,ecb\","
+                             "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                             "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb\","
             "\"Description\":\"test\""
           "}}",
     }, {
@@ -244,8 +244,8 @@ static const struct {
                              "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
                              "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
                              "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
-                             "ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,"
-                             "cmac,ctr,ofb,cbc,cfb,ecb\","
+                             "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                             "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb\","
             "\"Description\":\"test\""
           "}}",
     }, {
@@ -281,8 +281,8 @@ static const struct {
                              "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
                              "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
                              "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
-                             "ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,"
-                             "cmac,ctr,ofb,cbc,cfb,ecb\","
+                             "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                             "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb\","
             "\"Description\":\"test\""
           "}}",
     }, {
@@ -309,8 +309,8 @@ static const struct {
                              "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
                              "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
                              "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
-                             "ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,"
-                             "cmac,ctr,ofb,cbc,cfb,ecb\","
+                             "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                             "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb\","
             "\"Description\":\"test\""
           "}}",
     }, {


### PR DESCRIPTION
- Add ecc-sm2-p256 to all profiles since it had been enabled for a long time
- When reconciling the enabled curves with the min. key size, disable those curves that can be disabled and don't have the min. required size
- Prevent the list of disabled algorithms to start with a comma
- Fix the display of disabled elliptic curve algorithms by considering the enabledEccCurves array
