### PR TITLE
Add new RSA key generation function from upstream but keep it disabled

### DIFF
--- a/src/tpm2/TpmMath_Util_fp.h
+++ b/src/tpm2/TpmMath_Util_fp.h
@@ -83,6 +83,22 @@ LIB_EXPORT BOOL TpmMath_IntTo2B(
 				NUMBYTES         size    // IN: Size of output buffer - see comments.
 				);
 
+//*** TpmMath_GetRandomBits()
+// This function gets random bits for use in various places.
+//
+// One consequence of the generation scheme is that, if the number of bits requested
+// is not a multiple of 8, then the high-order bits are set to zero. This would come
+// into play when generating a 521-bit ECC key. A 66-byte (528-bit) value is
+// generated and the high order 7 bits are masked off (CLEAR).
+// In this situation, the highest order byte is the first byte (big-endian/TPM2B format)
+//  Return Type: BOOL
+//      TRUE(1)         success
+//      FALSE(0)        failure
+LIB_EXPORT BOOL TpmMath_GetRandomBits(
+				      BYTE*       pBuffer,  // OUT: buffer to set
+				      size_t      bits,     // IN: number of bits to generate (see remarks)
+				      RAND_STATE* rand      // IN: random engine
+				      );
 
 //*** TpmMath_GetRandomInteger
 // This function generates a random integer with the requested number of bits.

--- a/src/tpm2/crypto/CryptPrime_fp.h
+++ b/src/tpm2/crypto/CryptPrime_fp.h
@@ -124,12 +124,6 @@ TpmRsa_GeneratePrimeForRSA(
 			   RAND_STATE* rand       // IN: the random state
 			   );
 
-				// libtpms: added begin
-void RsaAdjustPrimeCandidate(Crypt_Int*        prime,
-			     SEED_COMPAT_LEVEL seedCompatLevel  // IN: compatibility level
-			     );
-				// libtpms: added end
-
 #endif  // ALG_RSA
 
 #endif  // _CRYPT_PRIME_FP_H_

--- a/src/tpm2/crypto/openssl/CryptPrime.c
+++ b/src/tpm2/crypto/openssl/CryptPrime.c
@@ -391,11 +391,74 @@ RsaAdjustPrimeCandidate_New(
 // significant bits of each prime candidate without introducing any computational
 // issues.
 //
+#if 0											// libtpms added
+static void RsaAdjustPrimeCandidate_Rev169(BYTE* bigNumberBuffer, size_t bufSize)	// libtpms: renamed
+{
+    // first, ensure the last byte is odd, making the entire value odd
+    bigNumberBuffer[bufSize - 1] |= 1;
+
+    // second, get the most significant 32 bits.
+    uint32_t msw = (bigNumberBuffer[0] << 24) | (bigNumberBuffer[1] << 16)
+		   | (bigNumberBuffer[2] << 8) | (bigNumberBuffer[3] << 0);
+
+    // Multiplying 0xff...f by 0x4AFB gives 0xff..f - 0xB5050...0
+    uint32_t adjusted = (msw >> 16) * 0x4AFB;
+    adjusted += ((msw & 0xFFFF) * 0x4AFB) >> 16;
+    adjusted += 0xB5050000UL;
+
+    // put the value back
+    bigNumberBuffer[0] = (uint8_t)(adjusted >> 24);
+    bigNumberBuffer[1] = (uint8_t)(adjusted >> 16);
+    bigNumberBuffer[2] = (uint8_t)(adjusted >> 8);
+    bigNumberBuffer[3] = (uint8_t)(adjusted >> 0);
+}
 
 //***TpmRsa_GeneratePrimeForRSA()
 // Function to generate a prime of the desired size with the proper attributes
 // for an RSA prime.
 // succeeds, or enters failure mode.
+static TPM_RC TpmRsa_GeneratePrimeForRSA_Rev169(			// libtpms: renamed
+				  Crypt_Int* prime,      // IN/OUT: points to the BN that will get the
+				  //  random value
+				  UINT32      bits,      // IN: number of bits to get
+				  UINT32      exponent,  // IN: the exponent
+				  RAND_STATE* rand       // IN: the random state
+				  )
+{
+    // Only try to handle specific sizes of keys.
+    // this is necessary so the RsaAdjustPrimeCandidate function works correctly.
+    pAssert((bits % 32) == 0);
+
+    // create buffer large enough for the largest key
+    TPM2B_TYPE(LARGEST, LARGEST_NUMBER);
+    TPM2B_LARGEST large;
+
+    NUMBYTES      bytes = (NUMBYTES)BITS_TO_BYTES(bits);
+    BOOL          OK    = (bytes <= sizeof(large.t.buffer));
+    BOOL          found = FALSE;
+    while(OK && !found)
+	{
+	    OK           = TpmMath_GetRandomBits(large.t.buffer, bits, rand);  // new
+	    large.t.size = bytes;
+	    RsaAdjustPrimeCandidate_Rev169(large.t.buffer, bytes);	// libtpms renamed
+	    // convert from 2B to Integer for prime checks
+	    OK = OK
+		 && (ExtMath_IntFromBytes(prime, large.t.buffer, large.t.size) != NULL);
+	    found = OK && (RsaCheckPrime(prime, exponent, rand) == TPM_RC_SUCCESS);
+	}
+
+    if(!OK)
+	{
+	    FAIL(FATAL_ERROR_CRYPTO);
+	}
+
+    return (OK && found) ? TPM_RC_SUCCESS : TPM_RC_FAILURE;
+}
+#endif									// libtpms added
+
+//									// libtpms added begin
+// This function uses different methods for generating RSA prime numbers
+// depending on the SeedCompatLevel of the DRBG.
 TPM_RC TpmRsa_GeneratePrimeForRSA(
 				  Crypt_Int* prime,      // IN/OUT: points to the BN that will get the
 				  //  random value
@@ -440,6 +503,6 @@ TPM_RC TpmRsa_GeneratePrimeForRSA(
 	    found = RsaCheckPrime(prime, exponent, rand) == TPM_RC_SUCCESS;
 	}
     return TPM_RC_SUCCESS;
-}
+}									// libtpms added end
 
 #endif  // ALG_RSA

--- a/src/tpm2/crypto/openssl/CryptPrime.c
+++ b/src/tpm2/crypto/openssl/CryptPrime.c
@@ -392,25 +392,6 @@ RsaAdjustPrimeCandidate_New(
 // issues.
 //
 
-
-
-LIB_EXPORT void RsaAdjustPrimeCandidate(Crypt_Int*        prime,
-				        SEED_COMPAT_LEVEL seedCompatLevel  // IN: compatibility level; libtpms added
-					)
-{
-    switch (seedCompatLevel) {
-    case SEED_COMPAT_LEVEL_ORIGINAL:
-        RsaAdjustPrimeCandidate_PreRev155(prime);
-        break;
-    case SEED_COMPAT_LEVEL_LAST:
-    /* case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX: */
-        RsaAdjustPrimeCandidate_New(prime);
-        break;
-    default:
-        FAIL(FATAL_ERROR_INTERNAL);
-    }
-}
-
 //***TpmRsa_GeneratePrimeForRSA()
 // Function to generate a prime of the desired size with the proper attributes
 // for an RSA prime.
@@ -444,16 +425,17 @@ TPM_RC TpmRsa_GeneratePrimeForRSA(
 		DRBG_Generate(rand, (BYTE *)prime->d, (UINT16)BITS_TO_BYTES(bits));
 		if (g_inFailureMode)
 		    return TPM_RC_FAILURE;
+		RsaAdjustPrimeCandidate_PreRev155(prime);
 		break;
 	    case SEED_COMPAT_LEVEL_LAST:
-            /* case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX: */
+	    /* case SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX: */
 		if(!TpmMath_GetRandomInteger(prime, bits, rand))                              // new
 		    return TPM_RC_FAILURE;
-                break;
-            default:
-                FAIL(FATAL_ERROR_INTERNAL);
+		RsaAdjustPrimeCandidate_New(prime);
+		break;
+	    default:
+		FAIL(FATAL_ERROR_INTERNAL);
 	    }
-	    RsaAdjustPrimeCandidate(prime, DRBG_GetSeedCompatLevel(rand));
 	// libtpms changed end
 	    found = RsaCheckPrime(prime, exponent, rand) == TPM_RC_SUCCESS;
 	}


### PR DESCRIPTION
Add the new RSA key generation function from upstream but keep it disabled since it does not seem to add much value compared to the existing function. For backwards compatibility reasons related to keys derived from seeds this code can also not just replace the existing code since it is based on a new random number generation function that may produce slightly different random numbers.