### PR TITLE
tpm2: Return TPM_RC_VALUE upon decryption failure

### DIFF
--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -1708,7 +1708,7 @@ CryptRsaDecrypt(
     outlen = sizeof(buffer);
     if (EVP_PKEY_decrypt(ctx, buffer, &outlen,
                          cIn->buffer, cIn->size) <= 0)
-        ERROR_EXIT(TPM_RC_FAILURE);
+        ERROR_EXIT(TPM_RC_VALUE);
 
     if (outlen > dOut->size)
         ERROR_EXIT(TPM_RC_FAILURE);


### PR DESCRIPTION
When decryption fails then return TPM_RC_VALUE rather than TPM_RC_FAILURE. The old error code could indicate to an application or driver that something is wrong with the TPM (has possibly gone into failure mode) even though only the decryption failed, possibly due to a wrong key.