### PR TITLE
tpm2: Implement TPMLIB_WasManufactured API call

### DIFF
--- a/include/libtpms/tpm_library.h
+++ b/include/libtpms/tpm_library.h
@@ -172,6 +172,8 @@ TPM_RESULT TPMLIB_GetState(enum TPMLIB_StateType st,
 
 TPM_RESULT TPMLIB_SetProfile(const char *profile);
 
+TPM_BOOL TPMLIB_WasManufactured(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libtpms/tpm_library.h.in
+++ b/include/libtpms/tpm_library.h.in
@@ -172,6 +172,8 @@ TPM_RESULT TPMLIB_GetState(enum TPMLIB_StateType st,
 
 TPM_RESULT TPMLIB_SetProfile(const char *profile);
 
+TPM_BOOL TPMLIB_WasManufactured(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/man/man3/Makefile.am
+++ b/man/man3/Makefile.am
@@ -23,6 +23,7 @@ man3_PODS = \
 	TPMLIB_SetState.pod \
 	TPMLIB_ValidateState.pod \
 	TPMLIB_VolatileAll_Store.pod \
+	TPMLIB_WasManufactured.pod \
 	TPM_Malloc.pod
 
 man3_MANS = \
@@ -54,6 +55,7 @@ man3_MANS_generated = \
 	TPMLIB_RegisterCallbacks.3 \
 	TPMLIB_ValidateState.3 \
 	TPMLIB_VolatileAll_Store.3 \
+	TPMLIB_WasManufactured.3 \
 	TPM_Malloc.3
 
 man3_MANS += $(man3_MANS_generated)

--- a/man/man3/TPMLIB_WasManufactured.pod
+++ b/man/man3/TPMLIB_WasManufactured.pod
@@ -1,0 +1,33 @@
+=head1 NAME
+
+TPMLIB_WasManufactured  - Check whether a new instance was created
+
+=head1 LIBRARY
+
+TPM library (libtpms, -ltpms)
+
+=head1 SYNOPSIS
+
+B<#include <libtpms/tpm_types.h>>
+
+B<#include <libtpms/tpm_library.h>>
+
+B<#include <libtpms/tpm_error.h>>
+
+B<TPM_BOOL TPMLIB_WasManufactured(void);>
+
+=head1 DESCRIPTION
+
+B<TPMLIB_WasManufactured()> is used to check whether a new TPM instance was
+created using B<TPMLIB_MainInit()> rather than an already existing one was
+restarted. This function will only return a valid result if it is called after
+B<TPMLIB_MainInit()>.
+
+This function only applies to a TPM 2 and for a TPM 1.2 it will always
+return I<FALSE>.
+
+=head1 SEE ALSO
+
+B<TPMLIB_ChooseTPMVersion>, B<TPMLIB_MainInit>(3)
+
+=cut

--- a/src/libtpms.syms
+++ b/src/libtpms.syms
@@ -41,6 +41,7 @@ LIBTPMS_0.6.0 {
 LIBTPMS_0.10.0 {
     global:
 	TPMLIB_SetProfile;
+	TPMLIB_WasManufactured;
     local:
 	*;
 } LIBTPMS_0.6.0;

--- a/src/tpm_library.c
+++ b/src/tpm_library.c
@@ -272,6 +272,11 @@ TPM_RESULT TPMLIB_SetProfile(const char *profile)
     return tpm_iface[tpmvers_choice]->SetProfile(profile);
 }
 
+TPM_BOOL TPMLIB_WasManufactured(void)
+{
+    return tpm_iface[tpmvers_choice]->WasManufactured();
+}
+
 static struct libtpms_callbacks libtpms_cbs;
 
 struct libtpms_callbacks *TPMLIB_GetCallbacks(void)

--- a/src/tpm_library_intern.h
+++ b/src/tpm_library_intern.h
@@ -84,6 +84,7 @@ struct tpm_interface {
     TPM_RESULT (*GetState)(enum TPMLIB_StateType st,
                            unsigned char **buffer, uint32_t *buflen);
     TPM_RESULT (*SetProfile)(const char *profile);
+    TPM_BOOL (*WasManufactured)(void);
 };
 
 extern const struct tpm_interface DisabledInterface;

--- a/src/tpm_tpm12_interface.c
+++ b/src/tpm_tpm12_interface.c
@@ -515,6 +515,11 @@ static TPM_RESULT TPM12_SetProfile(const char *profile)
     return TPM_FAIL;
 }
 
+static TPM_BOOL TPM12_WasManufactured(void)
+{
+    return FALSE;
+}
+
 const struct tpm_interface TPM12Interface = {
     .MainInit = TPM12_MainInit,
     .Terminate = TPM12_Terminate,
@@ -533,4 +538,5 @@ const struct tpm_interface TPM12Interface = {
     .SetState = TPM12_SetState,
     .GetState = TPM12_GetState,
     .SetProfile = TPM12_SetProfile,
+    .WasManufactured = TPM12_WasManufactured,
 };

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -70,6 +70,7 @@
 extern BOOL      g_inFailureMode;
 static BOOL      reportedFailureCommand;
 static char     *g_profile;
+static TPM_BOOL  g_wasManufactured;
 
 /*
  * Check whether the main NVRAM file exists. Return TRUE if it doesn, FALSE otherwise
@@ -108,6 +109,7 @@ static TPM_RESULT TPM2_MainInit(void)
 
     g_inFailureMode = FALSE;
     reportedFailureCommand = FALSE;
+    g_wasManufactured = FALSE;
 
 #ifdef TPM_LIBTPMS_CALLBACKS
     struct libtpms_callbacks *cbs = TPMLIB_GetCallbacks();
@@ -141,6 +143,8 @@ static TPM_RESULT TPM2_MainInit(void)
                 TPMLIB_LogTPM2Error("%s: TPM_Manufacture(TRUE) failed or TPM in "
                                     "failure mode\n", __func__);
                 reportedFailureCommand = TRUE;
+            } else {
+                g_wasManufactured = TRUE;
             }
         }
     } else if (!has_nvram_loaddata_callback) {
@@ -831,6 +835,11 @@ static TPM_RESULT TPM2_SetProfile(const char *profile)
     return TPM_SUCCESS;
 }
 
+static TPM_BOOL TPM2_WasManufactured(void)
+{
+    return g_wasManufactured;
+}
+
 const struct tpm_interface TPM2Interface = {
     .MainInit = TPM2_MainInit,
     .Terminate = TPM2_Terminate,
@@ -849,4 +858,5 @@ const struct tpm_interface TPM2Interface = {
     .SetState = TPM2_SetState,
     .GetState = TPM2_GetState,
     .SetProfile = TPM2_SetProfile,
+    .WasManufactured = TPM2_WasManufactured,
 };


### PR DESCRIPTION
Implement TPMLIB_WasManufactured API call for a TPM 2 so that callers can detect whether a TPM 2 instance was newly created and therefore the profile that was set was also applied.