### PR TITLE
tests: Use free rather than TPM_Free (OS/X)

### DIFF
--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <arpa/inet.h>
 
@@ -374,7 +375,7 @@ int main(void)
                     profile, testcases[i].exp_profile);
             goto exit;
         }
-        TPM_Free(profile);
+        free(profile);
         profile = NULL;
 
         for (j = 0;
@@ -412,7 +413,7 @@ int main(void)
     ret = 0;
 
 exit:
-    TPM_Free(profile);
+    free(profile);
     TPM_Free(rbuffer);
 
     return ret;


### PR DESCRIPTION
Use free rather than TPM_Free to avoid the following warning:

tpm2_setprofile.c:377:18: warning: passing 'char *' to parameter \
  of type 'unsigned char *' converts between pointers to integer \
  types with different sign [-Wpointer-sign]

        TPM_Free(profile);

../include/libtpms/tpm_memory.h:57:36: note: passing argument to \
  parameter 'buffer' here

void       TPM_Free(unsigned char *buffer);