### PR TITLE
tpm2: Adjust selection of StateFormatLevel

### DIFF
--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -714,15 +714,23 @@ RuntimeProfileSet(struct RuntimeProfile *RuntimeProfile,
     }
 
     if (jsonProfileIsFromUser || stateFormatLevelJSON == STATE_FORMAT_LEVEL_UNKNOWN) {
-	RuntimeProfile->stateFormatLevel = rp->stateFormatLevel;
 	if (!rp->allowModifications) {
+	    /* StateFormatLevels are controlled by internal profile */
 	    maxStateFormatLevel = rp->stateFormatLevel;
+	    RuntimeProfile->stateFormatLevel = rp->stateFormatLevel;
 	} else {
 	    if (stateFormatLevelJSON != STATE_FORMAT_LEVEL_UNKNOWN) {
+		if (stateFormatLevelJSON < 2) {
+		    TPMLIB_LogTPM2Error("The minimum required StateFormatLevel for '%s' profile is '2'\n",
+					profileName);
+		    goto error;
+		}
 		maxStateFormatLevel = stateFormatLevelJSON;
 	    } else {
 		maxStateFormatLevel = ~0;
 	    }
+	    /* User has some control over StateFormatLevel */
+	    RuntimeProfile->stateFormatLevel = stateFormatLevelJSON;
 	}
     } else {
 	/* JSON was from TPM 2 state */


### PR DESCRIPTION
When a non-modifyable profile is chosen then copy the StateFormatLevel (SFL) from the internal profile as before. A reason for copying the SFL is also because the user is not allowed to make modifications to this type of profile. Otherwise, if the user chooses a modifyable profile, then let the user choose the StateFormatLevel.