### PR TITLE
tpm2: Wrap asprintf to avoid static analyzer warnings

### DIFF
--- a/src/tpm2/AlgorithmTests.c
+++ b/src/tpm2/AlgorithmTests.c
@@ -886,6 +886,7 @@ TestAlgorithm(TPM_ALG_ID alg, ALGORITHM_VECTOR* toTest)
 		  case TPM_ALG_SM4: /* libtpms changed */
 #  endif  // ALG_SM4
 #  if ALG_CAMELLIA
+                  /* fallthrough */
 		  case TPM_ALG_CAMELLIA:  // libtpms activated
 #  endif
 #  if ALG_TDES

--- a/src/tpm2/NVCommands.c
+++ b/src/tpm2/NVCommands.c
@@ -154,9 +154,9 @@ TPM2_NV_DefineSpace(
 	    // It is not allowed to create a PIN Index that can't be modified.
 	    if(!IS_ATTRIBUTE(attributes, TPMA_NV, NO_DA))
 		return TPM_RCS_ATTRIBUTES + RC_NV_DefineSpace_publicInfo;
-            /* fall through */
 #endif
 #ifdef TPM_NT_PIN_PASS
+            /* fallthrough */			// libtpms moved
 	  case TPM_NT_PIN_PASS:
 	    // AUTHWRITE must be CLEAR (see note above to TPM_NT_PIN_FAIL)
 	    if(IS_ATTRIBUTE(attributes, TPMA_NV, AUTHWRITE)

--- a/src/tpm2/Object_spt.c
+++ b/src/tpm2/Object_spt.c
@@ -427,6 +427,7 @@ CreateChecks(OBJECT*           parentObject,
 	    // comment out the next line in order to prevent a fixedTPM derivation
 	    // parent
 	    //            break;
+	    /* fallthrough */				// libtpms added
 	  case TPM_ALG_SYMCIPHER:
 	    // A restricted key symmetric key (SYMCIPHER and KEYEDHASH)
 	    // must have sensitiveDataOrigin SET unless it has fixedParent and

--- a/src/tpm2/Object_spt.c
+++ b/src/tpm2/Object_spt.c
@@ -760,6 +760,7 @@ PublicAttributesValidation(
 		    return TPM_RCS_ATTRIBUTES;
 		}
 #else								// libtpms added begin
+            (void)primaryHierarchy;
 	    return TPM_RCS_ATTRIBUTES;
 #endif								// libtpms added end
 	}
@@ -785,6 +786,7 @@ PublicAttributesValidation(
 		    return TPM_RCS_ATTRIBUTES;
 		}
 #else								// libtpms added begin
+            (void)primaryHierarchy;
 	    return TPM_RCS_ATTRIBUTES;
 #endif								// libtpms added end
 	}
@@ -1078,7 +1080,7 @@ UnwrapOuter(OBJECT* protector,   // IN: The object that provides
 // 'nameAlg'
 // Returns the size of the marshaled area.
 static UINT16 MarshalSensitive(
-			       OBJECT*         parent,     // IN: the object parent (optional)
+			       OBJECT*         parent LIBTPMS_ATTR_UNUSED,     // IN: the object parent (optional)
 			       BYTE*           buffer,     // OUT: receiving buffer
 			       TPMT_SENSITIVE* sensitive,  // IN: the sensitive area to marshal
 			       TPMI_ALG_HASH   nameAlg     // IN:

--- a/src/tpm2/TpmEcc_Signature_ECDSA.c
+++ b/src/tpm2/TpmEcc_Signature_ECDSA.c
@@ -184,7 +184,7 @@ TpmEcc_SignEcdsa(Crypt_Int*            bnR,   // OUT: 'r' component of the signa
 		 //     process
 		 Crypt_Int*          bnD,     // IN: private signing key
 		 const TPM2B_DIGEST* digest,  // IN: the digest to sign
-		 RAND_STATE*         rand     // IN: used in debug of signing
+		 RAND_STATE*         rand LIBTPMS_ATTR_UNUSED  // IN: used in debug of signing
 		 )
 {
     ECDSA_SIG*    sig = NULL;

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -905,6 +905,7 @@ TPMI_RH_HIERARCHY_Unmarshal(TPMI_RH_HIERARCHY *target, BYTE **buffer, INT32 *siz
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_VALUE;
 	    *target = orig_target; // libtpms added
@@ -935,6 +936,7 @@ TPMI_RH_ENABLES_Unmarshal(TPMI_RH_ENABLES *target, BYTE **buffer, INT32 *size, B
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_VALUE;
 	    *target = orig_target; // libtpms added
@@ -1042,6 +1044,7 @@ TPMI_RH_ENDORSEMENT_Unmarshal(TPMI_RH_ENDORSEMENT *target, BYTE **buffer, INT32 
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_VALUE;
 	    *target = orig_target; // libtpms added
@@ -1339,6 +1342,7 @@ TPMI_ALG_HASH_Unmarshal(TPMI_ALG_HASH *target, BYTE **buffer, INT32 *size, BOOL 
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_HASH;
 	}
@@ -1386,6 +1390,7 @@ TPMI_ALG_SYM_Unmarshal(TPMI_ALG_SYM *target, BYTE **buffer, INT32 *size, BOOL al
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
 	}
@@ -1430,6 +1435,7 @@ TPMI_ALG_SYM_OBJECT_Unmarshal(TPMI_ALG_SYM_OBJECT *target, BYTE **buffer, INT32 
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
 	}
@@ -1480,6 +1486,7 @@ TPMI_ALG_SYM_MODE_Unmarshal(TPMI_ALG_SYM_MODE *target, BYTE **buffer, INT32 *siz
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_MODE;
 	}
@@ -1520,6 +1527,7 @@ TPMI_ALG_KDF_Unmarshal(TPMI_ALG_KDF *target, BYTE **buffer, INT32 *size, BOOL al
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_KDF;
 	    *target = orig_target; // libtpms added
@@ -1571,6 +1579,7 @@ TPMI_ALG_SIG_SCHEME_Unmarshal(TPMI_ALG_SIG_SCHEME *target, BYTE **buffer, INT32 
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_SCHEME;
 	}
@@ -1612,6 +1621,7 @@ TPMI_ECC_KEY_EXCHANGE_Unmarshal(TPMI_ECC_KEY_EXCHANGE *target, BYTE **buffer, IN
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_SCHEME;
 	}
@@ -1687,6 +1697,7 @@ TPMI_ALG_MAC_SCHEME_Unmarshal(TPMI_ALG_MAC_SCHEME *target, BYTE **buffer, INT32 
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_SYMMETRIC;
 	}
@@ -1734,6 +1745,7 @@ TPMI_ALG_CIPHER_MODE_Unmarshal(TPMI_ALG_CIPHER_MODE*target, BYTE **buffer, INT32
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_MODE;
 	}
@@ -3303,6 +3315,7 @@ TPMI_ALG_KEYEDHASH_SCHEME_Unmarshal(TPMI_ALG_KEYEDHASH_SCHEME *target, BYTE **bu
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_VALUE;
 	    *target = orig_target; // libtpms added
@@ -3860,6 +3873,7 @@ TPMI_ALG_RSA_SCHEME_Unmarshal(TPMI_ALG_RSA_SCHEME *target, BYTE **buffer, INT32 
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_VALUE;
 	}
@@ -3911,6 +3925,7 @@ TPMI_ALG_RSA_DECRYPT_Unmarshal(TPMI_ALG_RSA_DECRYPT *target, BYTE **buffer, INT3
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_VALUE;
 	    *target = orig_target; // libtpms added
@@ -4101,6 +4116,7 @@ TPMI_ALG_ECC_SCHEME_Unmarshal(TPMI_ALG_ECC_SCHEME *target, BYTE **buffer, INT32 
 	    if (allowNull) {
 		break;
 	    }
+	    /* fallthrough */
 	  default:
 	    rc = TPM_RC_SCHEME;
 	}

--- a/src/tpm2/crypto/openssl/CryptRsa.c
+++ b/src/tpm2/crypto/openssl/CryptRsa.c
@@ -1533,7 +1533,7 @@ CryptRsaEncrypt(
 		TPMT_RSA_DECRYPT            *scheme,        // IN: the type of padding and hash
 		//     if needed
 		const TPM2B                 *label,         // IN: in case it is needed
-		RAND_STATE                  *rand           // IN: random number generator
+		RAND_STATE                  *rand LIBTPMS_ATTR_UNUSED // IN: random number generator
 		//     state (mostly for testing)
 		)
 {
@@ -1744,7 +1744,7 @@ CryptRsaSign(
 	     TPMT_SIGNATURE      *sigOut,
 	     OBJECT              *key,           // IN: key to use
 	     TPM2B_DIGEST        *hIn,           // IN: the digest to sign
-	     RAND_STATE          *rand           // IN: the random number generator
+	     RAND_STATE          *rand LIBTPMS_ATTR_UNUSED // IN: the random number generator
 	     //      to use (mostly for testing)
 	     )
 {

--- a/src/tpm_library.c
+++ b/src/tpm_library.c
@@ -39,6 +39,7 @@
 
 #include <config.h>
 
+#define _GNU_SOURCE
 #include <assert.h>
 #include <string.h>
 #if defined __FreeBSD__
@@ -590,6 +591,18 @@ void TPMLIB_LogArray(unsigned int indent, const unsigned char *data,
     if (o > 0) {
         TPMLIB_LogPrintfA(indent, "%s\n", line);
     }
+}
+
+int TPMLIB_asprintf(char **strp, const char *fmt, ...)
+{
+    int ret;
+    va_list ap;
+
+    va_start(ap, fmt);
+    ret = vasprintf(strp, fmt, ap);
+    va_end(ap);
+
+    return ret;
 }
 
 void ClearCachedState(enum TPMLIB_StateType st)

--- a/src/tpm_library_intern.h
+++ b/src/tpm_library_intern.h
@@ -40,6 +40,7 @@
 #define TPM_LIBRARY_INTERN_H
 
 #include <stdbool.h>
+
 #include "compiler.h"
 #include "tpm_library.h"
 
@@ -115,6 +116,8 @@ void TPMLIB_LogArray(unsigned int indent, const unsigned char *data,
      TPMLIB_LogPrintfA(~0, "libtpms/tpm12: "format, __VA_ARGS__)
 #define TPMLIB_LogTPM2Error(format, ...) \
      TPMLIB_LogPrintfA(~0, "libtpms/tpm2: "format, __VA_ARGS__)
+
+int TPMLIB_asprintf(char **strp, const char *fmt, ...);
 
 /* prototypes for TPM2 */
 TPM_RESULT TPM2_IO_Hash_Start(void);

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -38,10 +38,7 @@
 
 #include <config.h>
 
-#define _GNU_SOURCE
 #include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <stdbool.h>
 
 #ifndef LIB_EXPORT
@@ -436,7 +433,7 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
     if ((flags & TPMLIB_INFO_TPMSPECIFICATION)) {
         fmt = buffer;
         buffer = NULL;
-        if (asprintf(&buffer, fmt, "", tpmspec, "%s%s%s") < 0)
+        if (TPMLIB_asprintf(&buffer, fmt, "", tpmspec, "%s%s%s") < 0)
             goto error;
         free(fmt);
         printed = true;
@@ -447,10 +444,10 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
 
         fmt = buffer;
         buffer = NULL;
-        if (asprintf(&tpmattrs, tpmattrs_temp, firmware_v1) < 0)
+        if (TPMLIB_asprintf(&tpmattrs, tpmattrs_temp, firmware_v1) < 0)
             goto error;
-        if (asprintf(&buffer, fmt,  printed ? "," : "",
-                     tpmattrs, "%s%s%s") < 0)
+        if (TPMLIB_asprintf(&buffer, fmt,  printed ? "," : "",
+                             tpmattrs, "%s%s%s") < 0)
             goto error;
         free(fmt);
         printed = true;
@@ -471,11 +468,11 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
                      CAMELLIA_256 ? ",256" : "");
         if (n >= sizeof(camelliakeys))
             goto error;
-        if (asprintf(&tpmfeatures, tpmfeatures_temp,
-                     rsakeys, camelliakeys) < 0)
+        if (TPMLIB_asprintf(&tpmfeatures, tpmfeatures_temp,
+                            rsakeys, camelliakeys) < 0)
             goto error;
-        if (asprintf(&buffer, fmt,  printed ? "," : "",
-                     tpmfeatures, "%s%s%s") < 0)
+        if (TPMLIB_asprintf(&buffer, fmt,  printed ? "," : "",
+                            tpmfeatures, "%s%s%s") < 0)
             goto error;
         free(fmt);
         printed = true;
@@ -489,14 +486,14 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
             if (!runtimeAlgos[rat])
                 goto error;
         }
-        if (asprintf(&runtimeAlgorithms, runtimeAlgorithms_temp,
-                     runtimeAlgos[RUNTIME_ALGO_IMPLEMENTED],
-                     runtimeAlgos[RUNTIME_ALGO_CAN_BE_DISABLED],
-                     runtimeAlgos[RUNTIME_ALGO_ENABLED],
-                     runtimeAlgos[RUNTIME_ALGO_DISABLED]) < 0)
+        if (TPMLIB_asprintf(&runtimeAlgorithms, runtimeAlgorithms_temp,
+                            runtimeAlgos[RUNTIME_ALGO_IMPLEMENTED],
+                            runtimeAlgos[RUNTIME_ALGO_CAN_BE_DISABLED],
+                            runtimeAlgos[RUNTIME_ALGO_ENABLED],
+                            runtimeAlgos[RUNTIME_ALGO_DISABLED]) < 0)
             goto error;
-        if (asprintf(&buffer, fmt,  printed ? "," : "",
-                     runtimeAlgorithms, "%s%s%s") < 0)
+        if (TPMLIB_asprintf(&buffer, fmt,  printed ? "," : "",
+                            runtimeAlgorithms, "%s%s%s") < 0)
             goto error;
         free(fmt);
         printed = true;
@@ -510,14 +507,14 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
             if (!runtimeCmds[rct])
                 goto error;
         }
-        if (asprintf(&runtimeCommands, runtimeCommands_temp,
-                     runtimeCmds[RUNTIME_CMD_IMPLEMENTED],
-                     runtimeCmds[RUNTIME_CMD_CAN_BE_DISABLED],
-                     runtimeCmds[RUNTIME_CMD_ENABLED],
-                     runtimeCmds[RUNTIME_CMD_DISABLED]) < 0)
+        if (TPMLIB_asprintf(&runtimeCommands, runtimeCommands_temp,
+                            runtimeCmds[RUNTIME_CMD_IMPLEMENTED],
+                            runtimeCmds[RUNTIME_CMD_CAN_BE_DISABLED],
+                            runtimeCmds[RUNTIME_CMD_ENABLED],
+                            runtimeCmds[RUNTIME_CMD_DISABLED]) < 0)
             goto error;
-        if (asprintf(&buffer, fmt,  printed ? "," : "",
-                     runtimeCommands, "%s%s%s") < 0)
+        if (TPMLIB_asprintf(&buffer, fmt,  printed ? "," : "",
+                            runtimeCommands, "%s%s%s") < 0)
             goto error;
         free(fmt);
         printed = true;
@@ -531,14 +528,14 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
             if (!runtimeAttrs[rabt])
                 goto error;
         }
-        if (asprintf(&runtimeAttributes, runtimeAttributes_temp,
-                     runtimeAttrs[RUNTIME_ATTR_IMPLEMENTED],
-                     runtimeAttrs[RUNTIME_ATTR_CAN_BE_DISABLED],
-                     runtimeAttrs[RUNTIME_ATTR_ENABLED],
-                     runtimeAttrs[RUNTIME_ATTR_DISABLED]) < 0)
+        if (TPMLIB_asprintf(&runtimeAttributes, runtimeAttributes_temp,
+                            runtimeAttrs[RUNTIME_ATTR_IMPLEMENTED],
+                            runtimeAttrs[RUNTIME_ATTR_CAN_BE_DISABLED],
+                            runtimeAttrs[RUNTIME_ATTR_ENABLED],
+                            runtimeAttrs[RUNTIME_ATTR_DISABLED]) < 0)
             goto error;
-        if (asprintf(&buffer, fmt,  printed ? "," : "",
-                     runtimeAttributes, "%s%s%s") < 0)
+        if (TPMLIB_asprintf(&buffer, fmt,  printed ? "," : "",
+                            runtimeAttributes, "%s%s%s") < 0)
             goto error;
         free(fmt);
         printed = true;
@@ -548,10 +545,10 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
         (profileJSON = RuntimeProfileGetJSON(&g_RuntimeProfile))) {
         fmt = buffer;
         buffer = NULL;
-        if (asprintf(&profile, tpmProfile_temp, profileJSON) < 0)
+        if (TPMLIB_asprintf(&profile, tpmProfile_temp, profileJSON) < 0)
             goto error;
-        if (asprintf(&buffer, fmt, printed ? "," : "",
-                     profile, "%s%s%s") < 0)
+        if (TPMLIB_asprintf(&buffer, fmt, printed ? "," : "",
+                            profile, "%s%s%s") < 0)
             goto error;
         free(fmt);
         printed = true;
@@ -567,11 +564,11 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
         tmp = NULL;
 
         while (RuntimeProfileGetByIndex(idx, &json) == TPM_RC_SUCCESS) {
-            if (asprintf(&availableProfiles,
-                         idx > 0 ? tmp : availableProfiles_temp,
-                         idx > 0 ? "," : "",
-                         json,
-                         "%s%s%s") < 0) {
+            if (TPMLIB_asprintf(&availableProfiles,
+                                idx > 0 ? tmp : availableProfiles_temp,
+                                idx > 0 ? "," : "",
+                                json,
+                                "%s%s%s") < 0) {
                 free(json);
                 goto error;
             }
@@ -582,11 +579,11 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
             idx++;
         }
         availableProfiles = NULL;
-        if (asprintf(&availableProfiles, tmp, "", "", "") < 0)
+        if (TPMLIB_asprintf(&availableProfiles, tmp, "", "", "") < 0)
             goto error;
 
-        if (asprintf(&buffer, fmt, printed ? "," : "",
-                     availableProfiles, "%s%s%s") < 0)
+        if (TPMLIB_asprintf(&buffer, fmt, printed ? "," : "",
+                            availableProfiles, "%s%s%s") < 0)
             goto error;
         free(fmt);
         printed = true;
@@ -595,7 +592,7 @@ static char *TPM2_GetInfo(enum TPMLIB_InfoFlags flags)
     /* nothing else to add */
     fmt = buffer;
     buffer = NULL;
-    if (asprintf(&buffer, fmt, "", "", "") < 0)
+    if (TPMLIB_asprintf(&buffer, fmt, "", "", "") < 0)
         goto error;
 
 exit:


### PR DESCRIPTION
To avoid static analyzer warnings due to non-literal format strings being used, wrap asprintf in TPMLIB_asprintf and call vasprintf from there.