### PR TITLE
tpm2: Allow setting the minimum HMAC key size: min-hmac-key-size

### DIFF
--- a/src/tpm2/CryptUtil.c
+++ b/src/tpm2/CryptUtil.c
@@ -85,6 +85,13 @@ static TPM_RC CryptHmacSign(TPMT_SIGNATURE* signature,  // OUT: signature
     HMAC_STATE hmacState;
     UINT32     digestSize;
 
+    if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,// libtpms added begin
+					     TPM_ALG_HMAC,
+					     signKey->sensitive.sensitive.bits.t.size * 8,
+					     TPM_ECC_NONE,
+					     g_RuntimeProfile.stateFormatLevel))
+	return TPM_RC_KEY_SIZE;							// libtpms added end
+
     digestSize = CryptHmacStart2B(&hmacState,
 				  signature->signature.any.hashAlg,
 				  &signKey->sensitive.sensitive.bits.b);
@@ -110,6 +117,14 @@ static TPM_RC CryptHMACVerifySignature(
     TPMT_SIGNATURE         test;
     TPMT_KEYEDHASH_SCHEME* keyScheme =
 	&signKey->publicArea.parameters.keyedHashDetail.scheme;
+
+    if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,// libtpm added begin
+					     TPM_ALG_HMAC,
+					     signKey->sensitive.sensitive.bits.t.size * 8,
+					     TPM_ECC_NONE,
+					     g_RuntimeProfile.stateFormatLevel))
+	return TPM_RC_KEY_SIZE;							// libtpms added end
+
     //
     if((signature->sigAlg != TPM_ALG_HMAC)
        || (signature->signature.hmac.hashAlg == TPM_ALG_NULL))

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -352,6 +352,37 @@ static const struct {
             "\"Description\":\"test\""
           "}}",
     }, {
+        .profile = "{" /* StateFormatLevel 7 is chosen */
+                    "\"Name\":\"custom:test\","
+                    "\"Algorithms\":\"rsa,rsa-min-size=1024,tdes,tdes-min-size=128,"
+                                     "sha1,hmac,aes,aes-min-size=128,mgf1,keyedhash,"
+                                     "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
+                                     "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
+                                     "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
+                                     "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                                     "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb,"
+                                     "hmac-min-key-size=128\","
+                    "\"Description\":\"test\""
+                   "}",
+        .exp_fail = false,
+        .exp_profile =
+          "{\"ActiveProfile\":{"
+            "\"Name\":\"custom:test\","
+            "\"StateFormatLevel\":7,"
+            "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
+                           "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
+                           "0x17a-0x193,0x197,0x199-0x19c\","
+            "\"Algorithms\":\"rsa,rsa-min-size=1024,tdes,tdes-min-size=128,"
+                             "sha1,hmac,aes,aes-min-size=128,mgf1,keyedhash,"
+                             "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
+                             "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
+                             "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
+                             "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                             "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb,"
+                             "hmac-min-key-size=128\","
+            "\"Description\":\"test\""
+          "}}",
+    }, {
         // keep last
     }
 };


### PR DESCRIPTION
Allow setting the minimum HMAC key size and add enforcement gates.