### PR TITLE
Allow user to provide an empty string as attributes and do not copy attributes from modifiable profile

### DIFF
--- a/man/man3/TPMLIB_SetProfile.pod
+++ b/man/man3/TPMLIB_SetProfile.pod
@@ -166,7 +166,31 @@ now. RSA key OBJECTs may be 4 bytes bigger while others are smaller now.
 
 =item 7: (since v0.10)
 
-This I<StateFormatLevel> enabled the I<fips-host> attribute.
+This I<StateFormatLevel> enabled the following profile attributes:
+
+=over 2
+
+=item * no-unpadded-encryption
+
+=item * no-sha1-signing
+
+=item * no-sha1-verification
+
+=item * no-sha1-hmac-creation
+
+=item * no-sha1-hmac-verification
+
+=item * no-sha1-hmac
+
+=item * fips-host
+
+=item * drbg-continous-test
+
+=item * pct
+
+=item * no-ecc-key-derivation
+
+=back
 
 =back
 

--- a/src/tpm2/RuntimeAttributes.c
+++ b/src/tpm2/RuntimeAttributes.c
@@ -111,8 +111,8 @@ RuntimeAttributesSetProfile(struct RuntimeAttributes *RuntimeAttributes,
 
     RuntimeAttributesInit(RuntimeAttributes);
 
-    /* NULL pointer for profile enables nothing */
-    if (!newProfile)
+    /* NULL pointer for profile or empty profiles enables nothing */
+    if (!newProfile || strlen(newProfile) == 0)
 	return TPM_RC_SUCCESS;
 
     token = newProfile;

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -98,9 +98,13 @@ static const struct RuntimeProfileDesc {
  *      - no-unpadded-encryption
  *      - no-sha1-signing
  *      - no-sha1-verification
+ *      - no-sha1-hmac-creation
+ *      - no-sha1-hmac-verification
+ *      - no-sha1-hmac
  *      - fips-host
  *      - drbg-continous-test
  *      - pct
+ *      - no-ecc-key-derivation
  */
     const char *description;
 #define DESCRIPTION_MAX_SIZE        250

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -150,6 +150,7 @@ static const struct RuntimeProfileDesc {
 	.prefix_len = 7,
 	.commandsProfile   = defaultCommandsProfile,
 	.algorithmsProfile = defaultAlgorithmsProfile,
+	/* no need to set attributes profile ever since user MUST provide it */
 	.stateFormatLevel = 2, /* minimum is '2', algos+cmds determine higher level */
 	.description = "This profile allows customization of enabled algorithms and commands. "
 		       "This profile requires at least libtpms v0.10.",
@@ -428,7 +429,7 @@ GetAttributesProfileFromJSON(
 			     char       **attributesProfile
 			     )
 {
-    const char *regex = "^\\{.*[[:space:]]*\"Attributes\"[[:space:]]*:[[:space:]]*\"([^\"]+)\".*\\}$";
+    const char *regex = "^\\{.*[[:space:]]*\"Attributes\"[[:space:]]*:[[:space:]]*\"([^\"]*)\".*\\}$";
     TPM_RC retVal;
 
     retVal = RuntimeProfileGetFromJSON(json, regex, attributesProfile, true, true);
@@ -729,7 +730,8 @@ RuntimeProfileSet(struct RuntimeProfile *RuntimeProfile,
     }
 
     retVal = TPM_RC_MEMORY;
-    if (!attributesProfile && rp->attributesProfile) {
+    if (!attributesProfile && rp->attributesProfile && !rp->allowModifications) {
+        /* only use default if no modications are allowed; use NULL otherwise */
 	if (!(attributesProfile = strdup(rp->attributesProfile)))
 	    goto error;
     }

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -82,6 +82,7 @@ static const struct {
                     "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                                    "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                                    "0x17a-0x193,0x197\","
+                    "\"Attributes\":\"\","
                     "\"Description\":\"test\""
                    "}",
         .exp_fail = false,
@@ -99,6 +100,7 @@ static const struct {
                              "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
                              "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
                              "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb\","
+            "\"Attributes\":\"\","
             "\"Description\":\"test\""
           "}}",
     }, {


### PR DESCRIPTION
If the user provided no attributes in the profile then never copy them from a modifiable profile assuming that the user wanted no attributes to be set. Also allow explicitly setting an empty string, which is possible since all attributes are optional.