### PR TITLE
tpm2: Add asserts to silence compiler warning due to -Wstringop-overf…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
            TARGET="install" NPROC="nproc"
       dist: jammy
       before_script:
+      - sudo pip install setuptools==59.6.0  # Default Jammy version
       - sudo pip install cpp-coveralls
       script:
         ./autogen.sh ${CONFIG} &&
@@ -51,7 +52,7 @@ matrix:
          sudo rm -rf /dev/tpm* &&
          sudo apt -y install devscripts equivs python3-twisted expect
            libtasn1-dev socat findutils gnutls-dev gnutls-bin tss2
-           python3-setuptools libjson-glib-dev &&
+           libjson-glib-dev &&
          ./autogen.sh --with-gnutls --prefix=/usr &&
          export SWTPM_TEST_EXPENSIVE=1 SWTPM_TEST_IBMTSS2=1 &&
          sudo make -j$(nproc) check &&

--- a/src/tpm2/crypto/openssl/CryptCmac.c
+++ b/src/tpm2/crypto/openssl/CryptCmac.c
@@ -92,6 +92,7 @@ CryptCmacStart(
     cState->symAlg      = def->algorithm;
     cState->keySizeBits = def->keyBits.sym;
     cState->iv.t.size = CryptGetSymmetricBlockSize(def->algorithm, def->keyBits.sym);
+    pAssert(cState->iv.t.size > 0 && cState->iv.t.size <= sizeof(cState->iv.t.buffer));	// libtpms added
     MemoryCopy2B(&cState->symKey.b, key, sizeof(cState->symKey.t.buffer));
     
     // Set up the dispatch methods for the CMAC
@@ -191,6 +192,9 @@ CryptCmacEnd(SMAC_STATES* state, UINT32 outSize, BYTE* outBuffer)
 	    // Now compute K2
 	    xorVal = ((subkey.t.buffer[0] & 0x80) == 0) ? 0 : 0x87;
 	    ShiftLeft(&subkey.b);
+MUST_BE(MAX_SYM_BLOCK_SIZE == 16);				// libtpms added begin: gcc -Wstringop-overflow=
+	    pAssert(subkey.t.size > 0 &&
+	            subkey.t.size <= sizeof(subkey.t.buffer));	// libtpms added end
 	    subkey.t.buffer[subkey.t.size - 1] ^= xorVal;
 	}
     // XOR the subkey into the IV


### PR DESCRIPTION
…low=

To silence the following compiler warning add runtime asserts:

tpm2/crypto/openssl/CryptCmac.c: In function 'CryptCmacEnd': tpm2/crypto/openssl/CryptCmac.c:194:48: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  194 |             subkey.t.buffer[subkey.t.size - 1] ^= xorVal;
      |                                                ^
tpm2/TpmTypes.h:1477:33: note: at offset -1 into destination object 'buffer' of size 16
 1477 |         BYTE                    buffer[MAX_SYM_BLOCK_SIZE];
      |                                 ^
lto1: all warnings being treated as errors

In CryptCmacStart the following initialization is done:

cState->iv.t.size = CryptGetSymmetricBlockSize(def->algorithm, def->keyBits.sym);

Also ensure that CryptGetSymmetricBlockSize in this case also always returns a valid size to the TPM2B_IV that it is initializing, which would be the root cause of any error.