### PR TITLE
Update RuntimeProfile.c

### DIFF
--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -123,7 +123,7 @@ static const struct RuntimeProfileDesc {
 			     "null,rsassa,rsaes,rsapss,oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
 			     "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,ecc-nist,"
 			     "ecc-bn,ecc-sm2-p256,symcipher,camellia,camellia-min-size=128,cmac,"
-			     "ctr,ofb,cbc,cfb,ecb";
+			     "ctr,ofb,cbc,cfb,ecb",
 	.stateFormatLevel  = 7,
 	.description = "This profile enables all libtpms v0.10-supported commands and "
 		       "algorithms. This profile is compatible with libtpms >= v0.10.",


### PR DESCRIPTION
Hello,  got this err on compilation from AUR (libtpms-git-0.10.0.r5.c56f8f77-1) : 

```bash
...
  CC       tpm2/libtpms_tpm2_la-BackwardsCompatibilityObject.lo
  CC       tpm2/libtpms_tpm2_la-LibtpmsCallbacks.lo
  CC       tpm2/libtpms_tpm2_la-NVMarshal.lo
  CC       tpm2/libtpms_tpm2_la-RuntimeAlgorithm.lo
  CC       tpm2/libtpms_tpm2_la-RuntimeAttributes.lo
  CC       tpm2/libtpms_tpm2_la-RuntimeCommands.lo
  CC       tpm2/libtpms_tpm2_la-RuntimeProfile.lo
  CC       tpm2/libtpms_tpm2_la-StateMarshal.lo
  CC       tpm2/libtpms_tpm2_la-Volatile.lo
tpm2/RuntimeProfile.c:126:51: error: expected ‘}’ before ‘;’ token
  126 |                              "ctr,ofb,cbc,cfb,ecb";
      |                                                   ^
tpm2/RuntimeProfile.c:115:29: note: to match this ‘{’
  115 |     [PROFILE_DEFAULT_IDX] = {
      |                             ^
  CC       tpm2/crypto/openssl/libtpms_tpm2_la-BnToOsslMath.lo
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
make[2]: *** [Makefile:3295: tpm2/libtpms_tpm2_la-RuntimeProfile.lo] Error 1
make[2]: *** Attente des tâches non terminées....
make[2] : on quitte le répertoire « /home/rnek0/.cache/paru/clone/libtpms-git/src/libtpms/src »
make[1]: *** [Makefile:527: all-recursive] Error 1
make[1] : on quitte le répertoire « /home/rnek0/.cache/paru/clone/libtpms-git/src/libtpms »
make: *** [Makefile:434: all] Error 2
==> ERREUR : Une erreur s’est produite dans build().
    Abandon…
erreur : échec de la compilation de 'libtpms-git-0.7.0.r304.2e2f854-1': 
erreur : la compilation des paquets suivants a échouée : libtpms-git-0.7.0.r304.2e2f854-1
```
A little typo?
have a nice day :)