### PR TITLE
tpm2: Restrict NV index datasize to MAX_NV_INDEX_SIZE (CID 1608875)

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -4952,8 +4952,10 @@ USER_NVRAM_Unmarshal(BYTE **buffer, INT32 *size)
                     rc = UINT32_Unmarshal(&datasize, buffer, size);
                 }
                 if (rc == TPM_RC_SUCCESS) {
-                    /* datasize cannot exceed 64k + a few bytes */
-                    if (datasize > (0x10000 + 0x100)) {
+                    /*
+                     * datasize cannot exceed MAX_NV_INDEX_SIZE (2048 bytes)
+                     */
+                    if (datasize > MAX_NV_INDEX_SIZE) {
                         TPMLIB_LogTPM2Error("datasize for NV_INDEX too "
                                             "large: %u\n", datasize);
                         rc = TPM_RC_SIZE;
@@ -4965,7 +4967,7 @@ USER_NVRAM_Unmarshal(BYTE **buffer, INT32 *size)
                     goto exit_size;
                 }
                 if (rc == TPM_RC_SUCCESS && datasize > 0) {
-                    BYTE buf[datasize];
+                    BYTE buf[MAX_NV_INDEX_SIZE];
                     rc = Array_Unmarshal(buf, datasize, buffer, size);
                     NvWrite(entryRef + o + offset, datasize, buf);
                     offset += datasize;


### PR DESCRIPTION
Resolve an issue reported by Coverity caused by the maximum value of datasize (max. size of an NV index) that was allowed to be 0x10100 (17 bits) even though later on it tried to read an array of maximum size expressed by 16 bits (Coverity complaint). However, the maximum value of datasize could only ever have been MAX_NV_INDEX_SIZE, which is gated by restrictions on the size of an NV index. Therefore, restrict the maximum datasize of an NV index to MAX_NV_INDEX_SIZE (2048 bytes) since this is the maximum size that an NV index can be defined for.