### PR TITLE
Enable support for 4096-bit RSA keys by default

### DIFF
--- a/man/man3/TPMLIB_SetProfile.pod
+++ b/man/man3/TPMLIB_SetProfile.pod
@@ -195,6 +195,10 @@ This I<StateFormatLevel> enabled the following profile attributes:
 
 =back
 
+=item 8: (since v0.11)
+
+This I<StateFormatLevel> enabled 4096-bit RSA.
+
 =back
 
 A user may specify the I<StateFormatLevel> when using the I<custom> profile.

--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -86,6 +86,7 @@ static const struct KeySizes s_KeySizesRSA[] = {
     { .enabled = RSA_1024, .size = 1024, .stateFormatLevel = 1 },
     { .enabled = RSA_2048, .size = 2048, .stateFormatLevel = 1 },
     { .enabled = RSA_3072, .size = 3072, .stateFormatLevel = 1 },
+    { .enabled = RSA_4096, .size = 4096, .stateFormatLevel = 8 },
     { .enabled = false   , .size = 0   , .stateFormatLevel = 0 },
 };
 static const struct KeySizes s_KeySizesECC[] = {

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -78,7 +78,7 @@ static const struct RuntimeProfileDesc {
      * This basically locks the name of the profile to the stateFormatLevel.
      */
     unsigned int stateFormatLevel;
-#define STATE_FORMAT_LEVEL_CURRENT 7
+#define STATE_FORMAT_LEVEL_CURRENT 8
 #define STATE_FORMAT_LEVEL_UNKNOWN 0 /* JSON didn't provide StateFormatLevel; this is only
 					allowed for the 'default' profile or when user
 					passed JSON via SetProfile() */
@@ -105,6 +105,7 @@ static const struct RuntimeProfileDesc {
  *      - drbg-continous-test
  *      - pct
  *      - no-ecc-key-derivation
+ *  8 : Enabled 4096-bit RSA support
  */
     const char *description;
 #define DESCRIPTION_MAX_SIZE        250
@@ -971,8 +972,8 @@ RuntimeProfileGetSeedCompatLevel(void)
     case 1: /* profile runs on v0.9 */
 	return SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX;
 
-    case 2 ... 7: /* profile runs on v0.10 */ {
-	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 7); // force update when this changes
+    case 2 ... 8: /* profile runs on v0.10 */ {
+	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 8); // force update when this changes
 	return SEED_COMPAT_LEVEL_LAST;
     }
 

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -111,9 +111,27 @@ static const struct RuntimeProfileDesc {
 #define DESCRIPTION_MAX_SIZE        250
     bool allowModifications; /* user is allowed to modify algorithms profile */
 } RuntimeProfileDescs[] = {
-#define PROFILE_DEFAULT_IDX	0
-#define PROFILE_NULL_IDX	1
-    [PROFILE_DEFAULT_IDX] = {
+#define PROFILE_DEFAULT_V2_IDX	0
+#define PROFILE_DEFAULT_V1_IDX	(PROFILE_DEFAULT_V2_IDX + 1)
+#define PROFILE_NULL_IDX	(PROFILE_DEFAULT_V1_IDX + 1)
+    [PROFILE_DEFAULT_V2_IDX] = {
+	 /* do not change this profile */
+	.name = "default-v2",
+	.commandsProfile   = "0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,0x15b-0x15e,"
+			     "0x160-0x165,0x167-0x174,0x176-0x178,0x17a-0x193,0x197,"
+			     "0x199-0x19c",
+	.algorithmsProfile = "rsa,rsa-min-size=1024,tdes,tdes-min-size=128,sha1,hmac,"
+			     "aes,aes-min-size=128,mgf1,keyedhash,xor,sha256,sha384,sha512,"
+			     "null,rsassa,rsaes,rsapss,oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
+			     "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,ecc-nist,"
+			     "ecc-bn,ecc-sm2-p256,symcipher,camellia,camellia-min-size=128,cmac,"
+			     "ctr,ofb,cbc,cfb,ecb",
+	.stateFormatLevel  = 7,
+	.description = "This profile enables all libtpms v0.11-supported commands and "
+		       "algorithms. This profile is compatible with libtpms >= v0.11.",
+	.allowModifications = false,
+    },
+    [PROFILE_DEFAULT_V1_IDX] = {
 	 /* do not change this profile */
 	.name = "default-v1",
 	.commandsProfile   = "0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,0x15b-0x15e,"

--- a/src/tpm2/TpmProfile_Common.h
+++ b/src/tpm2/TpmProfile_Common.h
@@ -162,7 +162,7 @@
 #define     RSA_1024                        (YES * ALG_RSA)
 #define     RSA_2048                        (YES * ALG_RSA)
 #define     RSA_3072                        (YES * ALG_RSA)
-#define     RSA_4096                        (NO  * ALG_RSA)	/* libtpms: NO */
+#define     RSA_4096                        (YES * ALG_RSA) /* since libtpms v0.11 stateFormatLevel 8 */
 #define     RSA_16384                       (NO  * ALG_RSA)
 
 #define     ALG_RSASSA                      (YES * ALG_RSA)

--- a/tests/nvram_offsets.c
+++ b/tests/nvram_offsets.c
@@ -61,8 +61,10 @@ int main(void)
      * size of the OBJECT is the same on all architectures so that a full
      * NVRAM fits on all architectures
      */
-#if RSA_4096
+#if RSA_16384
 # error Unsupported RSA key size
+#elif RSA_4096
+# define OBJECT_EXP_SIZE 3312
 #elif RSA_3072
 # define OBJECT_EXP_SIZE 2608
 #elif RSA_2048
@@ -72,11 +74,14 @@ int main(void)
         fprintf(stderr, "sizeof(OBJECT) does not have expected size of %u bytes"
                         "but %zu bytes\n", OBJECT_EXP_SIZE, sizeof(OBJECT));
         fprintf(stderr, "sizeof(TPMT_PUBLIC) is now %zu bytes;"
-                        "was 356/484 bytes for 2048/3072 bit RSA keys\n", sizeof(TPMT_PUBLIC));
+                        "was 356/484/612 bytes for 2048/3072/4096 bit RSA keys\n",
+                        sizeof(TPMT_PUBLIC));
         fprintf(stderr, "sizeof(TPMT_SENSITIVE) is now %zu bytes;"
-                        "was 776/1096 bytes for 2048/3072 bit RSA keys\n", sizeof(TPMT_SENSITIVE));
+                        "was 776/1096/1416 bytes for 2048/3072/4096 bit RSA keys\n",
+                        sizeof(TPMT_SENSITIVE));
         fprintf(stderr, "sizeof(privateExponent_t) is now %zu bytes;"
-                        "was 608/864 bytes for 2048/3072 bit RSA keys\n", sizeof(privateExponent_t));
+                        "was 608/864/1120 bytes for 2048/3072/4096 bit RSA keys\n",
+                        sizeof(privateExponent_t));
         return EXIT_FAILURE;
     }
 

--- a/tests/object_size.c
+++ b/tests/object_size.c
@@ -72,7 +72,7 @@ int main(void)
     };
 #pragma GCC diagnostics pop
     static const size_t exp_sizes[7] = {
-        0, 2580, 2580, 2580, 2580, 2580, 2584,
+        0, 3284, 3284, 3284, 3284, 3284, 3288,
     };
     BYTE buffer[2 * MAX_MARSHALLED_OBJECT_SIZE];
     UINT32 stateFormatLevel;

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -275,7 +275,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"custom\","
-            "\"StateFormatLevel\":5,"
+            "\"StateFormatLevel\":8,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197,0x19b-0x19c\","
@@ -339,7 +339,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"custom\","
-            "\"StateFormatLevel\":7,"
+            "\"StateFormatLevel\":8,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197\","
@@ -372,7 +372,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"custom:test\","
-            "\"StateFormatLevel\":7,"
+            "\"StateFormatLevel\":8,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197,0x199-0x19c\","

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -56,6 +56,26 @@ static const struct {
         .exp_fail = false,
         .exp_profile = null_profile,
     }, {
+        .profile = "{\"Name\":\"default-v2\"}",
+        .exp_profile =
+          "{\"ActiveProfile\":{"
+            "\"Name\":\"default-v2\","
+            "\"StateFormatLevel\":7,"
+            "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
+                           "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
+                           "0x17a-0x193,0x197,0x199-0x19c\","
+            "\"Algorithms\":\"rsa,rsa-min-size=1024,tdes,tdes-min-size=128,"
+                             "sha1,hmac,aes,aes-min-size=128,mgf1,keyedhash,"
+                             "xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,"
+                             "oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,"
+                             "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,"
+                             "ecc-nist,ecc-bn,ecc-sm2-p256,symcipher,camellia,"
+                             "camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb\","
+            "\"Description\":\"This profile enables all libtpms v0.11-supported "
+                              "commands and algorithms. This profile is compatible with "
+                              "libtpms >= v0.11.\""
+          "}}",
+    }, {
         .profile = "{\"Name\":\"default-v1\"}",
         .exp_profile =
           "{\"ActiveProfile\":{"


### PR DESCRIPTION
Currently, the defaults do not allow 4096-bit RSA keys, however many end users are starting to use them. The lack of support in libtpms - configured at compile time, not runtime - means that most Linux distros (which don't currently alter the defaults) do not allow the use of 4096-bit RSA keys inside virtual machines.

Not only does this prevent creating 4096-bit RSA keys in the tpm (e.g. tpm2_createprimary), but it also prevents loading external 4096-bit RSA keys into the VM's tpm, for example when attempting to use the tpm to verify an externally-generated data signature that was created using a 4096-bit RSA key (e.g. as part of a PolicyAuthorize and/or VerifySignature).