### PR TITLE
tpm2 + test: Make it compilable on Debian GNU Hurd

### DIFF
--- a/src/tpm2/TpmProfile_Common.h
+++ b/src/tpm2/TpmProfile_Common.h
@@ -89,7 +89,7 @@
 #else
 # include <endian.h>
 #endif
-#if defined __linux__ || defined __CYGWIN__
+#if defined __linux__ || defined __CYGWIN__ || defined __gnu_hurd__
  #if __BYTE_ORDER == __LITTLE_ENDIAN
   #define  BIG_ENDIAN_TPM       NO
  #endif

--- a/tests/common
+++ b/tests/common
@@ -5,7 +5,7 @@
 # @1: filename
 function get_filesize()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
 		stat -c%s "$1"
 	else
 		# OpenBSD


### PR DESCRIPTION
The simple changes make it compilable on GNU Hurd where it is currently failing to build.

Link: https://buildd.debian.org/status/package.php?p=libtpms&suite=sid