### PR TITLE
ci: Update from ubuntu-20.04 to ubuntu-22.04 due to EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches: [ "master", "stable-*" ]
 
 jobs:
-  build-ubuntu-focal:
-    runs-on: ubuntu-20.04
+  build-ubuntu-jammy:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Ubuntu 20.04 is EOL. Therefore, upgrade it to 22.04.