### PR TITLE
tpm2: Enable support for 4096 bit RSA keys (with fixes)

### DIFF
--- a/man/man3/TPMLIB_SetProfile.pod
+++ b/man/man3/TPMLIB_SetProfile.pod
@@ -195,6 +195,10 @@ This I<StateFormatLevel> enabled the following profile attributes:
 
 =back
 
+=item 8: (since v0.11)
+
+This I<StateFormatLevel> enabled 4096-bit RSA.
+
 =back
 
 A user may specify the I<StateFormatLevel> when using the I<custom> profile.

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -3870,7 +3870,7 @@ static const struct _entry {
     { COMPILE_CONSTANT(ALG_CBC, EQ) },
     { COMPILE_CONSTANT(ALG_CFB, EQ) },
     { COMPILE_CONSTANT(ALG_ECB, EQ) },
-    { COMPILE_CONSTANT(MAX_RSA_KEY_BITS, LE) }, /* old: 2048 */
+    { COMPILE_CONSTANT(3072, LE) }, /* previous: MAX_RSA_KEY_BITS (4096 since StateFormatLevel 8) */
     { COMPILE_CONSTANT(MAX_TDES_KEY_BITS, EQ) },
     { COMPILE_CONSTANT(MAX_AES_KEY_BITS, EQ) },
     { COMPILE_CONSTANT(128, EQ) }, /* MAX_SM4_KEY_BITS      in older code was 128 also with SM4 not active */
@@ -3943,7 +3943,7 @@ static const struct _entry {
     { COMPILE_CONSTANT(RSA_1024, LE) },
     { COMPILE_CONSTANT(RSA_2048, LE) },
     { COMPILE_CONSTANT(RSA_3072, LE) },
-    { COMPILE_CONSTANT(RSA_4096, LE) },
+    { COMPILE_CONSTANT(0, LE) }, /* was RSA_4096; changed a StateFormatLevel 8 */
     { COMPILE_CONSTANT(RSA_16384, LE) },
     { COMPILE_CONSTANT(RH_ACT_0, LE) },
     { COMPILE_CONSTANT(RH_ACT_1, LE) },

--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -86,6 +86,7 @@ static const struct KeySizes s_KeySizesRSA[] = {
     { .enabled = RSA_1024, .size = 1024, .stateFormatLevel = 1 },
     { .enabled = RSA_2048, .size = 2048, .stateFormatLevel = 1 },
     { .enabled = RSA_3072, .size = 3072, .stateFormatLevel = 1 },
+    { .enabled = RSA_4096, .size = 4096, .stateFormatLevel = 8 },
     { .enabled = false   , .size = 0   , .stateFormatLevel = 0 },
 };
 static const struct KeySizes s_KeySizesECC[] = {

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -78,7 +78,7 @@ static const struct RuntimeProfileDesc {
      * This basically locks the name of the profile to the stateFormatLevel.
      */
     unsigned int stateFormatLevel;
-#define STATE_FORMAT_LEVEL_CURRENT 7
+#define STATE_FORMAT_LEVEL_CURRENT 8
 #define STATE_FORMAT_LEVEL_UNKNOWN 0 /* JSON didn't provide StateFormatLevel; this is only
 					allowed for the 'default' profile or when user
 					passed JSON via SetProfile() */
@@ -105,6 +105,7 @@ static const struct RuntimeProfileDesc {
  *      - drbg-continous-test
  *      - pct
  *      - no-ecc-key-derivation
+ *  8 : Enabled 4096-bit RSA support
  */
     const char *description;
 #define DESCRIPTION_MAX_SIZE        250
@@ -989,8 +990,8 @@ RuntimeProfileGetSeedCompatLevel(void)
     case 1: /* profile runs on v0.9 */
 	return SEED_COMPAT_LEVEL_RSA_PRIME_ADJUST_FIX;
 
-    case 2 ... 7: /* profile runs on v0.10 */ {
-	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 7); // force update when this changes
+    case 2 ... 8: /* profile runs on v0.10 */ {
+	MUST_BE(STATE_FORMAT_LEVEL_CURRENT == 8); // force update when this changes
 	return SEED_COMPAT_LEVEL_LAST;
     }
 

--- a/src/tpm2/TpmProfile_Common.h
+++ b/src/tpm2/TpmProfile_Common.h
@@ -162,7 +162,7 @@
 #define     RSA_1024                        (YES * ALG_RSA)
 #define     RSA_2048                        (YES * ALG_RSA)
 #define     RSA_3072                        (YES * ALG_RSA)
-#define     RSA_4096                        (NO  * ALG_RSA)	/* libtpms: NO */
+#define     RSA_4096                        (YES * ALG_RSA) /* since libtpms v0.11 stateFormatLevel 8 */
 #define     RSA_16384                       (NO  * ALG_RSA)
 
 #define     ALG_RSASSA                      (YES * ALG_RSA)

--- a/tests/nvram_offsets.c
+++ b/tests/nvram_offsets.c
@@ -61,8 +61,10 @@ int main(void)
      * size of the OBJECT is the same on all architectures so that a full
      * NVRAM fits on all architectures
      */
-#if RSA_4096
+#if RSA_16384
 # error Unsupported RSA key size
+#elif RSA_4096
+# define OBJECT_EXP_SIZE 3312
 #elif RSA_3072
 # define OBJECT_EXP_SIZE 2608
 #elif RSA_2048
@@ -72,11 +74,14 @@ int main(void)
         fprintf(stderr, "sizeof(OBJECT) does not have expected size of %u bytes"
                         "but %zu bytes\n", OBJECT_EXP_SIZE, sizeof(OBJECT));
         fprintf(stderr, "sizeof(TPMT_PUBLIC) is now %zu bytes;"
-                        "was 356/484 bytes for 2048/3072 bit RSA keys\n", sizeof(TPMT_PUBLIC));
+                        "was 356/484/612 bytes for 2048/3072/4096 bit RSA keys\n",
+                        sizeof(TPMT_PUBLIC));
         fprintf(stderr, "sizeof(TPMT_SENSITIVE) is now %zu bytes;"
-                        "was 776/1096 bytes for 2048/3072 bit RSA keys\n", sizeof(TPMT_SENSITIVE));
+                        "was 776/1096/1416 bytes for 2048/3072/4096 bit RSA keys\n",
+                        sizeof(TPMT_SENSITIVE));
         fprintf(stderr, "sizeof(privateExponent_t) is now %zu bytes;"
-                        "was 608/864 bytes for 2048/3072 bit RSA keys\n", sizeof(privateExponent_t));
+                        "was 608/864/1120 bytes for 2048/3072/4096 bit RSA keys\n",
+                        sizeof(privateExponent_t));
         return EXIT_FAILURE;
     }
 

--- a/tests/object_size.c
+++ b/tests/object_size.c
@@ -72,7 +72,7 @@ int main(void)
     };
 #pragma GCC diagnostics pop
     static const size_t exp_sizes[7] = {
-        0, 2580, 2580, 2580, 2580, 2580, 2584,
+        0, 3284, 3284, 3284, 3284, 3284, 3288,
     };
     BYTE buffer[2 * MAX_MARSHALLED_OBJECT_SIZE];
     UINT32 stateFormatLevel;

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -295,7 +295,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"custom\","
-            "\"StateFormatLevel\":5,"
+            "\"StateFormatLevel\":8,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197,0x19b-0x19c\","
@@ -359,7 +359,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"custom\","
-            "\"StateFormatLevel\":7,"
+            "\"StateFormatLevel\":8,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197\","
@@ -392,7 +392,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"custom:test\","
-            "\"StateFormatLevel\":7,"
+            "\"StateFormatLevel\":8,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197,0x199-0x19c\","


### PR DESCRIPTION
- Enable RSA_4096
- Add RSA_4096 to s_KeySizesRSA at stateFormatLevel 8
- Increase STATE_FORMAT_LEVEL_CURRENT to 8
- Update tests for larger object size and increased StateFormatLevel
- In NVMarshal.c replace MAX_RSA_KEY_BITS with old value 3072 so that the state is acceptable to older versions of libtpms; if we wrote 4096, then older versions of libtpms would reject the state.
- In NVMarshal.c replace RSA_4096 with '0' so it is acceptable to older versions; if we wrote '1', then older versions of libtpms would reject the state.

Fixes: #491