### PR TITLE
tpm2: Set SFL of default-v2 profile to STATE_FORMAT_LEVEL_CURRENT

### DIFF
--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -126,7 +126,7 @@ static const struct RuntimeProfileDesc {
 			     "kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,ecc-nist,"
 			     "ecc-bn,ecc-sm2-p256,symcipher,camellia,camellia-min-size=128,cmac,"
 			     "ctr,ofb,cbc,cfb,ecb",
-	.stateFormatLevel  = 7,
+	.stateFormatLevel  = STATE_FORMAT_LEVEL_CURRENT, /* should always be the latest */
 	.description = "This profile enables all libtpms v0.11-supported commands and "
 		       "algorithms. This profile is compatible with libtpms >= v0.11.",
 	.allowModifications = false,

--- a/tests/tpm2_setprofile.c
+++ b/tests/tpm2_setprofile.c
@@ -60,7 +60,7 @@ static const struct {
         .exp_profile =
           "{\"ActiveProfile\":{"
             "\"Name\":\"default-v2\","
-            "\"StateFormatLevel\":7,"
+            "\"StateFormatLevel\":8,"
             "\"Commands\":\"0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,"
                            "0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,"
                            "0x17a-0x193,0x197,0x199-0x19c\","


### PR DESCRIPTION
To enable RSA-4096 in the default-v2 profile, set the stateFormatLevel to STATE_FORMAT_LEVEL_CURRENT (8).