### PR TITLE
tpm2: In CheckLockedOut replace TPM_RC_RETRY with TPM_RC_SUCCESS

### DIFF
--- a/src/tpm2/SessionProcess.c
+++ b/src/tpm2/SessionProcess.c
@@ -1334,7 +1334,7 @@ static TPM_RC CheckLockedOut(
 		    g_daUsed        = TRUE;
 		    gp.orderlyState = SU_DA_USED_VALUE;
 		    NV_SYNC_PERSISTENT(orderlyState);
-		    return TPM_RC_RETRY;
+		    return TPM_RC_SUCCESS; // libtpms changed: was TPM_RC_RETRY;
 		}
 #endif
 	}


### PR DESCRIPTION
In CheckLockedOut replace the return code of TPM_RC_RETRY with TPM_RC_SUCCESS since it does not seem to be necessary to run the TPM2 command again but the TPM2 can continue executing the current command. If NVRAM wasn't available then the code in CheckLockedOut would return with an error already.