### PR TITLE
tpm2: fix build for LibreSSL 4.1.0

### DIFF
--- a/src/tpm2/crypto/openssl/BnToOsslMath.c
+++ b/src/tpm2/crypto/openssl/BnToOsslMath.c
@@ -621,7 +621,7 @@ LIB_EXPORT BOOL BnEccModMult2(bigPoint            R,  // OUT: computed point
 	EC_POINT_mul(E->G, pR, bnD, pQ, bnU, E->CTX);
     else
 	{
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x4010000fL)
 	    EC_POINT *pR1 = EC_POINT_new(E->G);
 	    EC_POINT *pR2 = EC_POINT_new(E->G);
 	    int OK;


### PR DESCRIPTION
With LibreSSL 4.1.0 the `EC_POINTs_mul` function was removed, but the newer OpenSSL 3 code path works instead.

Running `make check` succeeds for me.
```
PASS: nvram_offsets
PASS: tpm2_cve-2023-1017.sh
PASS: tpm2_cve-2023-1018.sh
PASS: tpm2_pcr_read.sh
PASS: base64decode.sh
PASS: tpm2_setprofile.sh
PASS: object_size
PASS: tpm2_createprimary.sh
PASS: tpm2_selftest.sh
PASS: fuzz.sh
============================================================================
Testsuite summary for libtpms 0.11.0
============================================================================
# TOTAL: 10
# PASS:  10
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```