### PR TITLE
Convert some TPM_RC_FAILURE to TPM_RC_MEMORY

### DIFF
--- a/src/tpm2/TpmEcc_Signature_ECDSA.c
+++ b/src/tpm2/TpmEcc_Signature_ECDSA.c
@@ -194,6 +194,9 @@ TpmEcc_SignEcdsa(Crypt_Int*            bnR,   // OUT: 'r' component of the signa
     const BIGNUM* s;
     BIGNUM*       d = BN_new();
 
+    if (!d)
+        return TPM_RC_MEMORY;
+
     d = BigInitialized(d, (bigConst)bnD);
 
     eckey = EC_KEY_new();
@@ -309,6 +312,9 @@ TpmEcc_ValidateSignatureEcdsa(
     BIGNUM*    r = BN_new();
     BIGNUM*    s = BN_new();
     EC_POINT*  q = EcPointInitialized((bn_point_t*)ecQ, E);
+
+    if (!r || !s)
+        ERROR_EXIT(TPM_RC_MEMORY);
 
     if (digest->b.size == CryptHashGetDigestSize(TPM_ALG_SHA1) &&
 	RuntimeProfileRequiresAttributeFlags(&g_RuntimeProfile,

--- a/src/tpm2/crypto/openssl/BnToOsslMath.c
+++ b/src/tpm2/crypto/openssl/BnToOsslMath.c
@@ -483,7 +483,8 @@ LIB_EXPORT EC_POINT* EcPointInitialized(pointConst initializer, const bigCurveDa
 	    if(E == NULL)
 		FAIL(FATAL_ERROR_ALLOCATION);
 	    P = EC_POINT_new(E->G);
-	    if(!EC_POINT_set_affine_coordinates_GFp(E->G, P, bnX, bnY, E->CTX))
+	    if(P != NULL &&     // libtpms added
+	       !EC_POINT_set_affine_coordinates_GFp(E->G, P, bnX, bnY, E->CTX))
 		P = NULL;
 	    BN_clear_free(bnX); // libtpms added
 	    BN_clear_free(bnY); // libtpms added

--- a/src/tpm2/crypto/openssl/CryptSym.c
+++ b/src/tpm2/crypto/openssl/CryptSym.c
@@ -591,7 +591,7 @@ CryptSymmetricEncrypt(
         buffersize = TPM2_ROUNDUP(dSize, blockSize);
         buffer = malloc(buffersize);
         if (buffer == NULL)
-            ERROR_EXIT(TPM_RC_FAILURE);
+            ERROR_EXIT(TPM_RC_MEMORY);
 
         pOut = buffer;
     }
@@ -714,7 +714,7 @@ CryptSymmetricDecrypt(
     buffersize = TPM2_ROUNDUP(dSize + blockSize, blockSize);
     buffer = malloc(buffersize);
     if (buffer == NULL)
-        ERROR_EXIT(TPM_RC_FAILURE);
+        ERROR_EXIT(TPM_RC_MEMORY);
 
 #if ALG_TDES && ALG_CTR
     if (algorithm == TPM_ALG_TDES && mode == TPM_ALG_CTR) {

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -867,7 +867,7 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
     TPM_RC        retVal;
 
     if (ObjectGetPublicParameters(rsaKey, &N, &E) != 1)
-        return TPM_RC_FAILURE;
+        ERROR_EXIT(TPM_RC_FAILURE);
 
     if(!rsaKey->attributes.privateExp)
         CryptRsaLoadPrivateExponent(&rsaKey->publicArea, &rsaKey->sensitive,

--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -866,6 +866,9 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
     BN_CTX       *ctx = NULL;
     TPM_RC        retVal;
 
+    if (!dP || !dQ || !qInv)
+        ERROR_EXIT(TPM_RC_MEMORY);
+
     if (ObjectGetPublicParameters(rsaKey, &N, &E) != 1)
         ERROR_EXIT(TPM_RC_FAILURE);
 
@@ -884,7 +887,7 @@ InitOpenSSLRSAPrivateKey(OBJECT     *rsaKey,   // IN
         Q = BN_new();
         Qr = BN_new();
         if (ctx == NULL || Q == NULL || Qr == NULL)
-            ERROR_EXIT(TPM_RC_FAILURE);
+            ERROR_EXIT(TPM_RC_MEMORY);
         /* Q = N/P; no remainder */
         BN_set_flags(P, BN_FLG_CONSTTIME); // P is secret
         if (!BN_div(Q, Qr, N, P, ctx) || !BN_is_zero(Qr))
@@ -952,7 +955,9 @@ OpenSSLCryptRsaGenerateKey(
     EVP_PKEY            *pkey = NULL;
     CRYPT_RSA_VAR(tmp);
 
-    if (bnE == NULL || BN_set_word(bnE, e) != 1)
+    if (bnE == NULL)
+        return TPM_RC_MEMORY;
+    if (BN_set_word(bnE, e) != 1)
         ERROR_EXIT(TPM_RC_FAILURE);
 
     if ((ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL)) == NULL ||
@@ -1016,7 +1021,9 @@ OpenSSLCryptRsaGenerateKey(
     BIGNUM              *bnE = BN_new();
     CRYPT_RSA_VAR(tmp);
 
-    if (bnE == NULL || BN_set_word(bnE, e) != 1)
+    if (bnE == NULL)
+        return TPM_RC_MEMORY;
+    if (BN_set_word(bnE, e) != 1)
         ERROR_EXIT(TPM_RC_FAILURE);
 
     rsa = RSA_new();


### PR DESCRIPTION
Convert some of the TPM_RC_FAILURE to TPM_RC_MEMORY, but only do this if it is certain that the failure can only be related to an out-of-memory condition.