### PR TITLE
tpm2: Fix memory leak by freeing KDF context

### DIFF
--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -1141,7 +1141,7 @@ UINT16 OSSLCryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in HMAC
     size_t      buffer_size = 0;
     UINT16      generated = 0;
     size_t      offset = 0;
-    EVP_KDF_CTX *ctx;
+    EVP_KDF_CTX *ctx = NULL;
     EVP_KDF     *kdf;
     char        *buffer;
     INT16       bytes;  // number of bytes to generate
@@ -1207,6 +1207,7 @@ UINT16 OSSLCryptKDFe(TPM_ALG_ID   hashAlg,  // IN: hash algorithm used in HMAC
     generated = bytes;
 
 out:
+    EVP_KDF_CTX_free(ctx);
     EVP_KDF_free(kdf);
     free(buffer);
 


### PR DESCRIPTION
Fix a memory leak by freeing the KDF context after usage.