### PR TITLE
add pkg-config to ubunto prerequisites

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -70,6 +70,7 @@ Ubuntu:
 - gcc
 - libc-dev
 - libssl-dev
+- pkg-config
 
 To build for freebl (TPM 1.2 support only), the following development
 packages must have been installed prior to compilation:


### PR DESCRIPTION
On Ubuntu 24.04 pkg-config is not installed per default, but it is needed to run `./autogen.sh` without errors.