### PR TITLE
test: do not run localcheck test on powerpc64

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@
 #
 
 AM_CFLAGS = @AM_CFLAGS@
-AM_LDFLAGS = @AM_LDFLAGS@ $(HARDENING_LDFLAGS) $(SANITIZERS) $(FUZZER) 
+AM_LDFLAGS = @AM_LDFLAGS@ $(HARDENING_LDFLAGS) $(SANITIZERS) $(FUZZER)
 noinst_LTLIBRARIES =
 noinst_HEADERS =
 
@@ -156,7 +156,7 @@ libtpms_tpm12_la_CFLAGS += $(shell nss-config --cflags)
 #including nss3/blapi.h requires a look into nspr4 dir
 libtpms_tpm12_la_CFLAGS += $(shell nspr-config --cflags)
 
-else 
+else
 
 if LIBTPMS_USE_OPENSSL
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -668,7 +668,7 @@ check-local:
 	  darwin*|freebsd*) LDFLAGS_OS="-shared" ;; \
 	  *) ADDLIBS="" ;; \
 	esac; \
-	 ($(CC) $$LDFLAGS_OS $(LDFLAGS_ARCH) -nostdlib -L./.libs -ltpms $$ADDLIBS 2>/dev/null || \
+	 [[ "$(host_cpu)" =~ "powerpc64" ]] || ($(CC) $$LDFLAGS_OS $(LDFLAGS_ARCH) -nostdlib -L./.libs -ltpms $$ADDLIBS 2>/dev/null || \
 	 (echo "There are undefined symbols in libtpms ($$LDFLAGS_OS $(LDFLAGS_ARCH))";\
 	  $(CC) $$LDFLAGS_OS $(LDFLAGS_ARCH) -nostdlib -L./.libs -ltpms $$ADDLIBS 2>&1 | grep libtpms))
 	@case $(host_os) in \
@@ -676,7 +676,7 @@ check-local:
 	  darwin*|freebsd*) LDFLAGS_OS="-shared" ;; \
 	  *) ADDLIBS="" ;; \
 	esac; \
-	$(CC) $$LDFLAGS_OS $(LDFLAGS_ARCH) -nostdlib -L./.libs -ltpms $$ADDLIBS 2>/dev/null
+	[[ "$(host_cpu)" =~ "powerpc64" ]] || $(CC) $$LDFLAGS_OS $(LDFLAGS_ARCH) -nostdlib -L./.libs -ltpms $$ADDLIBS 2>/dev/null
 	rm a.out || true
 
 EXTRA_DIST = \


### PR DESCRIPTION
There is a spurious failure on powerpc64:

$ gcc -nostdlib -Lsrc/.libs -ltpms
/usr/bin/ld: src/.libs/libtpms.so: ABI version 1 is not compatible with ABI version 0 output
/usr/bin/ld: failed to merge target specific data of file src/.libs/libtpms.so
/usr/bin/ld: warning: cannot find entry symbol _start; defaulting to 00000000000000d8
collect2: error: ld returned 1 exit status

This is likely a linker bug, which has been reported, but
even if it is fixed, it will take a long time before it is available:

https://sourceware.org/bugzilla/show_bug.cgi?id=17742#c7