### PR TITLE
tpm2: use BN_BIT2 to determine RADIX_BITS

### DIFF
--- a/src/tpm2/crypto/openssl/tpm_radix.h
+++ b/src/tpm2/crypto/openssl/tpm_radix.h
@@ -64,15 +64,7 @@
 
 #ifdef TPM_POSIX                       // libtpms added begin
 # include <openssl/bn.h>
-# ifdef THIRTY_TWO_BIT
-#  define RADIX_BITS                     32
-# endif
-# ifdef SIXTY_FOUR_BIT_LONG
-#  define RADIX_BITS                     64
-# endif
-# ifndef RADIX_BITS
-#  error Need to determine RADIX_BITS value
-# endif
+# define RADIX_BITS BN_BITS2
 #endif
 #ifdef TPM_WINDOWS
 #define  RADIX_BITS                      32


### PR DESCRIPTION
Note: I am not certain I am doing this correctly, please review. All of the tests pass on my system at least.

With LibreSSL `4.2.0` the `THIRTY_TWO_BIT` and `SIXTY_FOUR_BIT_LONG` defines were removed, but `BN_BITS2` has the correct value for `RADIX_BITS`.