### PR TITLE
tpm2: Fix retrieval of updated IV when using OpenSSL >= 3.0

### DIFF
--- a/src/tpm2/crypto/openssl/Helpers.c
+++ b/src/tpm2/crypto/openssl/Helpers.c
@@ -354,7 +354,7 @@ TPM_RC DoEVPGetIV(
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     OSSL_PARAM params[] = {
-        OSSL_PARAM_octet_ptr(OSSL_CIPHER_PARAM_UPDATED_IV, &iv, iv_len),
+        OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV, iv, iv_len),
         OSSL_PARAM_END
     };
     if (EVP_CIPHER_CTX_get_params(ctx, params) != 1)


### PR DESCRIPTION
Fix the retrieval of the updated IV for when OpenSSL >= 3.0 is used. The previously used OSSL_PARAM_octet_ptr allocated a new buffer and then returned the IV but this newly allocated buffer did not make it back to the caller. We have to use OSSL_PARAM_octet_string instead to write the data into the buffer.

Resolves: https://github.com/stefanberger/libtpms/issues/541