### PR TITLE
tests: Properly fill-out data structure for stricter marshalling to work

### DIFF
--- a/tests/object_size.c
+++ b/tests/object_size.c
@@ -27,7 +27,14 @@ int main(void)
                     .keyBits = 256,
                     .mode = TPM_ALG_ECB,
                 },
-                .scheme = TPM_ALG_RSAPSS,
+                .scheme = {
+                    .scheme = TPM_ALG_RSAPSS,
+                    .details = {
+                        .rsapss = {
+                            .hashAlg = TPM_ALG_SHA256,
+                        },
+                    },
+                },
                 .keyBits = MAX_RSA_KEY_BITS,
                 .exponent = 0x10001,
             },


### PR DESCRIPTION
Properly fill out the TPMS_SIG_SCHEME_RSAPSS structure, especially the hashAlg that's found in TPMS_SCHEME_HASH, so that stricter marshalling implementations do not refuse to marshal the structure.