### PR TITLE
tpm2: Implement own function for ECC key size checking

### DIFF
--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -534,13 +534,13 @@ RuntimeAlgorithmCheckEnabled(struct RuntimeAlgorithm *RuntimeAlgorithm,
  * it needs to be filtered-out so that the profile doesn't need an upgrade to
  * stateFormatLevel '4'.
  */
-LIB_EXPORT BOOL
-RuntimeAlgorithmKeySizeCheckEnabled(struct RuntimeAlgorithm *RuntimeAlgorithm,
-				    TPM_ALG_ID               algId,			// IN: the algorithm to check
-				    UINT16                   keySizeInBits,		// IN: size of the key in bits
-				    TPM_ECC_CURVE            curveId,			// IN: curve Id if algId == TPM_ALG_ECC
-				    unsigned int             maxStateFormatLevel	// IN: maximum stateFormatLevel
-				    )
+static BOOL _RuntimeAlgorithmKeySizeCheckEnabled(
+    struct RuntimeAlgorithm *RuntimeAlgorithm,
+    TPM_ALG_ID               algId,			// IN: the algorithm to check
+    UINT16                   keySizeInBits,		// IN: size of the key in bits
+    unsigned int             maxStateFormatLevel,	// IN: maximum stateFormatLevel
+    TPM_ECC_CURVE            curveId			// IN: curve Id for TPM_ALG_ECC
+)
 {
     const struct KeySizes *keysizes;
     UINT16 minKeySize;
@@ -576,6 +576,41 @@ RuntimeAlgorithmKeySizeCheckEnabled(struct RuntimeAlgorithm *RuntimeAlgorithm,
     }
 
     return TRUE;
+}
+
+LIB_EXPORT BOOL
+RuntimeAlgorithmKeySizeCheckEnabled(
+    struct RuntimeAlgorithm *RuntimeAlgorithm,
+    TPM_ALG_ID               algId,			// IN: the algorithm to check
+    UINT16                   keySizeInBits,		// IN: size of the key in bits
+    unsigned int             maxStateFormatLevel	// IN: maximum stateFormatLevel
+   )
+{
+    return _RuntimeAlgorithmKeySizeCheckEnabled(
+        RuntimeAlgorithm,
+        algId,
+        keySizeInBits,
+        maxStateFormatLevel,
+        TPM_ECC_NONE
+    );
+}
+
+LIB_EXPORT BOOL
+RuntimeAlgorithmEccKeySizeCheckEnabled(
+    struct RuntimeAlgorithm *RuntimeAlgorithm,
+    TPM_ALG_ID               algId,			// IN: the algorithm to check
+    UINT16                   keySizeInBits,		// IN: size of the key in bits
+    TPM_ECC_CURVE            curveId,			// IN: curve Id if algId == TPM_ALG_ECC
+    unsigned int             maxStateFormatLevel	// IN: maximum stateFormatLevel
+   )
+{
+    return _RuntimeAlgorithmKeySizeCheckEnabled(
+        RuntimeAlgorithm,
+        algId,
+        keySizeInBits,
+        maxStateFormatLevel,
+        curveId
+    );
 }
 
 static char *

--- a/src/tpm2/RuntimeAlgorithm_fp.h
+++ b/src/tpm2/RuntimeAlgorithm_fp.h
@@ -43,12 +43,21 @@ RuntimeAlgorithmCheckEnabled(struct RuntimeAlgorithm *RuntimeAlgorithm,
 			     );
 
 BOOL
-RuntimeAlgorithmKeySizeCheckEnabled(struct RuntimeAlgorithm *RuntimeAlgorithm,
-				    TPM_ALG_ID               algId,			// IN: the algorithm to check
-				    UINT16                   keySizeInBits,		// IN: size of the key in bits
-				    TPM_ECC_CURVE	     curveId,			// IN: curveId if algId == TPM_ALG_ECC
-				    unsigned int             maxStateFormatLevel	// IN: maximum stateFormatLevel
-				    );
+RuntimeAlgorithmKeySizeCheckEnabled(
+    struct RuntimeAlgorithm *RuntimeAlgorithm,
+    TPM_ALG_ID               algId,			// IN: the algorithm to check
+    UINT16                   keySizeInBits,		// IN: size of the key in bits
+    unsigned int             maxStateFormatLevel	// IN: maximum stateFormatLevel
+);
+
+BOOL
+RuntimeAlgorithmEccKeySizeCheckEnabled(
+    struct RuntimeAlgorithm *RuntimeAlgorithm,
+    TPM_ALG_ID               algId,			// IN: the algorithm to check
+    UINT16                   keySizeInBits,		// IN: size of the key in bits
+    TPM_ECC_CURVE	     curveId,			// IN: curveId if algId == TPM_ALG_ECC
+    unsigned int             maxStateFormatLevel	// IN: maximum stateFormatLevel
+);
 
 enum RuntimeAlgorithmType {
     RUNTIME_ALGO_IMPLEMENTED,

--- a/src/tpm2/TPMCmd/tpm/src/crypt/AlgorithmTests.c
+++ b/src/tpm2/TPMCmd/tpm/src/crypt/AlgorithmTests.c
@@ -177,7 +177,6 @@ static void TestSymmetricAlgorithm(const SYMMETRIC_TEST_VECTOR* test,  //
     /* Skip test cases whose algorithms or keysizes are runtime-disabled */
     if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
 					     test->alg, test->keyBits,
-					     TPM_ECC_NONE,
 					     g_RuntimeProfile.stateFormatLevel))
 	return;
     // libtpms added end

--- a/src/tpm2/TPMCmd/tpm/src/crypt/CryptEccMain.c
+++ b/src/tpm2/TPMCmd/tpm/src/crypt/CryptEccMain.c
@@ -128,11 +128,11 @@ CryptCapGetECCCurve(TPM_ECC_CURVE   curveID,   // IN: the starting ECC curve
             continue;
         if (!CryptEccIsCurveRuntimeUsable(curve))	// libtpms added begin
            continue;
-        if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
-                                                 TPM_ALG_ECC,
-                                                 CryptEccGetKeySizeForCurve(curve),
-                                                 curve,
-                                                 g_RuntimeProfile.stateFormatLevel))
+        if (!RuntimeAlgorithmEccKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
+                                                    TPM_ALG_ECC,
+                                                    CryptEccGetKeySizeForCurve(curve),
+                                                    curve,
+                                                    g_RuntimeProfile.stateFormatLevel))
             continue;					// libtpms added end
         if(curveList->count < maxCount)
         {
@@ -160,11 +160,11 @@ BOOL CryptCapGetOneECCCurve(TPM_ECC_CURVE curveID  // IN: the  ECC curve
     UINT16 i;
 
     if (!CryptEccIsCurveRuntimeUsable(curveID) ||	// libtpms added begin
-	!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
-					     TPM_ALG_ECC,
-					     CryptEccGetKeySizeForCurve(curveID),
-					     curveID,
-					     g_RuntimeProfile.stateFormatLevel))
+	!RuntimeAlgorithmEccKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
+                                                TPM_ALG_ECC,
+                                                CryptEccGetKeySizeForCurve(curveID),
+                                                curveID,
+                                                g_RuntimeProfile.stateFormatLevel))
 	return FALSE;					// libtpms added end
 
     // Scan the eccCurveValues array

--- a/src/tpm2/TPMCmd/tpm/src/crypt/CryptUtil.c
+++ b/src/tpm2/TPMCmd/tpm/src/crypt/CryptUtil.c
@@ -32,7 +32,6 @@ static TPM_RC CryptHmacSign(TPMT_SIGNATURE* signature,  // OUT: signature
     if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,// libtpms added begin
                                              TPM_ALG_HMAC,
                                              signKey->sensitive.sensitive.bits.t.size * 8,
-                                             TPM_ECC_NONE,
                                              g_RuntimeProfile.stateFormatLevel))
 	return TPM_RC_KEY_SIZE;							// libtpms added end
 
@@ -70,7 +69,6 @@ static TPM_RC CryptHMACVerifySignature(
     if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,// libtpm added begin
 					     TPM_ALG_HMAC,
 					     signKey->sensitive.sensitive.bits.t.size * 8,
-					     TPM_ECC_NONE,
 					     g_RuntimeProfile.stateFormatLevel))
 	return TPM_RC_KEY_SIZE;							// libtpms added end
 

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -223,11 +223,11 @@ TPM_ECC_CURVE_Unmarshal(TPM_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 		!CryptEccIsCurveRuntimeUsable(*target)) {
 	      rc = TPM_RC_CURVE;
 	    }
-	    if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
-						     TPM_ALG_ECC,
-						     CryptEccGetKeySizeForCurve(*target),
-						     *target,
-						     g_RuntimeProfile.stateFormatLevel)) {
+	    if (!RuntimeAlgorithmEccKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
+						        TPM_ALG_ECC,
+							CryptEccGetKeySizeForCurve(*target),
+							*target,
+						        g_RuntimeProfile.stateFormatLevel)) {
 		rc = TPM_RC_CURVE;
 	    }						// libtpms added end
 	    break;
@@ -2872,7 +2872,6 @@ TPMI_AES_KEY_BITS_Unmarshal(TPMI_AES_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	    if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,	// libtpms added begin
 						     TPM_ALG_AES,
 						     *target,
-						     TPM_ECC_NONE,
 						     g_RuntimeProfile.stateFormatLevel)) {
 		rc = TPM_RC_VALUE;
 	    }											// libtpms added end
@@ -2912,7 +2911,6 @@ TPMI_CAMELLIA_KEY_BITS_Unmarshal(TPMI_CAMELLIA_KEY_BITS *target, BYTE **buffer, 
 	    if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,	// libtpms added begin
 						     TPM_ALG_CAMELLIA,
 						     *target,
-						     TPM_ECC_NONE,
 						     g_RuntimeProfile.stateFormatLevel)) {
 		rc = TPM_RC_VALUE;
 	    }											// libtpms added end
@@ -2975,7 +2973,6 @@ TPMI_TDES_KEY_BITS_Unmarshal(TPMI_SM4_KEY_BITS *target, BYTE **buffer, INT32 *si
 	    if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,// libtpms added begin
 						     TPM_ALG_TDES,
 						     *target,
-						     TPM_ECC_NONE,
 						     g_RuntimeProfile.stateFormatLevel)) {
 		rc = TPM_RC_VALUE;
 	    }										// libtpms added end
@@ -3961,7 +3958,6 @@ TPMI_RSA_KEY_BITS_Unmarshal(TPMI_RSA_KEY_BITS *target, BYTE **buffer, INT32 *siz
 	    if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
 						     TPM_ALG_RSA,
 						     *target,
-						     TPM_ECC_NONE,
 						     g_RuntimeProfile.stateFormatLevel)) {
 		rc = TPM_RC_VALUE;
 	    }										// libtpms added end


### PR DESCRIPTION
Refactor the code to have own function for ECC key size checking. Later on other algorithms may get their own function as well.