### PR TITLE
tpm2: Check valid range of command code before conversion to index

### DIFF
--- a/src/tpm2/RuntimeCommands.c
+++ b/src/tpm2/RuntimeCommands.c
@@ -415,6 +415,8 @@ LIB_EXPORT BOOL
 RuntimeCommandsCheckEnabled(struct RuntimeCommands *RuntimeCommands,
                             TPM_CC                  cc)
 {
+    if (cc > TPM_CC_LAST || cc < TPM_CC_FIRST)
+        return FALSE;
     return RuntimeCommandsCheckEnabledByIdx(RuntimeCommands, CcToIdx(cc));
 }
 


### PR DESCRIPTION
Check the range of the (untrusted) command code before converting it to a command index.