### PR TITLE
Limit the response buffer size to the negotiated size

### DIFF
--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -226,7 +226,11 @@ static TPM_RESULT TPM2_Process(unsigned char **respbuffer, uint32_t *resp_size,
         memcpy(*respbuffer, resp.Buffer, resp.BufferSize);
     }
 
-    *resp_size = resp.BufferSize;
+    /*
+     * Limit the response buffer size to the TPMLIB_SetBufferSize-negotiated
+     * maximum response size even if this means we truncate the response.
+     */
+    *resp_size = MIN(resp.BufferSize, TPM2_GetBufferSize());
 
     if (_plat__InFailureMode() && !reportedFailureCommand) {
         reportedFailureCommand = TRUE;

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -635,7 +635,14 @@ static uint32_t TPM2_SetBufferSize(uint32_t wanted_size,
                                    uint32_t *min_size,
                                    uint32_t *max_size)
 {
-    const uint32_t min = MAX_CONTEXT_SIZE + 128;
+    /*
+     * The maximum size is equivalent to the size of the buffer supported by
+     * TPM 2 TIS and SPAPR (= 4kb). The CRB only supports 3968 bytes. No command
+     * or response of the TPM 2 currently requires that many bytes. The maximum
+     * buffer size used for requests or responses is related to TPMS_CONTEXT
+     * (plus a generous 128 bytes) and the TPM_ContextLoad/Save commands.
+     */
+    const uint32_t min = sizeof(TPMS_CONTEXT) + 128;
     const uint32_t max = TPM_BUFFER_MAX;
 
     if (min_size)


### PR DESCRIPTION
This PR deals with buffer sizes
- It limits the value set in the response buffer size variable to the size negotiated with the TPMLIB_SetBufferSize() call even if this means truncating the response (not expected to happen).
- Add comments to how the maximum and minimum sizes of the buffer were chosen. Adjust the lower size even though it is assumed to be correct at this point. 