### PR TITLE
tpmlib: Introduce TPMPROP_TPM2_BUFFER_MAX and set it to 4096 for now

### DIFF
--- a/include/libtpms/tpm_library.h.in
+++ b/include/libtpms/tpm_library.h.in
@@ -5,7 +5,7 @@
 /*		       IBM Thomas J. Watson Research Center			*/
 /*	      $Id: tpm_library.h 4623 2011-09-28 15:15:09Z kgoldman $		*/
 /*										*/
-/* (c) Copyright IBM Corporation 2010.						*/
+/* (c) Copyright IBM Corporation 2010-2026.					*/
 /*										*/
 /* All rights reserved.								*/
 /* 										*/
@@ -98,6 +98,7 @@ enum TPMLIB_TPMProperty {
     TPMPROP_TPM_MAX_NV_SPACE,
     TPMPROP_TPM_MAX_SAVESTATE_SPACE,
     TPMPROP_TPM_MAX_VOLATILESTATE_SPACE,
+    TPMPROP_TPM2_BUFFER_MAX,
 };
 
 TPM_RESULT TPMLIB_GetTPMProperty(enum TPMLIB_TPMProperty prop, int *result);

--- a/man/man3/TPMLIB_GetTPMProperty.pod
+++ b/man/man3/TPMLIB_GetTPMProperty.pod
@@ -94,6 +94,10 @@ The maximum size of the savestate blob (includes the space safety margin).
 The maximum size of the volatile state blob (includes the space saferty
 margin).
 
+=item B<TPMPROP_TPM2_BUFFER_MAX> (since v0.11)
+
+The maximum sizes of the TPM2 command and result buffers.
+
 =back
 
 =head1 ERRORS

--- a/src/tpm_library_conf.h
+++ b/src/tpm_library_conf.h
@@ -53,6 +53,8 @@
 /* maximum size of the IO buffer used for requests and responses */
 #define TPM_BUFFER_MAX             4096
 
+#define TPM2_BUFFER_MAX            4096
+
 /*
  * Below the following acronyms are used to identify what
  * #define influences which one of the state blobs the TPM

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -199,15 +199,15 @@ static TPM_RESULT TPM2_Process(unsigned char **respbuffer, uint32_t *resp_size,
     req.Buffer = command;
 
     /* have the TPM 2 write directly into the response buffer */
-    if (*respbufsize < TPM_BUFFER_MAX || !*respbuffer) {
-        tmp = realloc(*respbuffer, TPM_BUFFER_MAX);
+    if (*respbufsize < TPM2_BUFFER_MAX || !*respbuffer) {
+        tmp = realloc(*respbuffer, TPM2_BUFFER_MAX);
         if (!tmp) {
             TPMLIB_LogTPM2Error("Could not allocated %u bytes.\n",
-                                TPM_BUFFER_MAX);
+                                TPM2_BUFFER_MAX);
             return TPM_SIZE;
         }
         *respbuffer = tmp;
-        *respbufsize = TPM_BUFFER_MAX;
+        *respbufsize = TPM2_BUFFER_MAX;
     }
     resp.BufferSize = *respbufsize;
     resp.Buffer = *respbuffer;
@@ -321,12 +321,16 @@ static TPM_RESULT TPM2_GetTPMProperty(enum TPMLIB_TPMProperty prop,
                                       int *result)
 {
     switch (prop) {
-    case  TPMPROP_TPM_RSA_KEY_LENGTH_MAX:
+    case TPMPROP_TPM_RSA_KEY_LENGTH_MAX:
         *result = MAX_RSA_KEY_BITS;
         break;
 
-    case  TPMPROP_TPM_KEY_HANDLES:
+    case TPMPROP_TPM_KEY_HANDLES:
         *result = MAX_HANDLE_NUM;
+        break;
+
+    case TPMPROP_TPM2_BUFFER_MAX: /* v0.11 */
+        *result = TPM2_BUFFER_MAX;
         break;
 
     /* not supported for TPM 2 */
@@ -629,7 +633,7 @@ error:
     goto exit;
 }
 
-static uint32_t tpm2_buffersize = TPM_BUFFER_MAX;
+static uint32_t tpm2_buffersize = TPM2_BUFFER_MAX;
 
 static uint32_t TPM2_SetBufferSize(uint32_t wanted_size,
                                    uint32_t *min_size,
@@ -643,7 +647,7 @@ static uint32_t TPM2_SetBufferSize(uint32_t wanted_size,
      * (plus a generous 128 bytes) and the TPM_ContextLoad/Save commands.
      */
     const uint32_t min = sizeof(TPMS_CONTEXT) + 128;
-    const uint32_t max = TPM_BUFFER_MAX;
+    const uint32_t max = TPM2_BUFFER_MAX;
 
     if (min_size)
         *min_size = min;


### PR DESCRIPTION
In preparation for PQC support, introduce TPMPROP_TPM2_BUFFER_MAX for an API user (e.g., swtpm) to be able to get the size of the TPM 2 request and response buffer. Set the new TPM2_BUFFER_MAX to 4096 for now, which is the same value as TPM_BUFFER_MAX. In the TPM 2 related code replace TPM_BUFFER_MAX with TPM2_BUFFER_MAX.