### PR TITLE
fix(RuntimeProfile): Fix false deduplication of tokens that are a suffix of last token.

### DIFF
--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -266,9 +266,9 @@ RuntimeProfileDedupStrItems(char *input)
         while (true) {
             dup = strstr(ncomma + 1, pos);
             if (dup) {
-                /* ensure 'dup' is a prefix of 'pos' with either ',' or '\0' before it */
-                if (((dup[-1] == ',' || dup[-1] == 0) && dup[slen] == exp) ||
-                     (dup[slen] == 0) /* last item in list */) {
+                /* ensure 'dup' is a whole token: valid left boundary AND right boundary */
+                if ((dup[-1] == ',' || dup[-1] == 0) &&
+                    (dup[slen] == exp || dup[slen] == 0)) {
                     memmove(pos, comma + 1, strlen(comma + 1) + 1);
                     /* keep pos as-is */
                     found = true;


### PR DESCRIPTION
Fix false deduplication of tokens that are a suffix of last token.

When processing a comma-separated list containing `<token>` at an arbitrary location and `other-<token>` at the end of the list, the `RuntimeProfileDedupStrItems` function incorrectly deletes `<token>` as a duplicate.

The root cause is in the boundary check when a `strstr` found match at the end of the string:

```c
if (((dup[-1] == ',' || dup[-1] == 0) && dup[slen] == exp) ||
     (dup[slen] == 0) /* last item in list */)
```

When `<token>` is matched as a substring inside `other-<token>` (the last item), the `(dup[slen] == 0)` branch triggers without verifying that the left boundary of the match is valid — i.e. that it is preceded by a `,` or start of string. This causes `<token>` to be incorrectly deduplicated out of the list.

The fix tightens the boundary check to require a valid left-side delimiter in all cases:

```c
if ((dup[-1] == ',' || dup[-1] == 0) &&
     (dup[slen] == exp || dup[slen] == 0))
```

This ensures a match is only treated as a true duplicate when both the left boundary and the right boundary are valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comma-separated list deduplication: duplicates are now removed only when an item has valid boundaries on both sides, preventing partial-match edge cases and reducing incorrect removals when processing in-place comma-delimited values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->