### PR TITLE
Fixes for OpenBSD

### DIFF
--- a/man/man3/Makefile.am
+++ b/man/man3/Makefile.am
@@ -62,7 +62,8 @@ man3_MANS += $(man3_MANS_generated)
 
 # Ensure the build is reproducible, for details see:
 # https://reproducible-builds.org/docs/source-date-epoch/
-%.3 : %.pod
+SUFFIXES: .pod .3
+.pod.3:
 	@if test -n "$$SOURCE_DATE_EPOCH"; then \
 		BUILD_DATE=$$(date +%F --utc --date="@$$SOURCE_DATE_EPOCH"); \
 	else \
@@ -70,7 +71,7 @@ man3_MANS += $(man3_MANS_generated)
 	fi; \
 	pod2man -r "libtpms" \
 		-c "" \
-		-n $(basename $@) \
+		-n $(<:.pod=) \
 		--date="$$BUILD_DATE" \
 		--section=3 $< > $@
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -708,10 +708,8 @@ LDFLAGS_ARCH += $(findstring -m64, $(AM_CFLAGS))
 LDFLAGS_ARCH += $(findstring -m32, $(AM_LDFLAGS))
 LDFLAGS_ARCH += $(findstring -m64, $(AM_LDFLAGS))
 
-check-local: SHELL?="/usr/bin/env bash"
 check-local:
 	@case $(host_os) in \
-	  openbsd*) ADDLIBS="-lc" ;; \
 	  darwin*|freebsd*) LDFLAGS_OS="-shared" ;; \
 	  *) ADDLIBS="" ;; \
 	esac; \
@@ -719,7 +717,6 @@ check-local:
 	 (echo "There are undefined symbols in libtpms ($$LDFLAGS_OS $(LDFLAGS_ARCH))";\
 	  $(CC) $$LDFLAGS_OS $(LDFLAGS_ARCH) -nostdlib -L./.libs -ltpms $$ADDLIBS 2>&1 | grep libtpms))
 	@case $(host_os) in \
-	  openbsd*) ADDLIBS="-lc" ;; \
 	  darwin*|freebsd*) LDFLAGS_OS="-shared" ;; \
 	  *) ADDLIBS="" ;; \
 	esac; \

--- a/src/tpm12/tpm_crypto.c
+++ b/src/tpm12/tpm_crypto.c
@@ -135,9 +135,7 @@ static TPM_RESULT TPM_SymmetricKeyData_Crypt(unsigned char *data_out,
 
 #include <openssl/aes.h>
 
-#if defined(__OpenBSD__)
- # define OPENSSL_OLD_API
-#elif OPENSSL_VERSION_NUMBER < 0x10100000
+#if OPENSSL_VERSION_NUMBER < 0x10100000
  #define OPENSSL_OLD_API
 #endif
 

--- a/src/tpm2/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c
+++ b/src/tpm2/TPMCmd/tpm/cryptolibs/Ossl/BnToOsslMath.c
@@ -577,7 +577,9 @@ LIB_EXPORT BOOL BnEccModMult2(bigPoint            R,  // OUT: computed point
         EC_POINT_mul(E->G, pR, bnD, pQ, bnU, E->CTX);
     else
     {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L			\
+    || (defined(LIBRESSL_VERSION_NUMBER)			\
+    && LIBRESSL_VERSION_NUMBER >= 0x4010000fL)
          EC_POINT *pR1 = EC_POINT_new(E->G);
          EC_POINT *pR2 = EC_POINT_new(E->G);
          int OK;

--- a/src/tpm2/TPMCmd/tpm/include/tpm_public/tpm_radix.h
+++ b/src/tpm2/TPMCmd/tpm/include/tpm_public/tpm_radix.h
@@ -12,13 +12,11 @@
 # if defined(SIXTY_FOUR_BIT_LONG) || defined(SIXTY_FOUR_BIT) // x32 architecture
 #  define RADIX_BITS                     64
 # endif
-# ifndef RADIX_BITS
-#  error Need to determine RADIX_BITS value
-# endif
 #else
 # error Target platform is not supported
 #endif                                 // libtpms added end
 
+// reachable with LibreSSL:
 #ifndef RADIX_BITS
 #  if defined(__x86_64__) || defined(__x86_64) || defined(__amd64__)                 \
       || defined(__amd64) || defined(_WIN64) || defined(_M_X64) || defined(_M_ARM64) \


### PR DESCRIPTION
To build this library on OpenBSD, I did:

```
export AUTOCONF_VERSION=2.69
export AUTOMAKE_VERSION=1.11
./autogen.sh
make
make check
```

A ports Makefile could look like this:

```
COMMENT =       emulation library for Trusted Platform Module TPM 1.2 or 2.0

GH_ACCOUNT =    stefanberger
GH_PROJECT =    libtpms
GH_TAGNAME =    v0.10.2
DISTNAME =      libtpms-${GH_TAGNAME:S/v//}

SHARED_LIBS +=  tpms                    0.0 # 10.2

CATEGORIES =    devel security

MAINTAINER =            Moritz Buhl <mbuhl@openbsd.org>

# BSD 3-Clause (TPM1.2/lib), BSD 2-Clause (TPM2 ref), TCG license (other TPM2)
PERMIT_PACKAGE =        Yes

SEPARATE_BUILD =        Yes
AUTOCONF_VERSION =      2.69
AUTOMAKE_VERSION =      1.11
AUTORECONF =            ./autogen.sh
CONFIGURE_STYLE =       autoreconf

WANTLIB +=      crypto

TEST_DEPENDS =  shells/bash

.include <bsd.port.mk>
```

I'll send it to ports@ once I have a working swtpm.
Currently libtpms is linking against the libcrypto in base, I tried creating a OpenSSL flavor without success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made manpage generation produce more consistent, reproducible output names.
  * Simplified the local check/build target so shell and platform flags are resolved more reliably at runtime.
  * Expanded crypto compatibility to better support a wider range of OpenSSL and LibreSSL versions.
  * Clarified POSIX 32/64-bit integer-width selection to avoid ambiguous configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->