### PR TITLE
tpm2: fix GCC 15 stringop-overflow error in MakeIv

### DIFF
--- a/src/tpm2/TPMCmd/tpm/src/crypt/AlgorithmTests.c
+++ b/src/tpm2/TPMCmd/tpm/src/crypt/AlgorithmTests.c
@@ -138,9 +138,9 @@ TestSMAC(
 
 //*** MakeIv()
 // Internal function to make the appropriate IV depending on the mode.
-static UINT32 MakeIv(TPM_ALG_ID mode,  // IN: symmetric mode
-                     UINT32     size,  // IN: block size of the algorithm
-                     BYTE*      iv     // OUT: IV to fill in
+static UINT32 MakeIv(TPM_ALG_ID     mode,  // IN: symmetric mode
+                     UINT32         size,  // IN: block size of the algorithm
+                     volatile BYTE* iv     // OUT: IV to fill in; 'volatile' for gcc15
 )
 {
     BYTE i;


### PR DESCRIPTION
When compiling with GCC 15 using `CFLAGS=-march=x86-64-v4`, the compiler's aggressively optimized vectorizer triggers a false-positive -Wstringop-overflow error. Because x86-64-v4 enables wide AVX-512 registers, the compiler misinterprets the loop unrolling and warns that a 64-byte vector write is overflowing the destination buffer:
```
  tpm2/TPMCmd/tpm/src/crypt/AlgorithmTests.c:158:17: error: 
  writing 64 bytes into a region of size 15 [-Werror=stringop-overflow=]
    158 |             *iv = i;
```

This fixes the warning by marking the `iv` output pointer parameter as `volatile`. This inhibits the over-aggressive loop vectorization on this specific buffer, silencing the compiler error without changing the underlying logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**No user-visible changes**

* **Refactor**
  * Internal adjustment to how an IV buffer is handled to improve compiler/memory behavior; no functional changes or public interface impacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->