### PR TITLE
Fix a compilation error in TPMLIB_GetPlaintext

### DIFF
--- a/src/tpm_library.c
+++ b/src/tpm_library.c
@@ -416,7 +416,7 @@ static unsigned char *TPMLIB_GetPlaintext(const char *stream,
                                           const char *endtag,
                                           size_t *length)
 {
-    char *start, *end;
+    const char *start, *end;
     unsigned char *plaintext = NULL;
 
     start = strstr(stream, starttag);


### PR DESCRIPTION
Fix a compilation error that newer gcc versions may complain about:

tpm_library.c: In function 'TPMLIB_GetPlaintext':
tpm_library.c:441:11: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  441 |     start = strstr(stream, starttag);
      |           ^
At top level:
cc1: note: unrecognized command-line option '-Wno-self-assign' may have been intended to silence earlier diagnostics
cc1: all warnings being treated as errors