### PR TITLE
tpm2: Make OaepDecode near constant-time (CVE-2026-6727)

### DIFF
--- a/src/tpm2/TPMCmd/tpm/src/crypt/CryptRsa.c
+++ b/src/tpm2/TPMCmd/tpm/src/crypt/CryptRsa.c
@@ -11,10 +11,11 @@
 #define CRYPT_RSA_C
 #include "Tpm.h"
 #include "TpmMath_Util_fp.h"
-#include "Helpers_fp.h"  // libtpms added
+#include "Helpers_fp.h"		// libtpms added begin
 
-#include <assert.h>	 // libtpms added
-#include <openssl/rsa.h> // libtpms added
+#include <assert.h>
+#include <openssl/rsa.h>
+#include <openssl/crypto.h>	// libtpms added end
 
 #if ALG_RSA
 
@@ -382,19 +383,23 @@ static TPM_RC OaepDecode(
     TPM2B*       padded    // IN: the padded data
 )
 {
-    UINT32 i;
+    UINT32 i, j, k;
     BYTE   seedMask[MAX_DIGEST_SIZE];
     UINT32 hLen = CryptHashGetDigestSize(hashAlg);
 
     BYTE   mask[MAX_RSA_KEY_BYTES];
     BYTE*  pp;
     BYTE*  pm;
-    TPM_RC retVal = TPM_RC_SUCCESS;
+    TPM_RC retVal;
+    BOOL   bad = FALSE;
+    NUMBYTES sizemask;
 
     // Strange size (anything smaller can't be an OAEP padded block)
     // Also check for no leading 0
-    if((padded->size < (unsigned)((2 * hLen) + 2)) || (padded->buffer[0] != 0))
-        ERROR_EXIT(TPM_RC_VALUE);
+    // padded->size should be the size of an RSA public key (128/256/384)
+    if(padded->size < (unsigned)((2 * hLen) + 2))
+       ERROR_EXIT(TPM_RC_VALUE);
+    bad |= (padded->buffer[0] != 0);
     // Use the hash size to determine what to put through MGF1 in order
     // to recover the seedMask
     CryptMGF_KDF(hLen,
@@ -425,8 +430,7 @@ static TPM_RC OaepDecode(
     if((CryptHashBlock(hashAlg, label->size, (BYTE*)label->buffer, hLen, seedMask))
        != hLen)
         FAIL(FATAL_ERROR_INTERNAL);
-    if(memcmp(seedMask, mask, hLen) != 0)
-        ERROR_EXIT(TPM_RC_VALUE);
+    bad |= (CRYPTO_memcmp(seedMask, mask, hLen) != 0);
 
     // find the start of the data
     pm = &mask[hLen];
@@ -436,20 +440,30 @@ static TPM_RC OaepDecode(
             break;
     }
     // If we ran out of data or didn't end with 0x01, then return an error
-    if(i == 0 || pm[-1] != 0x01)
-        ERROR_EXIT(TPM_RC_VALUE);
+    bad |= i == 0;
+    bad |= pm[-1] != 0x01; /* due to pm++ above, pm[-1] is valid */
 
     // pm should be pointing at the first part of the data
     // and i is one greater than the number of bytes to move
     i--;
-    if(i > dataOut->size)
-        // Special exit to preserve the size of the output buffer
-        return TPM_RC_VALUE;
+    bad |= i > dataOut->size;
+
+    // Limit i to dataOut->size;
+    j = i;
+    k = dataOut->size;
+    if(i > k)
+        i = k;
+    else
+        i = j;
+
     memcpy(dataOut->buffer, pm, i);
     dataOut->size = (UINT16)i;
-Exit:
-    if(retVal != TPM_RC_SUCCESS)
-        dataOut->size = 0;
+    retVal = bad ? TPM_RC_VALUE : TPM_RC_SUCCESS;
+
+ Exit:
+    sizemask = retVal != TPM_RC_SUCCESS ? 0 : ~0;
+    dataOut->size &= sizemask;
+
     return retVal;
 }
 


### PR DESCRIPTION
This patch fixes CVE-2026-6727. Libtpms is typically not affected unless it was configured with --disable-use-openssl-functions or if it was built with '-DUSE_OPENSSL_FUNCTIONS_RSA=0'. Neither would be the 'typical' case.

OaepDecode exposes a potential timing side-channel. Fix the timing side-channel of this function by accumulating a bad result in a variable while still executing most of the code. This at least causes the test case to not report the issue anymore.

Note: This issue only appears when using libtpms with --disable-use-openssl-functions, which circumvents many OpenSSL functions for RSA, ECDSA, and others, that likely handle constant-time issues better than the TPM 2 reference code does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RSA-OAEP decryption validation and error handling.
  * Strengthened protection against timing-based information leaks during validation.
  * Ensured failed operations return no output and handle partial output buffers safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->