### PR TITLE
Sync: Clear OBJECT on ObjectFlush (CVE-2026-6726)

### DIFF
--- a/src/tpm2/TPMCmd/tpm/src/subsystem/Object.c
+++ b/src/tpm2/TPMCmd/tpm/src/subsystem/Object.c
@@ -20,6 +20,7 @@
 // Note: This could be converted to a macro.
 void ObjectFlush(OBJECT* object)
 {
+    MemorySet(object, 0, sizeof(*object));
     object->attributes.occupied = CLEAR;
 }
 


### PR DESCRIPTION
This patch applies a fix for CVE-2026-6726 by clearing the OBJECT on ObjectFlush.

libtpms does NOT seem to be affected by the vulnerability since a previous commit already resolved this issue:

https://github.com/stefanberger/libtpms/commit/17255da54cf8354d02369f1323dc50cfb87e2bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when flushing objects by clearing all associated object data, helping prevent stale information from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->