### PR TITLE
Sync: Clear OBJECT on ObjectFlush (CVE-2026-6726)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           sudo make install
           git clone https://github.com/stefanberger/swtpm.git
           pushd swtpm
+            git checkout stable-0.10
             sudo apt -y update
             sudo apt -y install devscripts equivs python3-twisted expect \
               libtasn1-dev socat findutils gnutls-dev gnutls-bin tss2 \

--- a/src/tpm2/Object.c
+++ b/src/tpm2/Object.c
@@ -78,6 +78,7 @@
 // Note: This could be converted to a macro.
 void ObjectFlush(OBJECT* object)
 {
+    MemorySet(object, 0, sizeof(*object));
     object->attributes.occupied = CLEAR;
 }
 


### PR DESCRIPTION
This patch applies a fix for CVE-2026-6726 by clearing the OBJECT on ObjectFlush.

libtpms does NOT seem to be affected by the vulnerability since a previous commit already resolved this issue:

https://github.com/stefanberger/libtpms/commit/17255da54cf8354d02369f1323dc50cfb87e2bf