### PR TITLE
Sync: Clear OBJECT on ObjectFlush (CVE-2026-6726)

### DIFF
--- a/src/tpm2/Object.c
+++ b/src/tpm2/Object.c
@@ -77,6 +77,7 @@ ObjectFlush(
 	    OBJECT          *object
 	    )
 {
+    MemorySet(object, 0, sizeof(*object));
     object->attributes.occupied = CLEAR;
 }
 /* 8.6.3.2 ObjectSetInUse() */


### PR DESCRIPTION
This patch applies a fix for CVE-2026-6726 by clearing the OBJECT on ObjectFlush.

libtpms does NOT seem to be affected by the vulnerability since a previous commit already resolved this issue:

https://github.com/stefanberger/libtpms/commit/17255da54cf8354d02369f1323dc50cfb87e2bf