### PR TITLE
Sync: Clear OBJECT on ObjectFlush (CVE-2026-6726)

### DIFF
--- a/src/tpm2/Object.c
+++ b/src/tpm2/Object.c
@@ -77,6 +77,7 @@ ObjectFlush(
 	    OBJECT          *object
 	    )
 {
+    MemorySet(object, 0, sizeof(*object));
     object->attributes.occupied = CLEAR;
 }
 /* 8.6.3.2 ObjectSetInUse() */


### PR DESCRIPTION
This patch applies a fix for CVE-2026-6726 by clearing the OBJECT on ObjectFlush.

libtpms does NOT seem to be affected by the vulnerability since a previous commit already resolved this issue:

https://github.com/stefanberger/libtpms/commit/33a03986e0a09dde439985e0312d1c8fb3743aab