### PR TITLE
Set variables to NULL after transfer of ownership and check for NULL pointer return

### DIFF
--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -804,8 +804,11 @@ RuntimeAlgorithmPrint(struct RuntimeAlgorithm   *RuntimeAlgorithm,
 	}
 
 skip:
-	if (algId == TPM_ALG_ECC)
+	if (algId == TPM_ALG_ECC) {
 	    buffer = RuntimeAlgorithmGetEcc(RuntimeAlgorithm, rat, buffer, &first);
+	    if (!buffer)
+		return NULL;
+        }
     }
 
     n = asprintf(&nbuffer, "%s\"", buffer);

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -731,25 +731,30 @@ RuntimeProfileSet(struct RuntimeProfile *RuntimeProfile,
 
     free(RuntimeProfile->RuntimeAlgorithm.algorithmProfile);
     RuntimeProfile->RuntimeAlgorithm.algorithmProfile = algorithmsProfile;
+    algorithmsProfile = NULL;
 
     free(RuntimeProfile->RuntimeCommands.commandsProfile);
     RuntimeProfile->RuntimeCommands.commandsProfile = commandsProfile;
+    commandsProfile = NULL;
 
     free(RuntimeProfile->RuntimeAttributes.attributesProfile);
     RuntimeProfile->RuntimeAttributes.attributesProfile = attributesProfile;
+    attributesProfile = NULL;
 
     free(RuntimeProfile->profileName);
     RuntimeProfile->profileName = profileName;
+    profileName = NULL;
 
     free(RuntimeProfile->profileDescription);
     RuntimeProfile->profileDescription = profileDescription;
+    profileDescription = NULL;
 
     /* Indicate whether the profile was mapped to the default profile due to
      * a NULL pointer read from the state.
      */
     RuntimeProfile->wasNullProfile = (jsonProfile == NULL) && (jsonProfileIsFromUser == FALSE);
     /* Another way is if the user passed in the null profile */
-    if (jsonProfileIsFromUser && !strcmp("null", profileName))
+    if (jsonProfileIsFromUser && !strcmp("null", RuntimeProfile->profileName))
 	RuntimeProfile->wasNullProfile = true;
 
     return TPM_RC_SUCCESS;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of memory allocation failures while formatting ECC profile information.
  * Corrected runtime profile validation after profile values are transferred, preventing incorrect null-profile detection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->