### PR TITLE
Deprecated TPM 1.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
             sudo make install
           popd
           rm -rf ibmtss
-          ./autogen.sh --with-openssl --prefix=/usr --with-tpm2 --enable-test-coverage
+          ./autogen.sh --with-openssl --prefix=/usr --with-tpm2 --with-tpm1 --enable-test-coverage
           make -j$((2 * $(nproc)))
           make -j$((2 * $(nproc))) check
           sudo make install

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 CHANGES - changes for libtpms
 
+version 0.11.0:
+  - NOTE: TPM 1.2 support is now deprecated; it will not be built by
+          default anymore (must configure with --with-tpm1)
+
 version 0.10.0:
   - tpm2: Support for profiles: default-v1 & custom
   - tpm2: Add new API call TPMLIB_SetProfile to enable user to set a profile

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ m4_if(
 AM_CONDITIONAL([HAVE_VERSION_SCRIPT], [test "x$have_version_script" = "xyes"])
 
 AC_ARG_WITH([tpm1],
-    AS_HELP_STRING([--with-tpm1], [build libtpms with TPM 1.2 support]), [], [with_tpm1=yes])
+    AS_HELP_STRING([--with-tpm1], [build libtpms with TPM 1.2 support]), [], [with_tpm1=no])
 AM_CONDITIONAL([WITH_TPM1], [test "x$with_tpm1" != "xno"])
 AS_IF([test "x$with_tpm1" != "xno"], [
     AC_DEFINE([WITH_TPM1], [1], [With TPM 1.2 support])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - TPM 1.2 support is now deprecated and is no longer built by default.
  - To include TPM 1.2 support, explicitly enable it with the `--with-tpm1` configuration option.
  - TPM 2 support remains available through the existing configuration options.

- **Documentation**
  - Updated the changelog to document the TPM 1.2 build behavior and configuration requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->