### PR TITLE
Fix some issues in NVMarshal.c

### DIFF
--- a/man/man3/TPMLIB_ValidateState.pod
+++ b/man/man3/TPMLIB_ValidateState.pod
@@ -26,19 +26,22 @@ able to determine whether it can support the version of blobs that were
 migrated and if this is not the case, the caller can refuse the
 migration.
 
-The B<tpmlib_state> parameter can be a logical 'or' of one or
-multiple of of the following: B<TPMLIB_STATE_PERMANENT>,
-B<TPMLIB_STATE_VOLATILE>, or B<TPMLIB_STATE_SAVE_STATE>.
+The B<st> parameter can be a logical 'or' of the following:
+B<TPMLIB_STATE_PERMANENT>, B<TPMLIB_STATE_VOLATILE>, or
+B<TPMLIB_STATE_SAVE_STATE>.
+
 The B<flags> parameter is currently not used and should be set to 0.
 
 The first state blob that should be loaded is the permanent state,
 since for example the volatile state requires it to be available
 for validation.
 
-This function should be called before B<TPMLIB_MainInit()> is invoked.
+If this function is called then it should be called before B<TPMLIB_MainInit()>
+is invoked and B<TPMLIB_MainInit()> should only be called if this function does
+not return an error.
 
 =head1 SEE ALSO
 
-B<TPMLIB_MainInit>(3), B<TPMLIB_Terminate>(3)
+B<TPMLIB_MainInit>(3), B<TPMLIB_Terminate>(3), B<TPMLIB_SetState>(3)
 
 =cut

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -284,9 +284,11 @@ String_Marshal(const char *source, BYTE **buffer, INT32 *size)
     written += UINT16_Marshal(&len, buffer, size);
 
     if (len > 0 && *size >= len) {
-        memcpy(*buffer, source, len);
-        *buffer += len;
-        *size -= len;
+        if (buffer != NULL) {
+            memcpy(*buffer, source, len);
+            *buffer += len;
+            *size -= len;
+        }
 
         written += len;
     }

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -4991,7 +4991,11 @@ USER_NVRAM_Unmarshal(BYTE **buffer, INT32 *size)
 
                     memset(&obj, 0, sizeof(obj));
                     rc = ANY_OBJECT_Unmarshal(&obj, buffer, size, true);
-                    pAssert(rc == TPM_RC_SUCCESS);
+                    if (rc != TPM_RC_SUCCESS) {
+                        TPMLIB_LogTPM2Error("USER_NVRAM: Failed to unmarshal ANY_OBJECT: 0x%08x\n",
+                                            rc);
+                        return rc;
+                    }
                     // convert the OBJECT into a buffer to copy into NVRAM
                     marshalledObjectSize = NvObjectToBuffer(&obj, objBuffer, sizeof(objBuffer));
 

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -1565,7 +1565,7 @@ ci_prime_t_Unmarshal(ci_prime_t *data, BYTE **buffer, INT32 *size)
     }
     if (rc == TPM_RC_SUCCESS) {
         /* coverity: num_bytes is sanitized here! */
-        data->size = (numbytes + sizeof(crypt_uword_t) - 1) / sizeof(crypt_word_t);
+        data->size = (numbytes + sizeof(crypt_uword_t) - 1) / sizeof(crypt_uword_t);
         if (data->size > data->allocated) {
             TPMLIB_LogTPM2Error("ci_prime_t: Require size larger %zu than "
                                 "allocated %zu\n",

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -4841,7 +4841,11 @@ USER_NVRAM_Marshal(BYTE **buffer, INT32 *size, struct RuntimeProfile *RuntimePro
 
             written += NV_INDEX_Marshal(&nvi, buffer, size);
             /* after that: bulk data */
+            /* ensure TPM code gives good entry_size */
+            pAssert(entrysize >= sizeof(UINT32) + sizeof(nvi));
             datasize = entrysize - sizeof(UINT32) - sizeof(nvi);
+            /* datasize must be bounded by MAX_NV_INDEX_SIZE by TPM code */
+            pAssert(datasize <= MAX_NV_INDEX_SIZE);
             written += UINT32_Marshal(&datasize, buffer, size);
             if (datasize > 0) {
                 BYTE buf[datasize];

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -875,9 +875,8 @@ PCR_SAVE_Unmarshal(PCR_SAVE *data, BYTE **buffer, INT32 *size,
     }
     if (rc == TPM_RC_SUCCESS &&
         array_size != NUM_STATIC_PCR) {
-        TPMLIB_LogTPM2Error("Non-matching PCR_SAVE NUM_STATIC_PCR. "
-                            "Expected %zu, got %u\n",
-                            sizeof(NUM_STATIC_PCR), array_size);
+        TPMLIB_LogTPM2Error("Non-matching PCR_SAVE NUM_STATIC_PCR. Expected %d, got %hu\n",
+                            NUM_STATIC_PCR, array_size);
         rc = TPM_RC_SIZE;
     }
 

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -4039,7 +4039,7 @@ PACompileConstants_Unmarshal(BYTE **buffer, INT32 *size)
             exp_array_size = 88;
             break;
         case 3:
-            /* PA_COMPILE_CONSTANTS_VERSION 3 had 104 entries */
+            /* PA_COMPILE_CONSTANTS_VERSION 3 had 120 entries */
             exp_array_size = 120;
             break;
         default:

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -106,10 +106,13 @@ block_skip_write_push(block_skip_t *bs, BOOL has_block,
  * needed.
  */
 static void
-block_skip_write_pop(block_skip_t *bs, INT32 *size) {
+block_skip_write_pop(block_skip_t *bs, INT32 *size)
+{
     UINT16 skip;
-    unsigned i = --bs->idx;
-    pAssert_VOID_OK((int)bs->idx >= 0);
+    unsigned i;
+
+    pAssert_VOID_OK(bs->idx > 0);
+    i = --bs->idx;
     skip = bs->pos[i].size - *size - sizeof(UINT16);
     UINT16_Marshal(&skip, &bs->pos[i].buffer, &bs->pos[i].size);
 }

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -931,7 +931,7 @@ PCR_SAVE_Unmarshal(PCR_SAVE *data, BYTE **buffer, INT32 *size,
         }
         if (t) {
             if (rc == TPM_RC_SUCCESS) {
-                algs_needed &= ~(1 << algid);
+                algs_needed &= ~((UINT64)1 << algid);
                 rc = UINT16_Unmarshal(&array_size, buffer, size);
             }
             if (rc == TPM_RC_SUCCESS && array_size != needed_size) {
@@ -1113,7 +1113,7 @@ PCR_Unmarshal(PCR *data, BYTE **buffer, INT32 *size,
         }
         if (t) {
             if (rc == TPM_RC_SUCCESS) {
-                algs_needed &= ~(1 << algid);
+                algs_needed &= ~((UINT64)1 << algid);
                 rc = UINT16_Unmarshal(&array_size, buffer, size);
             }
             if (rc == TPM_RC_SUCCESS && array_size != needed_size) {

--- a/src/tpm_tpm2_interface.c
+++ b/src/tpm_tpm2_interface.c
@@ -683,13 +683,9 @@ static TPM_RESULT TPM2_ValidateState(enum TPMLIB_StateType st,
     TPM_RC rc = TPM_RC_SUCCESS;
     unsigned char *data = NULL;
     uint32_t length;
-    unsigned char bak_NV[NV_MEMORY_SIZE];
     INT32 size;
     BYTE *buffer;
     BOOL restored;
-
-    /* make backup of current NvChip memory */
-    memcpy(bak_NV, s_NV, sizeof(bak_NV));
 
 #ifdef TPM_LIBTPMS_CALLBACKS
     struct libtpms_callbacks *cbs = TPMLIB_GetCallbacks();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NV data validation and bounds checking to prevent invalid payloads from being processed.
  - Fixed PCR error reporting and algorithm handling.
  - Added safeguards for empty skip stacks and unavailable string buffers.
  - Improved error handling when restoring user NVRAM data.
  - Corrected unsigned size handling during state unmarshalling.

- **Documentation**
  - Clarified `TPMLIB_ValidateState()` parameter descriptions and valid flag combinations.
  - Documented when to call `TPMLIB_MainInit()` and added a reference to `TPMLIB_SetState()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->