### PR TITLE
crypto: clear generated RSA/ECC private key material before return

### DIFF
--- a/src/tpm2/TPMCmd/tpm/src/crypt/CryptEccMain.c
+++ b/src/tpm2/TPMCmd/tpm/src/crypt/CryptEccMain.c
@@ -7,6 +7,8 @@
 #include "TpmEcc_Signature_ECDSA_fp.h"  // required for pairwise test in key generation
 #include "Helpers_fp.h"                // libtpms added
 
+#include <openssl/crypto.h>  // libtpms added
+
 #if ALG_ECC
 //** Functions
 
@@ -478,6 +480,12 @@ BOOL TpmEcc_GenPrivateScalar(
     OK = OK && ExtMath_Mod(bnExtraBits, nMinus1);
     OK = OK && ExtMath_AddWord(dOut, bnExtraBits, 1);
 
+    // libtpms added begin: bnExtraBits_buf holds the raw random value that
+    // dOut (the private scalar) is directly derived from; clear it here
+    // rather than leaving it in this stack frame.
+    OPENSSL_cleanse(&bnExtraBits_buf, sizeof(bnExtraBits_buf));
+    // libtpms added end
+
     return OK && !_plat__InFailureMode();
 }
 #else                                  // libtpms added begin
@@ -512,6 +520,11 @@ BOOL TpmEcc_GenPrivateScalar(
     OK = OK && ExtMath_SubtractWord(nMinus1, order, 1);
     OK = OK && ExtMath_Mod(bnExtraBits, nMinus1);
     OK = OK && ExtMath_AddWord(dOut, bnExtraBits, 1);
+
+    // bnExtraBits_buf holds the raw random value that dOut (the private
+    // scalar) is directly derived from; clear it here rather than
+    // leaving it in this stack frame.
+    OPENSSL_cleanse(&bnExtraBits_buf, sizeof(bnExtraBits_buf));
 
     return OK && !_plat__InFailureMode();
 }
@@ -573,6 +586,10 @@ BOOL TpmEcc_GenerateKeyPair(Crypt_Int*            bnD,  // OUT: private scalar
     } else {
         OK = OK && ExtEcc_PointMultiply(ecQ, NULL, bnD, E);
     }
+    // bnD1_buf is bnD + order (order is public), so it trivially reveals
+    // the private scalar bnD; clear it here rather than leaving it in
+    // this stack frame.
+    OPENSSL_cleanse(&bnD1_buf, sizeof(bnD1_buf));
     return OK;
 }
 
@@ -754,7 +771,8 @@ LIB_EXPORT TPM_RC CryptEccGenerateKey(
         // Get a random value to sign using the built in DRBG state
         DRBG_Generate(NULL, digest.t.buffer, digest.t.size);
         if(_plat__InFailureMode())
-            return TPM_RC_FAILURE;
+            ERROR_EXIT(TPM_RC_FAILURE); // libtpms changed: fall through to
+                                        // Exit so bnD_buf is cleared below
         TpmEcc_SignEcdsa(bnT, bnS, E, bnD, &digest, NULL);
         // and make sure that we can validate the signature
         OK = TpmEcc_ValidateSignatureEcdsa(bnT, bnS, E, ecQ, &digest)
@@ -763,6 +781,10 @@ LIB_EXPORT TPM_RC CryptEccGenerateKey(
 //#  endif										// libtpms changed
     retVal = (OK) ? TPM_RC_SUCCESS : TPM_RC_NO_RESULT;
 Exit:
+    // libtpms added begin: bnD_buf holds the generated ECC private key (the
+    // scalar 'd'); clear it here rather than leaving it in this stack frame.
+    OPENSSL_cleanse(&bnD_buf, sizeof(bnD_buf));
+    // libtpms added end
     CRYPT_CURVE_FREE(E);
     return retVal;
 }

--- a/src/tpm2/TPMCmd/tpm/src/crypt/CryptRsa.c
+++ b/src/tpm2/TPMCmd/tpm/src/crypt/CryptRsa.c
@@ -1549,6 +1549,12 @@ Exit:
         if (retVal)
             retVal = TPM_RC_FAILURE;
     }						// libtpms added end
+    // libtpms added begin: Z holds the generated RSA private key (primes P,
+    // Q and their CRT parameters); clear it here rather than leaving it in
+    // this stack frame. Harmless no-op on the OpenSSL key-generation path,
+    // where Z is never populated.
+    OPENSSL_cleanse(Z, sizeof(*Z));
+    // libtpms added end
     return retVal;
 }
 


### PR DESCRIPTION
## Summary

Fixes #610. `CryptRsaGenerateKey()` and `CryptEccGenerateKey()` generate a fresh asymmetric private key into a stack-local buffer and return without clearing it, leaving the freshly-generated private key material resident in the stack frame after return.

**RSA** (`CryptRsa.c`): `NEW_PRIVATE_EXPONENT(Z)` expands to a stack `privateExponent _Z` struct holding the generated primes P, Q and their CRT parameters (dP, dQ, qInv) — the actual private key.

**ECC** (`CryptEccMain.c`): `CRYPT_ECC_NUM(bnD)` expands to a stack `bnD_buf` holding the generated private scalar `d`.

## Fix

- `CryptRsaGenerateKey()`: add `OPENSSL_cleanse(Z, sizeof(*Z))` at the single return point, which every path funnels through (including the OpenSSL key-generation path, where `Z` is never populated, and the various `ERROR_EXIT`/`Exit:` paths).
- `CryptEccGenerateKey()`: add `OPENSSL_cleanse(&bnD_buf, sizeof(bnD_buf))` at the `Exit:` label. One early `return TPM_RC_FAILURE` inside the PWCT (pairwise consistency test) block bypassed `Exit:` entirely; changed it to set `retVal` and `goto Exit` instead so this path also clears `bnD_buf` rather than skipping cleanup.

`OPENSSL_cleanse()` rather than `MemorySet()`/`memset()`, because the latter (a one-line wrapper, see `src/tpm2/TPMCmd/tpm/src/support/Memory.c`) is a legitimate dead-store-elimination target once the buffer isn't read again. Both files already link OpenSSL (`USE_OPENSSL_FUNCTIONS_RSA` / `USE_OPENSSL_FUNCTIONS_EC`), so this adds no new dependency — `CryptEccMain.c` needed one new `#include <openssl/crypto.h>`, matching what `CryptRsa.c` already has.

## Verification

- `make` (the project's `-Wall -Werror -Wshadow -Wreturn-type -Wsign-compare` build) compiles both files clean.
- `tests/tpm2_createprimary` — the project's own test, which drives a real `TPM2_CreatePrimary` (RSA) command through `TPMLIB_Process()` end-to-end, exercising `CryptRsaGenerateKey()` — passes:
  ```
  OK
  ```
- I traced the ECC side's correctness via macro expansion and scope analysis (`bnD_buf` is declared at the top level of the function body, so it's in scope at every `Exit:`/`goto Exit` site including the one I changed) rather than a live ECC `CreatePrimary` run, since the project's bundled tests don't include an ECC key-generation case I could reuse directly. Happy to add one, or to adjust the fix, if that's wanted.

---
> Found and fixed with assistance from Claude Code (claude.ai/code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved protection for sensitive cryptographic key material by clearing temporary ECC and RSA values after key generation.
  * ECC key generation now follows consistent cleanup handling when random-number generation fails.
  * Strengthened cleanup across successful and unsuccessful key-generation paths to reduce residual sensitive data in memory.
  * Private key components and intermediate calculation data are cleared more reliably before cryptographic operations finish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->