### PR TITLE
Backport a few patches for v0.10.3

### DIFF
--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -4148,6 +4148,9 @@ PERSISTENT_DATA_PPList_Unmarshal(PERSISTENT_DATA *data, BYTE **buffer, INT32 *si
 
     if (rc == TPM_RC_SUCCESS) {
         rc = UINT16_Unmarshal(&array_size, buffer, size);
+        /* check array_size for a reasonable maximum that should never be reached */
+        if (rc == TPM_RC_SUCCESS && array_size > 1024)
+            rc = TPM_RC_SIZE;
     }
     if (rc == TPM_RC_SUCCESS) {
         BYTE buf[array_size];
@@ -4216,6 +4219,9 @@ PERSISTENT_DATA_AuditCommands_Unmarshal(PERSISTENT_DATA *data, BYTE **buffer, IN
 
     if (rc == TPM_RC_SUCCESS) {
         rc = UINT16_Unmarshal(&array_size, buffer, size);
+        /* check array_size for a reasonable maximum that should never be reached */
+        if (rc == TPM_RC_SUCCESS && array_size > 1024)
+            rc = TPM_RC_SIZE;
     }
     if (rc == TPM_RC_SUCCESS) {
         BYTE buf[array_size];

--- a/src/tpm2/NVMarshal.c
+++ b/src/tpm2/NVMarshal.c
@@ -5002,7 +5002,11 @@ USER_NVRAM_Unmarshal(BYTE **buffer, INT32 *size)
 
                     memset(&obj, 0, sizeof(obj));
                     rc = ANY_OBJECT_Unmarshal(&obj, buffer, size, true);
-                    pAssert(rc == TPM_RC_SUCCESS);
+                    if (rc != TPM_RC_SUCCESS) {
+                        TPMLIB_LogTPM2Error("USER_NVRAM: Failed to unmarshal ANY_OBJECT: 0x%08x\n",
+                                            rc);
+                        return rc;
+                    }
                     // convert the OBJECT into a buffer to copy into NVRAM
                     marshalledObjectSize = NvObjectToBuffer(&obj, objBuffer, sizeof(objBuffer));
 

--- a/src/tpm2/RuntimeAlgorithm.c
+++ b/src/tpm2/RuntimeAlgorithm.c
@@ -514,7 +514,7 @@ RuntimeAlgorithmSwitchProfile(struct RuntimeAlgorithm  *RuntimeAlgorithm,
                                         &stateFormatLevel, maxStateFormatLevel);
     if (retVal != TPM_RC_SUCCESS) {
 	RuntimeAlgorithmSetProfile(RuntimeAlgorithm, *oldProfile,
-	                           &stateFormatLevel, maxStateFormatLevel);
+	                           &stateFormatLevel, ~0);
 	*oldProfile = NULL;
     }
     return retVal;

--- a/src/tpm2/RuntimeAttributes.c
+++ b/src/tpm2/RuntimeAttributes.c
@@ -185,7 +185,7 @@ RuntimeAttributesSwitchProfile(struct RuntimeAttributes *RuntimeAttributes,
 					 &stateFormatLevel, maxStateFormatLevel);
     if (retVal != TPM_RC_SUCCESS) {
 	RuntimeAttributesSetProfile(RuntimeAttributes, *oldProfile,
-				    &stateFormatLevel, maxStateFormatLevel);
+				    &stateFormatLevel, ~0);
 	*oldProfile = NULL;
     }
     return retVal;

--- a/src/tpm2/RuntimeCommands.c
+++ b/src/tpm2/RuntimeCommands.c
@@ -490,7 +490,7 @@ RuntimeCommandsGetArraySize(struct RuntimeCommands *RuntimeCommands)
 
     /* search for byte where command with highest code is enabled */
     for (i = sizeof(RuntimeCommands->enabledCommandsByIdx) - 1;
-         i >= 0;
+         (ssize_t)i >= 0;
          i--) {
         if (RuntimeCommands->enabledCommandsByIdx[i])
             return i + 1;

--- a/src/tpm2/RuntimeCommands.c
+++ b/src/tpm2/RuntimeCommands.c
@@ -394,7 +394,7 @@ RuntimeCommandsSwitchProfile(struct RuntimeCommands   *RuntimeCommands,
 				       &stateFormatLevel, maxStateFormatLevel);
     if (retVal != TPM_RC_SUCCESS) {
 	RuntimeCommandsSetProfile(RuntimeCommands, *oldProfile,
-				  &stateFormatLevel, maxStateFormatLevel);
+				  &stateFormatLevel, ~0);
 	*oldProfile = NULL;
     }
     return retVal;

--- a/src/tpm2/RuntimeProfile.c
+++ b/src/tpm2/RuntimeProfile.c
@@ -479,6 +479,9 @@ GetParametersFromJSON(const char    *jsonProfile,
 	return TPM_RC_SUCCESS;
     }
 
+    if (strlen(jsonProfile) > MAX_PROFILE_SIZE)
+        return TPM_RC_SIZE;
+
     retVal = RuntimeProfileCheckJSON(jsonProfile);
     if (retVal != TPM_RC_SUCCESS)
 	return retVal;

--- a/src/tpm2/RuntimeProfile_fp.h
+++ b/src/tpm2/RuntimeProfile_fp.h
@@ -46,6 +46,8 @@
 #include "RuntimeCommands_fp.h"
 #include "RuntimeAttributes_fp.h"
 
+#define MAX_PROFILE_SIZE    (32 * 1024)
+
 struct RuntimeProfile {
     struct RuntimeAlgorithm RuntimeAlgorithm;
     struct RuntimeCommands  RuntimeCommands;

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -249,9 +249,10 @@ TPM_ECC_CURVE_Unmarshal(TPM_ECC_CURVE *target, BYTE **buffer, INT32 *size)
 #  endif  // ECC_CURVE_448
 	    if (*target != TPM_ECC_NONE &&		// libtpms added begin
 		!CryptEccIsCurveRuntimeUsable(*target)) {
-	      rc = TPM_RC_CURVE;
+	        rc = TPM_RC_CURVE;
 	    }
-	    if (!RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
+	    if (rc == TPM_RC_SUCCESS && *target != TPM_ECC_NONE &&
+	        !RuntimeAlgorithmKeySizeCheckEnabled(&g_RuntimeProfile.RuntimeAlgorithm,
 						     TPM_ALG_ECC,
 						     CryptEccGetKeySizeForCurve(*target),
 						     *target,

--- a/src/tpm2/Unmarshal.c
+++ b/src/tpm2/Unmarshal.c
@@ -47,7 +47,7 @@
 TPM_RC
 UINT8_Unmarshal(UINT8 *target, BYTE **buffer, INT32 *size)
 {
-    if ((UINT32)*size < sizeof(UINT8)) {
+    if (*size < 0 || (UINT32)*size < sizeof(UINT8)) {
 	return TPM_RC_INSUFFICIENT;
     }
     *target = (*buffer)[0];
@@ -65,7 +65,7 @@ INT8_Unmarshal(INT8 *target, BYTE **buffer, INT32 *size)
 TPM_RC
 UINT16_Unmarshal(UINT16 *target, BYTE **buffer, INT32 *size)
 {
-    if ((UINT32)*size < sizeof(UINT16)) {
+    if (*size < 0 || (UINT32)*size < sizeof(UINT16)) {
 	return TPM_RC_INSUFFICIENT;
     }
     *target = ((UINT16)((*buffer)[0]) << 8) |
@@ -78,7 +78,7 @@ UINT16_Unmarshal(UINT16 *target, BYTE **buffer, INT32 *size)
 TPM_RC
 UINT32_Unmarshal(UINT32 *target, BYTE **buffer, INT32 *size)
 {
-    if ((UINT32)*size < sizeof(UINT32)) {
+    if (*size < 0 || (UINT32)*size < sizeof(UINT32)) {
 	return TPM_RC_INSUFFICIENT;
     }
     *target = ((UINT32)((*buffer)[0]) << 24) |
@@ -93,7 +93,7 @@ UINT32_Unmarshal(UINT32 *target, BYTE **buffer, INT32 *size)
 TPM_RC
 UINT64_Unmarshal(UINT64 *target, BYTE **buffer, INT32 *size)
 {
-    if ((UINT32)*size < sizeof(UINT64)) {
+    if (*size < 0 || (UINT32)*size < sizeof(UINT64)) {
 	return TPM_RC_INSUFFICIENT;
     }
     *target = ((UINT64)((*buffer)[0]) << 56) |
@@ -114,7 +114,7 @@ Array_Unmarshal(BYTE *targetBuffer, UINT16 targetSize, BYTE **buffer, INT32 *siz
 {
     TPM_RC rc = TPM_RC_SUCCESS;
 
-    if (targetSize > *size) {
+    if (*size < 0 || targetSize > (UINT32)*size) {
 	rc = TPM_RC_INSUFFICIENT;
     }
     else {


### PR DESCRIPTION
Backport a few patches to v0.10.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved profile switching so failed changes reliably restore the previous profile.
  - Fixed command scanning to terminate correctly in all cases.
  - Added validation to reject oversized runtime profiles and invalid persistent data.
  - Improved handling of malformed object data by returning an error instead of continuing.
  - Corrected elliptic-curve validation when earlier input errors occur or no curve is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->