### PR TITLE
tpmlib: Return TPM_FAIL on invalid TPMLIB_BlobType

### DIFF
--- a/src/tpm_library.c
+++ b/src/tpm_library.c
@@ -456,6 +456,9 @@ TPM_RESULT TPMLIB_DecodeBlob(const char *buffer, enum TPMLIB_BlobType type,
 {
     TPM_RESULT res = TPM_SUCCESS;
 
+    if (type < TPMLIB_BLOB_TYPE_INITSTATE || type >= TPMLIB_BLOB_TYPE_LAST)
+        return TPM_FAIL;
+
     *result = TPMLIB_GetPlaintext(buffer,
                                   tags_and_indices[type].starttag,
                                   tags_and_indices[type].endtag,


### PR DESCRIPTION
Check that the passed TPMLIB_BlobType parameter is valid and therefore within the bounds of the array and return TPM_FAIL if this is not the case. Before it would crash if the user did not use the API with a correct parameter.

Reported-by: Leyao, ICT CAS <lileyao2002@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid blob types are now rejected safely instead of potentially causing an out-of-bounds access.
  * Blob decoding now returns an appropriate failure result when given unsupported input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->